### PR TITLE
Add debt and fine email notification warnings

### DIFF
--- a/src/entity/transactions/transaction.ts
+++ b/src/entity/transactions/transaction.ts
@@ -16,6 +16,7 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import {
+  AfterInsert,
   Entity, ManyToOne, OneToMany,
 } from 'typeorm';
 // eslint-disable-next-line import/no-cycle
@@ -23,6 +24,10 @@ import SubTransaction from './sub-transaction';
 import User from '../user/user';
 import BaseEntity from '../base-entity';
 import PointOfSaleRevision from '../point-of-sale/point-of-sale-revision';
+import BalanceService from '../../service/balance-service';
+import Mailer from '../../mailer';
+import UserDebtNotification from '../../mailer/templates/user-debt-notification';
+import DineroTransformer from '../transformer/dinero-transformer';
 
 /**
  * @typedef {BaseEntity} Transaction
@@ -48,4 +53,32 @@ export default class Transaction extends BaseEntity {
 
   @ManyToOne(() => PointOfSaleRevision)
   public pointOfSale: PointOfSaleRevision;
+
+  @AfterInsert()
+  // NOTE: this event listener is only called when calling .save() on a new Transaction object instance,
+  // not .save() on the static method of the Transaction class
+  async sendEmailNotificationIfNowInDebt() {
+    if (process.env.NODE_ENV === 'test') return;
+
+    const user = await User.findOne({ where: { id: this.from.id } });
+    const balance = await BalanceService.getBalance(user.id);
+    const currentBalance = balance.amount.amount - this.subTransactions[0].subTransactionRows[0].amount * this.subTransactions[0].subTransactionRows[0].product.priceInclVat.getAmount();
+
+    if (currentBalance >= 0) return;
+    // User is now in debt
+
+    const balanceBefore = await BalanceService.getBalance(
+      user.id,
+      new Date(this.createdAt.getTime() - 1),
+    );
+
+    if (balanceBefore.amount.amount < 0) return;
+    // User was not in debt before this new transaction
+
+    await Mailer.getInstance().send(user, new UserDebtNotification({
+      name: user.firstName,
+      balance: DineroTransformer.Instance.from(currentBalance),
+      url: '',
+    }));
+  }
 }

--- a/src/gewis/gewis.ts
+++ b/src/gewis/gewis.ts
@@ -435,6 +435,7 @@ export default class Gewis {
         },
         Fine: {
           ...admin,
+          notify: { all: star },
         },
       },
       assignmentCheck: async (user: User) => await AssignedRole.findOne({ where: { role: 'SudoSOS - BAC PM', user: { id: user.id } } }) != undefined,

--- a/src/mailer/templates/user-got-fined.ts
+++ b/src/mailer/templates/user-got-fined.ts
@@ -60,7 +60,7 @@ const userGotFinedEnglish = new MailContent<UserGotFinedOptions>({
   getHTML: (context) => `
 <p>Dear ${context.name},</p>
 
-<p>On ${context.referenceDate.toLocaleString('nl-NL')} you had a balance of <span style="color: red; font-weight: bold;">${context.balance.toFormat()}</span>.<br>
+<p>On ${context.referenceDate.toLocaleString('en-US')} you had a balance of <span style="color: red; font-weight: bold;">${context.balance.toFormat()}</span>.<br>
 For your debt, you have been fined for an amount of ${context.fine.toFormat()}.<br>
 This brings your total fine to:<br>
 <span style="color: red; font-weight: bold; font-size: 20px;">${context.totalFine.toFormat()}</span>.</p>

--- a/src/mailer/templates/user-will-get-fined.ts
+++ b/src/mailer/templates/user-will-get-fined.ts
@@ -1,0 +1,111 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2020  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Dinero } from 'dinero.js';
+import MailContent from './mail-content';
+import { signatureDutch, signatureEnglish } from './signature';
+import MailTemplate, { Language, MailLanguageMap } from './mail-template';
+
+interface UserWillGetFinedOptions {
+  name: string;
+  referenceDate: Date;
+  fine: Dinero;
+  balance: Dinero;
+}
+
+const formatBalance = (b: Dinero) => {
+  if (b.isPositive()) {
+    return `<span style="font-weight: bold;">${b.toFormat()}</span>`;
+  } else {
+    return `<span style="color: red; font-weight: bold;">${b.toFormat()}</span>`;
+  }
+};
+
+const getDateNL = (d: Date) => {
+  const diff = Math.abs(new Date().getTime() - d.getTime());
+  // Last 15 minutes
+  if (diff < 15 * 60 * 1000) {
+    return 'Op het moment van schrijven heb';
+  }
+  return `Op ${d.toLocaleString('nl-NL')} had`;
+};
+
+const getDateEN = (d: Date) => {
+  const diff = Math.abs(new Date().getTime() - d.getTime());
+  // Last 15 minutes
+  if (diff < 15 * 60 * 1000) {
+    return 'Currently, you have';
+  }
+  return `On ${d.toLocaleString('en-US')} you had`;
+};
+
+const userGotFinedDutch = new MailContent<UserWillGetFinedOptions>({
+  getHTML: (context) => `
+<p>Beste ${context.name},</p>
+
+<p>${getDateNL(context.referenceDate)} je een saldo van ${formatBalance(context.balance)}.<br>
+Vandaag heeft de BAC boetes uitgedeeld. De volgende keer dat er boetes worden uitgedeeld (waarschijnlijk volgende week), krijg jij een boute van ${context.fine.toFormat()}!<br>
+
+<p>Ga snel naar de SudoSOS website om je saldo op te hogen en deze boete te voorkomen.</p>
+
+${signatureDutch}`,
+  getSubject: () => 'De volgende keer krijg je een boete voor je negatieve SudoSOS saldo',
+  getText: (context) => `
+Beste ${context.name},
+
+${getDateNL(context.referenceDate)} je een saldo van ${context.balance.toFormat()}.
+Vandaag heeft de BAC boetes uitgedeeld. De volgende keer dat er boetes worden uitgedeeld (waarschijnlijk volgende week), krijg jij een boute van ${context.fine.toFormat()}!
+
+Ga snel naar de SudoSOS website om je saldo op te hogen en deze boete te voorkomen.
+
+Met vriendelijke groet,
+SudoSOS`,
+});
+
+const userGotFinedEnglish = new MailContent<UserWillGetFinedOptions>({
+  getHTML: (context) => `
+<p>Dear ${context.name},</p>
+
+<p>${getDateEN(context.referenceDate)} a balance of ${formatBalance(context.balance)}.<br>
+Today, the BAC has handed out fines. Next time fines will be handed out (probably next week), you will get a fine of ${context.fine.toFormat()}!<br>
+
+<p>Go to the SudoSOS website to deposit money into your account to prevent this fine.</p>
+
+${signatureEnglish}`,
+  getSubject: () => 'Next time you will get fined for your negative SudoSOS balance',
+  getText: (context) => `
+Dear ${context.name},
+
+${getDateEN(context.referenceDate)} a balance of ${context.balance.toFormat()}.
+Today, the BAC has handed out fines. Next time fines will be handed out (probably next week), you will get a fine of ${context.fine.toFormat()}!
+
+Go to the SudoSOS website to deposit money into your account to prevent this fine.
+
+Kind regards,
+SudoSOS`,
+});
+
+const mailContents: MailLanguageMap<UserWillGetFinedOptions> = {
+  [Language.DUTCH]: userGotFinedDutch,
+  [Language.ENGLISH]: userGotFinedEnglish,
+};
+
+export default class UserWillGetFined extends MailTemplate<UserWillGetFinedOptions> {
+  public constructor(options: UserWillGetFinedOptions) {
+    super(options, mailContents);
+  }
+}

--- a/src/service/transaction-service.ts
+++ b/src/service/transaction-service.ts
@@ -339,11 +339,11 @@ export default class TransactionService {
     }
 
     // init transaction
-    const transaction = ((update) ? {
+    const transaction = ((update) ? Object.assign(new Transaction(), {
       ...update,
       version: update.version + 1,
       updatedAt: new Date(),
-    } : {}) as Transaction;
+    }) : Object.assign(new Transaction(), {})) as Transaction;
 
     // get users
     transaction.from = await User.findOne({ where: { id: req.from } });
@@ -654,8 +654,10 @@ export default class TransactionService {
   Promise<TransactionResponse | undefined> {
     const transaction = await this.asTransaction(req);
 
+    await transaction.save();
+
     // save the transaction and invalidate user balance cache
-    const savedTransaction = await this.asTransactionResponse(await Transaction.save(transaction));
+    const savedTransaction = await this.asTransactionResponse(transaction);
     await this.invalidateBalanceCache(savedTransaction);
 
     // save transaction and return response

--- a/test/unit/entity/transactions/transaction.ts
+++ b/test/unit/entity/transactions/transaction.ts
@@ -1,0 +1,247 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2020  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Connection } from 'typeorm';
+import User, { TermsOfServiceStatus, UserType } from '../../../../src/entity/user/user';
+import Transaction from '../../../../src/entity/transactions/transaction';
+import SubTransaction from '../../../../src/entity/transactions/sub-transaction';
+import Transfer from '../../../../src/entity/transactions/transfer';
+import Database from '../../../../src/database/database';
+import {
+  seedContainers,
+  seedPointsOfSale,
+  seedProductCategories,
+  seedProducts, seedTransactions, seedTransfers,
+  seedUsers,
+  seedVatGroups,
+} from '../../../seed';
+import { calculateBalance } from '../../../helpers/balance';
+import ProductRevision from '../../../../src/entity/product/product-revision';
+import ContainerRevision from '../../../../src/entity/container/container-revision';
+import PointOfSaleRevision from '../../../../src/entity/point-of-sale/point-of-sale-revision';
+import Mailer from '../../../../src/mailer';
+import sinon, { SinonSandbox, SinonSpy } from 'sinon';
+import nodemailer, { Transporter } from 'nodemailer';
+import { expect } from 'chai';
+import TransactionService from '../../../../src/service/transaction-service';
+import BalanceService from '../../../../src/service/balance-service';
+
+describe('Transaction', () => {
+  let ctx: {
+    connection: Connection,
+    adminUser: User,
+    users: User[],
+    usersNotInDebt: User[],
+    usersInDebt: User[],
+    products: ProductRevision[];
+    containers: ContainerRevision[];
+    pointOfSales: PointOfSaleRevision[];
+    transactions: Transaction[],
+    subTransactions: SubTransaction[],
+    transfers: Transfer[];
+  };
+
+  let sandbox: SinonSandbox;
+  let sendMailFake: SinonSpy;
+
+  let env: string;
+
+  before(async () => {
+    const connection = await Database.initialize();
+
+    // create dummy users
+    const adminUser = {
+      id: 1,
+      firstName: 'Admin',
+      type: UserType.LOCAL_ADMIN,
+      active: true,
+      acceptedToS: TermsOfServiceStatus.ACCEPTED,
+    } as User;
+
+    const users = await seedUsers();
+    const categories = await seedProductCategories();
+    const vatGroups = await seedVatGroups();
+    const { productRevisions } = await seedProducts([adminUser], categories, vatGroups);
+    const { containerRevisions } = await seedContainers([adminUser], productRevisions);
+    const { pointOfSaleRevisions } = await seedPointsOfSale([adminUser], containerRevisions);
+    const { transactions } = await seedTransactions(users, pointOfSaleRevisions, new Date('2020-02-12'), new Date('2021-11-30'), 10);
+    const transfers = await seedTransfers(users, new Date('2020-02-12'), new Date('2021-11-30'));
+    const subTransactions: SubTransaction[] = Array.prototype.concat(...transactions
+      .map((t) => t.subTransactions));
+
+    ctx = {
+      connection,
+      adminUser,
+      users,
+      usersNotInDebt: users.filter((u) => calculateBalance(u, transactions, subTransactions, transfers).amount.getAmount() >= 0),
+      usersInDebt: users.filter((u) => calculateBalance(u, transactions, subTransactions, transfers).amount.getAmount() < 0),
+      products: productRevisions,
+      containers: containerRevisions,
+      pointOfSales: pointOfSaleRevisions,
+      transactions,
+      subTransactions,
+      transfers,
+    };
+
+    Mailer.reset();
+
+    sandbox = sinon.createSandbox();
+    sendMailFake = sandbox.spy();
+    sandbox.stub(nodemailer, 'createTransport').returns({
+      sendMail: sendMailFake,
+    } as any as Transporter);
+
+    env = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'test-transactions';
+  });
+
+  after(async () => {
+    await ctx.connection.dropDatabase();
+    await ctx.connection.destroy();
+    sandbox.restore();
+
+    process.env.NODE_ENV = env;
+  });
+
+  afterEach(() => {
+    sendMailFake.resetHistory();
+  });
+
+  describe('sendEmailNotificationIfNowInDebt', () => {
+    it('should send an email if someone gets into debt', async () => {
+      const user = ctx.usersNotInDebt[0];
+      const currentBalance = calculateBalance(user, ctx.transactions, ctx.subTransactions, ctx.transfers).amount;
+      expect(currentBalance.getAmount()).to.be.at.least(0);
+      expect((await BalanceService.getBalance(user.id)).amount.amount).to.equal(currentBalance.getAmount());
+
+      const pos = ctx.pointOfSales[0];
+      const container = ctx.containers[0];
+      const product = ctx.products[0];
+
+      const amount = Math.ceil(currentBalance.getAmount() / product.priceInclVat.getAmount()) + 1 ;
+      const totalPriceInclVat = product.priceInclVat.multiply(amount).toObject();
+      await TransactionService.createTransaction({
+        from: user.id,
+        pointOfSale: {
+          id: pos.pointOfSaleId,
+          revision: pos.revision,
+        },
+        createdBy: user.id,
+        totalPriceInclVat,
+        subTransactions: [{
+          container: {
+            id: container.containerId,
+            revision: container.revision,
+          },
+          to: product.product.owner.id,
+          totalPriceInclVat,
+          subTransactionRows: [{
+            product: {
+              id: product.productId,
+              revision: product.revision,
+            },
+            amount,
+            totalPriceInclVat,
+          }],
+        }],
+      });
+
+      expect(sendMailFake).to.be.calledOnce;
+    });
+    it('should not send email if someone does not go into debt', async () => {
+      const user = ctx.usersNotInDebt[1];
+      const currentBalance = calculateBalance(user, ctx.transactions, ctx.subTransactions, ctx.transfers).amount;
+      expect(currentBalance.getAmount()).to.be.at.least(0);
+      expect((await BalanceService.getBalance(user.id)).amount.amount).to.equal(currentBalance.getAmount());
+
+      const pos = ctx.pointOfSales[0];
+      const container = ctx.containers[0];
+      const product = ctx.products[0];
+
+      const amount = Math.floor(currentBalance.getAmount() / product.priceInclVat.getAmount()) - 1;
+      expect(amount).to.be.at.least(0);
+      const totalPriceInclVat = product.priceInclVat.multiply(amount).toObject();
+      await TransactionService.createTransaction({
+        from: user.id,
+        pointOfSale: {
+          id: pos.pointOfSaleId,
+          revision: pos.revision,
+        },
+        createdBy: user.id,
+        totalPriceInclVat,
+        subTransactions: [{
+          container: {
+            id: container.containerId,
+            revision: container.revision,
+          },
+          to: product.product.owner.id,
+          totalPriceInclVat,
+          subTransactionRows: [{
+            product: {
+              id: product.productId,
+              revision: product.revision,
+            },
+            amount,
+            totalPriceInclVat,
+          }],
+        }],
+      });
+
+      expect(sendMailFake).to.not.be.called;
+    });
+    it('should not send email if someone is already in debt', async () => {
+      const user = ctx.usersInDebt[0];
+      const currentBalance = calculateBalance(user, ctx.transactions, ctx.subTransactions, ctx.transfers).amount;
+      expect(currentBalance.getAmount()).to.be.at.most(-1);
+      expect((await BalanceService.getBalance(user.id)).amount.amount).to.equal(currentBalance.getAmount());
+
+      const pos = ctx.pointOfSales[0];
+      const container = ctx.containers[0];
+      const product = ctx.products[0];
+
+      const amount = 1;
+      const totalPriceInclVat = product.priceInclVat.toObject();
+      await TransactionService.createTransaction({
+        from: user.id,
+        pointOfSale: {
+          id: pos.pointOfSaleId,
+          revision: pos.revision,
+        },
+        createdBy: user.id,
+        totalPriceInclVat,
+        subTransactions: [{
+          container: {
+            id: container.containerId,
+            revision: container.revision,
+          },
+          to: product.product.owner.id,
+          totalPriceInclVat,
+          subTransactionRows: [{
+            product: {
+              id: product.productId,
+              revision: product.revision,
+            },
+            amount,
+            totalPriceInclVat,
+          }],
+        }],
+      });
+
+      expect(sendMailFake).to.not.be.called;
+    });
+  });
+});

--- a/test/unit/entity/transactions/transfer.ts
+++ b/test/unit/entity/transactions/transfer.ts
@@ -16,10 +16,10 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { Connection } from 'typeorm';
-import User from '../../../src/entity/user/user';
-import Transaction from '../../../src/entity/transactions/transaction';
-import Transfer from '../../../src/entity/transactions/transfer';
-import Database from '../../../src/database/database';
+import User from '../../../../src/entity/user/user';
+import Transaction from '../../../../src/entity/transactions/transaction';
+import Transfer from '../../../../src/entity/transactions/transfer';
+import Database from '../../../../src/database/database';
 import {
   seedContainers,
   seedPointsOfSale,
@@ -27,15 +27,15 @@ import {
   seedProducts, seedTransactions, seedTransfers,
   seedUsers,
   seedVatGroups,
-} from '../../seed';
-import SubTransaction from '../../../src/entity/transactions/sub-transaction';
-import { calculateBalance } from '../../helpers/balance';
-import DebtorService from '../../../src/service/debtor-service';
+} from '../../../seed';
+import SubTransaction from '../../../../src/entity/transactions/sub-transaction';
+import { calculateBalance } from '../../../helpers/balance';
+import DebtorService from '../../../../src/service/debtor-service';
 import { expect } from 'chai';
-import { addTransfer } from '../../helpers/transaction-helpers';
-import BalanceService from '../../../src/service/balance-service';
+import { addTransfer } from '../../../helpers/transaction-helpers';
+import BalanceService from '../../../../src/service/balance-service';
 import dinero from 'dinero.js';
-import Fine from '../../../src/entity/fine/fine';
+import Fine from '../../../../src/entity/fine/fine';
 
 describe('transfer', (): void => {
   let ctx: {


### PR DESCRIPTION
Users will get an automatic email once they go into debt by making a transaction.

The treasurer can send notifications manually to people that they will get fined next time. This email is however only sent to people who are actually eligible for a fine at the time of sending.