### PR TITLE
Fixed bug where bindings were not overwritten for the cron tasks.

### DIFF
--- a/src/cron.ts
+++ b/src/cron.ts
@@ -73,6 +73,9 @@ async function createCronTasks(): Promise<void> {
 
   application.tasks = [syncBalances];
 
+  // INJECT GEWIS BINDINGS
+  Gewis.overwriteBindings();
+
   if (process.env.ENABLE_LDAP === 'true') {
     await ADService.syncUsers();
     await ADService.syncSharedAccounts().then(


### PR DESCRIPTION
The cron task runs in a different process than the main. This means that GEWIS bindings were never injected for the cron tasks and thus the LDAP sync created "normal" user accounts. This gave GEWIS users two accounts, one of their GEWIS web account and one for the LDAP sync.