### PR TITLE
Hotfix for stripe transaction erroring on deposit update

### DIFF
--- a/src/service/stripe-service.ts
+++ b/src/service/stripe-service.ts
@@ -28,9 +28,9 @@ import {
   StripePaymentIntentResponse,
 } from '../controller/response/stripe-response';
 import TransferService from './transfer-service';
-import {EntityManager, IsNull} from 'typeorm';
+import { EntityManager, IsNull } from 'typeorm';
 import { parseUserToBaseResponse } from '../helpers/revision-to-response';
-import wrapInManager from "../helpers/database";
+import wrapInManager from '../helpers/database';
 
 export const STRIPE_API_VERSION = '2022-08-01';
 
@@ -158,7 +158,7 @@ export default class StripeService {
       throw new Error('Cannot create status FAILED, because SUCCEEDED already exists');
     }
 
-    const depositStatus = Object.assign(new StripeDepositStatus(), { deposit, state });
+    const depositStatus = Object.assign(new StripeDepositStatus(), { deposit: { id: deposit.id }, state });
     await manager.save(depositStatus);
 
     // If payment has succeeded, create the transfer
@@ -173,7 +173,7 @@ export default class StripeService {
         toId: deposit.to.id,
         description: deposit.stripeId,
         fromId: undefined,
-      });
+      }, manager);
 
       await manager.save(deposit);
     }

--- a/src/subscriber/transfer-subscriber.ts
+++ b/src/subscriber/transfer-subscriber.ts
@@ -43,7 +43,7 @@ export default class TransferSubscriber implements EntitySubscriberInterface {
     // Remove currently unpaid fines when new balance is positive.
     if (currentBalance >= 0) {
       user.currentFines = null;
-      await user.save();
+      await event.manager.save(user);
     }
   }
 }

--- a/test/unit/controller/transaction-controller.ts
+++ b/test/unit/controller/transaction-controller.ts
@@ -36,8 +36,6 @@ import { TransactionRequest } from '../../../src/controller/request/transaction-
 import { defaultPagination, PAGINATION_DEFAULT, PaginationResult } from '../../../src/helpers/pagination';
 import { inUserContext, UserFactory } from '../../helpers/user-factory';
 import MemberAuthenticator from '../../../src/entity/authenticator/member-authenticator';
-import { tr } from 'date-fns/locale';
-import { validDate } from '../../../src/controller/request/validators/duration-spec';
 
 describe('TransactionController', (): void => {
   let ctx: {


### PR DESCRIPTION
TypeOrm failed to correctly save the stripe deposit status within the type orm transaction (because reasons?), Stating the id seemed to work.