### PR TITLE
hotfix: improved logging

### DIFF
--- a/src/service/invoice-pdf-service.ts
+++ b/src/service/invoice-pdf-service.ts
@@ -235,7 +235,8 @@ export default class InvoicePdfService {
       const buffer = Buffer.from(await blob.arrayBuffer());
       return this.pdfGenerator.fileService.uploadInvoicePdf(invoice, buffer, invoice.to, hashJSON(this.getInvoiceParameters(invoice)));
     }).catch((res: any) => {
-      throw new Error(`Invoice generation failed: ${res}`);
+      console.error('Invoice failed with ', res);
+      throw new Error('Invoice generation failed');
     });
   }
 }


### PR DESCRIPTION
The error would just report the classic `[object Object]`