### PR TITLE
ci: add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,42 @@
+name: "🐛 Bug Report"
+description: Report a bug found while using the SudoSOS backend.
+labels: ["Type: Bug", "Status: Triage"]
+body:
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current behavior
+      description: A description of what is currently happening, including error messages, logs, and other useful information (**DO NOT INCLUDE PRIVATE INFORMATION**).
+      placeholder: Currently...
+    validations:
+      required: true
+  - type: textarea
+    id: desired-behavior
+    attributes:
+      label: Desired behavior
+      description: A clear description of what you think should happen.
+      placeholder: In this situation, I expected ...
+  - type: input
+    id: api-route
+    attributes:
+      label: API Route
+      description: The specific API route that was being used when the issue occurred (optional).
+      placeholder: ex. POST /api/v1/resource
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Clearly describe the steps or actions taken to arrive at the problem. Include any relevant code snippets or configuration details.
+      placeholder: I did X, then Y, before arriving at Z, when ERROR ...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and Error Messages
+      description: Provide any relevant logs or error messages that can help diagnose the problem.
+  - type: textarea
+    id: other
+    attributes:
+      label: Other Information
+      description: Any other details? Things like additional configurations, specific modules or packages, etc.

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,29 @@
+name: "✨ Feature Request"
+description: Suggest a feature or enhancement to improve SudoSOS backend. Please make sure that this is a feature for the backend and not the frontend.
+labels: ["Type: Idea"]
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: What would you like?
+      description: A clear description of the feature or enhancement wanted on the SudoSOS backend.
+      placeholder: I'd like to be able to...
+    validations:
+      required: true
+  - type: textarea
+    id: reason
+    attributes:
+      label: Why is this needed?
+      description: A clear description of why this would be useful to have in the SudoSOS backend.
+      placeholder: I want this because...
+  - type: textarea
+    id: implementation
+    attributes:
+      label: How could it be implemented?
+      description: A clear description of how this feature could be implemented, including any relevant technical details or suggestions.
+      placeholder: This could be implemented by...
+  - type: textarea
+    id: other
+    attributes:
+      label: Other information
+      placeholder: Any other details?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- Provide a general summary of your changes in the title above. -->
+
+# Description
+<!--
+What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
+Describe your changes in detail and, if relevant, explain which choices you have made and why.
+When making changes to the UI, make sure to include comparison screenshots!
+-->
+
+## Related issues/external references
+<!--
+Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
+`ABC-YYMM-XXX`.
+-->
+
+## Types of changes
+<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
+- Bug fix _(non-breaking change which fixes an issue)_
+- New feature _(non-breaking change which adds functionality)_
+- Breaking change _(fix or feature that would cause existing functionality to change)_
+- Documentation improvement
+- Style _(Change that do not affect the functionality of the code)_
+- CI/CD _(Changes to the CI/CD configuration)_


### PR DESCRIPTION
Adds basic templates for issues and PR's.

based on sudosos-frontend