### PR TITLE
Remove createdBy transactions on the user related endpoints.

### DIFF
--- a/src/controller/user-controller.ts
+++ b/src/controller/user-controller.ts
@@ -1001,7 +1001,7 @@ export default class UserController extends BaseController {
 
   /**
    * GET /users/{id}/transactions
-   * @summary Get an user's transactions (from, to or created)
+   * @summary Get transactions from a user.
    * @operationId getUsersTransactions
    * @tags users - Operations of user controller
    * @param {integer} id.path.required - The id of the user that should be involved
@@ -1062,7 +1062,7 @@ export default class UserController extends BaseController {
 
   /**
    * GET /users/{id}/transfers
-   * @summary Get an user's transfers
+   * @summary Get transfers to or from an user.
    * @operationId getUsersTransfers
    * @tags users - Operations of user controller
    * @param {integer} id.path.required - The id of the user that should be involved
@@ -1241,7 +1241,7 @@ export default class UserController extends BaseController {
 
   /**
    * GET /users/{id}/financialmutations
-   * @summary Get all financial mutations of a user.
+   * @summary Get all financial mutations of a user (from or to).
    * @operationId getUsersFinancialMutations
    * @tags users - Operations of user controller
    * @param {integer} id.path.required - The id of the user to get the mutations from

--- a/src/service/transaction-service.ts
+++ b/src/service/transaction-service.ts
@@ -575,7 +575,6 @@ export default class TransactionService {
     if (user) {
       query.andWhere(new Brackets((qb) => {
         qb.where('transaction.fromId = :userId', { userId: user.id })
-          .orWhere('transaction.createdById = :userId', { userId: user.id })
           .orWhere('subTransaction.toId = :userId', { userId: user.id });
       }));
     }

--- a/test/unit/controller/user-controller.ts
+++ b/test/unit/controller/user-controller.ts
@@ -1175,7 +1175,7 @@ describe('UserController', (): void => {
         .leftJoinAndSelect('pointOfSaleRev.pointOfSale', 'pointOfSale')
         .leftJoin('transaction.subTransactions', 'subTransaction')
         .leftJoin('subTransaction.subTransactionRows', 'subTransactionRow')
-        .where('transaction.fromId = :userId OR transaction.createdById = :userId OR subTransaction.toId = :userId', { userId: user.id })
+        .where('transaction.fromId = :userId OR subTransaction.toId = :userId', { userId: user.id })
         .distinct(true)
         .getRawMany();
 


### PR DESCRIPTION
Remove transactions created by the user from the transactions overview of the user (as well as the financial mutation)

# Description
Currently, financial mutations and transactions on `/user/{id}/transactions` and `/user/{id}/financialmutations` return also transactions that are created by the user. This PR removes that functionality. The idea is that all the financial mutation (transactions, transfers, and financialmutation) on the `/user/*` should only return transactions/transfers that mutate the user's balance. 

This is also tied into the frontend, where it would only make sense to display only transactions that influence the balance of the user together, serving the purpose of being able to see why you are €-15 when you topped up a week ago. Transactions that are created by the user should be displayed in a separate view because it serves a different purpose (namely, looking back at who you bought for in case someone comes knocking after an event). 

## Related issues/external references
This also solves (not fixes) the need for #157, because now transactions/transfers from users will actually be treated in a different way than transactions from an endpoint. They will get different views based on their purpose (seeing influences or your balance, or administratively what transactions happened on a PoS or by a user).

## Types of changes
- Breaking change _(fix or feature that would cause existing functionality to change)_