### PR TITLE
feat: maximum top-up amount check

### DIFF
--- a/src/service/stripe-service.ts
+++ b/src/service/stripe-service.ts
@@ -49,16 +49,28 @@ export default class StripeService {
   }
 
   /**
-   * Topup should be at least 10 euros or the users negative balance.
+   * Topup should be at least 10 euros or the user's negative balance.
    * @param balance
    * @param request
    */
-  public static validateStripeRequestAmount(balance: BalanceResponse, request: StripeRequest): boolean {
+  public static validateStripeRequestMinimumAmount(balance: BalanceResponse, request: StripeRequest): boolean {
     const MIN_TOPUP = process.env.MIN_TOPUP || 1000;
 
-    // Check if top up is enough
+    // Check if top-up is enough
     if (request.amount.amount >= MIN_TOPUP) return true;
     return request.amount.amount === -1 * balance.amount.amount;
+  }
+
+  /**
+   * Topup should be at most 150 euros minus user's positive balance or user's negative balance.
+   * @param balance
+   * @param request
+   */
+  public static validateStripeRequestMaximumAmount(balance: BalanceResponse, request: StripeRequest): boolean {
+    const MAX_BALANCE = process.env.MAX_BALANCE || 15000;
+
+    // Check if top-up will not exceed max balance
+    return MAX_BALANCE >= (balance.amount.amount + request.amount.amount);
   }
 
   private static asStripeDepositStatusResponse(status: StripeDepositStatus): StripeDepositStatusResponse {


### PR DESCRIPTION
Introduces validation for the maximum amount a top-up can have; to verify that the user can only top-up their balance with €150 minus their current balance.