### PR TITLE
Change NodeJS runner to add more workers & improve performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,14 @@ RUN apk add openssl
 
 WORKDIR /app
 COPY ./package.json ./package-lock.json ./
-RUN npm install --production
+RUN npm ci
+RUN npm install pm2 -g
 ARG TYPEORM_USERNAME
 ARG TYPEORM_PASSWORD
 ARG TYPEORM_DATABASE
 
 COPY --from=build --chown=node /app/init_scripts /app/init_scripts
+COPY --from=build --chown=node /app/process.json /app/process.json
 RUN chmod +x /app/init_scripts/start.sh
 
 COPY --from=build --chown=node /app/out/src /app/out/src

--- a/init_scripts/start.sh
+++ b/init_scripts/start.sh
@@ -3,4 +3,4 @@ chmod +x /app/init_scripts/00_make_sudosos_data_dirs.sh
 chmod +x /app/init_scripts/00_regen_sudosos_secrets.sh
 sh /app/init_scripts/00_make_sudosos_data_dirs.sh
 sh /app/init_scripts/00_regen_sudosos_secrets.sh
-npm run serve
+pm2-runtime start /app/process.json

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "ts-node-dev --poll src/index.ts",
+    "cron": "ts-node-dev --poll src/cron.ts",
     "serve": "node out/src/index.js",
     "schema": "node out/src/database/schema.js",
     "seed": "ts-node-dev --poll src/database/seed.ts",

--- a/process.json
+++ b/process.json
@@ -1,0 +1,10 @@
+{
+  "apps": [{
+    "name": "http-worker",
+    "script": "./out/src/index.js",
+    "instances": 4
+  }, {
+    "name": "cron",
+    "script": "./out/src/cron.js"
+  }]
+}

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -1,0 +1,104 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2020  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import log4js, { Logger } from 'log4js';
+import Database from './database/database';
+import dinero, { Currency } from 'dinero.js';
+import { Connection } from 'typeorm';
+import cron from 'node-cron';
+import BalanceService from './service/balance-service';
+import ADService from './service/ad-service';
+import RoleManager from './rbac/role-manager';
+import Gewis from './gewis/gewis';
+
+class CronApplication {
+  logger: Logger;
+
+  connection: Connection;
+
+  tasks: cron.ScheduledTask[];
+
+  roleManager: RoleManager;
+
+  public async stop(): Promise<void> {
+    this.tasks.forEach((task) => task.stop());
+    await this.connection.close();
+    this.logger.info('Application stopped.');
+  }
+}
+
+async function createCronTasks(): Promise<void> {
+  const application = new CronApplication();
+  application.connection = await Database.initialize();
+  application.logger = log4js.getLogger('Application');
+  application.logger.level = process.env.LOG_LEVEL;
+  application.logger.info('Starting cron tasks...');
+
+  const logger = log4js.getLogger('Console (cron)');
+  logger.level = process.env.LOG_LEVEL;
+  console.log = (message: any, ...additional: any[]) => logger.debug(message, ...additional);
+
+  // Set up monetary value configuration.
+  dinero.defaultCurrency = process.env.CURRENCY_CODE as Currency;
+  dinero.defaultPrecision = parseInt(process.env.CURRENCY_PRECISION, 10);
+
+  // Setup RBAC.
+  application.roleManager = new RoleManager();
+  const gewis = new Gewis(application.roleManager);
+  await gewis.registerRoles();
+
+  await BalanceService.updateBalances({});
+  const syncBalances = cron.schedule('41 1 * * *', () => {
+    logger.debug('Syncing balances.');
+    BalanceService.updateBalances({}).then(() => {
+      logger.debug('Synced balances.');
+    }).catch((error => {
+      logger.error('Could not sync balances.', error);
+    }));
+  });
+
+  cron.schedule('* * * * *', () => logger.error('Test at ' + new Date().toLocaleString()));
+
+  application.tasks = [syncBalances];
+
+  if (process.env.ENABLE_LDAP === 'true') {
+    await ADService.syncUsers();
+    await ADService.syncSharedAccounts().then(
+      () => ADService.syncUserRoles(application.roleManager),
+    );
+    const syncADGroups = cron.schedule('*/10 * * * *', async () => {
+      logger.debug('Syncing AD.');
+      await ADService.syncSharedAccounts().then(
+        () => ADService.syncUserRoles(application.roleManager),
+      );
+      logger.debug('Synced AD');
+    });
+    application.tasks.push(syncADGroups);
+  }
+
+  application.logger.info('Tasks registered');
+}
+
+if (require.main === module) {
+  // Only execute the application directly if this is the main execution file.
+  createCronTasks().catch((e) => {
+    console.error(e);
+    const logger = log4js.getLogger('index');
+    logger.level = process.env.LOG_LEVEL;
+    logger.fatal(e);
+  });
+}

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -16,7 +16,7 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import {
-  createConnection, Connection, getConnectionOptions,
+  createConnection, Connection,
 } from 'typeorm';
 import User from '../entity/user/user';
 import Product from '../entity/product/product';
@@ -67,12 +67,20 @@ import UserFineGroup from '../entity/fine/userFineGroup';
 export default class Database {
   public static async initialize(): Promise<Connection> {
     const options: DataSourceOptions = {
-      ...await getConnectionOptions(),
+      host: process.env.TYPEORM_HOST,
+      port: parseInt(process.env.TYPEORM_PORT || '3001'),
+      database: process.env.TYPEORM_DATABASE,
+      type: process.env.TYPEORM_CONNECTION as 'postgres' | 'mariadb' | 'mysql',
+      username: process.env.TYPEORM_USERNAME,
+      password: process.env.TYPEORM_PASSWORD,
+      synchronize: process.env.TYPEORM_SYNCHRONIZE === 'true',
+      logging: process.env.TYPEORM_LOGGING === 'true',
       extra: {
         authPlugins: {
           mysql_clear_password: () => () => Buffer.from(`${process.env.TYPEORM_PASSWORD}\0`),
         },
       },
+      poolSize: 4,
       entities: [
         ProductCategory,
         VatGroup,


### PR DESCRIPTION
Should improve performance of SudoSOS and stop the POS from "hanging". It is the same fix as was implemented in the SNiC CelerIT backend. However, because SudoSOS also has timed tasks to synchronize stuff, these had to be moved to a separate file. Otherwise, each worker would start the tasks at exactly the same time and thus the same work would be done four times, defeating the point of having workers.

The docker container starts correctly on my machine, but I have not yet tested whether SudoSOS actually works correctly, as I do not have a production environment setup on my machine. Therefore, I propose to test this on sudosos.test.gewis.nl.