### PR TITLE
Fix filtering and make it more consistent across the API and fix user debt notifications

### DIFF
--- a/src/controller/balance-controller.ts
+++ b/src/controller/balance-controller.ts
@@ -98,7 +98,7 @@ export default class BalanceController extends BaseController {
    * @param {boolean} hasFine.query - Only users with(out) fines
    * @param {integer} minFine.query - Minimum fine
    * @param {integer} maxFine.query - Maximum fine
-   * @param {Array<string|number>} userType.query - enum:MEMBER,ORGAN,VOUCHER,LOCAL_USER,LOCAL_ADMIN,INVOICE,AUTOMATIC_INVOICE - Filter based on user type.
+   * @param {Array<string|number>} userTypes.query - enum:MEMBER,ORGAN,VOUCHER,LOCAL_USER,LOCAL_ADMIN,INVOICE,AUTOMATIC_INVOICE - Filter based on user type.
    * @param {string} orderBy.query - Column to order balance by - eg: id,amount
    * @param {string} orderDirection.query - enum:ASC,DESC - Order direction
    * @param {integer} take.query - How many transactions the endpoint should return

--- a/src/controller/invoice-controller.ts
+++ b/src/controller/invoice-controller.ts
@@ -88,8 +88,7 @@ export default class InvoiceController extends BaseController {
    * @security JWT
    * @param {integer} toId.query - Filter on Id of the debtor
    * @param {number} invoiceId.query - Filter on invoice ID
-   * @param {integer} state.query.enum{1,2,3,4} - Filter based on Invoice State.
-   *    Possible values: 1 (CREATED), 2 (SENT), 3 (PAID), 4 (DELETED)
+   * @param {Array<string|number>} state.query enum:CREATED,SENT,PAID,DELETED - Filter based on Invoice State.
    * @param {boolean} returnEntries.query - Boolean if invoice entries should be returned
    * @param {string} fromDate.query - Start date for selected invoices (inclusive)
    * @param {string} tillDate.query - End date for selected invoices (exclusive)

--- a/src/controller/invoice-controller.ts
+++ b/src/controller/invoice-controller.ts
@@ -88,7 +88,7 @@ export default class InvoiceController extends BaseController {
    * @security JWT
    * @param {integer} toId.query - Filter on Id of the debtor
    * @param {number} invoiceId.query - Filter on invoice ID
-   * @param {Array<string|number>} state.query enum:CREATED,SENT,PAID,DELETED - Filter based on Invoice State.
+   * @param {Array<string|number>} currentState.query enum:CREATED,SENT,PAID,DELETED - Filter based on Invoice State.
    * @param {boolean} returnEntries.query - Boolean if invoice entries should be returned
    * @param {string} fromDate.query - Start date for selected invoices (inclusive)
    * @param {string} tillDate.query - End date for selected invoices (exclusive)

--- a/src/entity/user/user.ts
+++ b/src/entity/user/user.ts
@@ -53,6 +53,13 @@ export const TOSRequired = [
 ];
 
 /**
+ * All users that should be notified when in debt.
+ */
+export const NotifyDebtUserTypes: UserType[] = [
+  UserType.LOCAL_ADMIN, UserType.LOCAL_USER, UserType.MEMBER,
+];
+
+/**
  * @typedef {BaseEntity} User
  * @property {string} firstName.required - First name of the user.
  * @property {string} lastName - Last name of the user.

--- a/src/service/invoice-service.ts
+++ b/src/service/invoice-service.ts
@@ -44,11 +44,7 @@ import User from '../entity/user/user';
 import DineroTransformer from '../entity/transformer/dinero-transformer';
 import SubTransactionRow from '../entity/transactions/sub-transaction-row';
 import { parseUserToBaseResponse } from '../helpers/revision-to-response';
-import {
-  collectByToId,
-  collectProductsByRevision,
-  reduceMapToInvoiceEntries,
-} from '../helpers/transaction-mapper';
+import { collectByToId, collectProductsByRevision, reduceMapToInvoiceEntries } from '../helpers/transaction-mapper';
 import SubTransaction from '../entity/transactions/sub-transaction';
 
 export interface InvoiceFilterParameters {
@@ -63,7 +59,7 @@ export interface InvoiceFilterParameters {
   /**
    * Filter based on the current invoice state
    */
-  currentState?: InvoiceState
+  invoiceStatus?: InvoiceState
   /**
    * Boolean if the invoice entries should be added to the response.
    */
@@ -82,7 +78,7 @@ export function parseInvoiceFilterParameters(req: RequestWithToken): InvoiceFilt
   return {
     toId: asNumber(req.query.toId),
     invoiceId: asNumber(req.query.invoiceId),
-    currentState: asInvoiceState(req.query.currentState),
+    invoiceStatus: asInvoiceState(req.query.currentState),
     returnInvoiceEntries: asBoolean(req.query.returnInvoiceEntries),
     fromDate: asDate(req.query.fromDate),
     tillDate: asDate(req.query.tillDate),
@@ -526,6 +522,7 @@ export default class InvoiceService {
       currentState: 'currentState',
       toId: 'toId',
       invoiceId: 'id',
+      invoiceStatus: 'invoiceStatus.state'
     };
 
     const relations: FindOptionsRelationByString = ['to', 'invoiceStatus', 'transfer', 'transfer.to', 'transfer.from'];

--- a/src/subscriber/transaction-subscriber.ts
+++ b/src/subscriber/transaction-subscriber.ts
@@ -47,7 +47,14 @@ export default class TransactionSubscriber implements EntitySubscriberInterface 
 
     let currentBalance = balance.amount.amount;
     if (balance.lastTransactionId < event.entity.id) {
-      currentBalance -= entity.subTransactions[0].subTransactionRows[0].amount * entity.subTransactions[0].subTransactionRows[0].product.priceInclVat.getAmount();
+      // Check if subTransactions exists, is not empty, and subTransactionRows exists and is not empty
+      if (entity.subTransactions?.length > 0 && entity.subTransactions[0].subTransactionRows?.length > 0) {
+        const subTransaction = entity.subTransactions[0].subTransactionRows[0];
+        // Ensure the amount and product.priceInclVat.getAmount() exist before performing the calculation
+        if (subTransaction.amount && typeof subTransaction.product?.priceInclVat?.getAmount === 'function') {
+          currentBalance -= subTransaction.amount * subTransaction.product.priceInclVat.getAmount();
+        }
+      }
     }
 
     if (currentBalance >= 0) return;

--- a/src/subscriber/transaction-subscriber.ts
+++ b/src/subscriber/transaction-subscriber.ts
@@ -17,7 +17,7 @@
  */
 import { EntitySubscriberInterface, EventSubscriber, InsertEvent } from 'typeorm';
 import Transaction from '../entity/transactions/transaction';
-import User from '../entity/user/user';
+import User, {NotifyDebtUserTypes} from '../entity/user/user';
 import BalanceService from '../service/balance-service';
 import Mailer from '../mailer';
 import UserDebtNotification from '../mailer/templates/user-debt-notification';
@@ -67,6 +67,9 @@ export default class TransactionSubscriber implements EntitySubscriberInterface 
 
     if (balanceBefore.amount.amount < 0) return;
     // User was not in debt before this new transaction
+
+    if (!(user.type in NotifyDebtUserTypes)) return;
+    // User should be notified of debt
 
     Mailer.getInstance().send(user, new UserDebtNotification({
       name: user.firstName,

--- a/test/unit/subscribe/transaction-subscriber.ts
+++ b/test/unit/subscribe/transaction-subscriber.ts
@@ -16,7 +16,7 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { Connection } from 'typeorm';
-import User, { TermsOfServiceStatus, UserType } from '../../../src/entity/user/user';
+import User, {NotifyDebtUserTypes, TermsOfServiceStatus, UserType} from '../../../src/entity/user/user';
 import Transaction from '../../../src/entity/transactions/transaction';
 import SubTransaction from '../../../src/entity/transactions/sub-transaction';
 import Transfer from '../../../src/entity/transactions/transfer';
@@ -87,8 +87,8 @@ describe('TransactionSubscriber', () => {
       connection,
       adminUser,
       users,
-      usersNotInDebt: users.filter((u) => calculateBalance(u, transactions, subTransactions, transfers).amount.getAmount() >= 0),
-      usersInDebt: users.filter((u) => calculateBalance(u, transactions, subTransactions, transfers).amount.getAmount() < 0),
+      usersNotInDebt: users.filter((u) => calculateBalance(u, transactions, subTransactions, transfers).amount.getAmount() >= 0 && u.type in NotifyDebtUserTypes),
+      usersInDebt: users.filter((u) => calculateBalance(u, transactions, subTransactions, transfers).amount.getAmount() < 0 && u.type in NotifyDebtUserTypes),
       products: productRevisions,
       containers: containerRevisions,
       pointOfSales: pointOfSaleRevisions,


### PR DESCRIPTION
Filtering is flawed in a couple places, and should be up to the latest spec (as seen on GET /balances/all). This PR should fix that, along with some filtering issues where the parameter seems to be simply ignored.

Fixes #84.

TODO:

- [x] Make invoice filtering actually work
- [x] Add "available values" to every filtering option with an enum, as on GET /users/