### PR TITLE
refactor: Make generating/calculating invoices and involving substructures separate from saving

### DIFF
--- a/src/helpers/transaction-mapper.ts
+++ b/src/helpers/transaction-mapper.ts
@@ -180,10 +180,10 @@ export function reduceMapToCategoryEntries(categoryMap: Map<number, SubTransacti
  * Transforms an array of SubTransactionRows of the same product into invoice entries.
  * @param productMap
  * @param invoice
+ * @param saveToDatabase
  */
 export async function reduceMapToInvoiceEntries(productMap: Map<string, SubTransactionRow[]>, invoice: Invoice): Promise<InvoiceEntry[]> {
   const invoiceEntries: InvoiceEntry[] = [];
-  const promises: Promise<any>[] = [];
   productMap.forEach((tSubRow) => {
     const product = tSubRow[0].product;
     const count = tSubRow.reduce((sum, current) => {
@@ -196,8 +196,14 @@ export async function reduceMapToInvoiceEntries(productMap: Map<string, SubTrans
       priceInclVat: product.priceInclVat,
       vatPercentage: product.vat.percentage,
     });
-    promises.push(InvoiceEntry.save(entry).then((i) => invoiceEntries.push(i)));
+    invoiceEntries.push(entry);
   });
-  await Promise.all(promises);
   return invoiceEntries;
+}
+
+export async function saveInvoiceEntries(entries: InvoiceEntry[]): Promise<void> {
+  const promises: Promise<any>[] = [];
+  entries.forEach((entry) => promises.push(InvoiceEntry.save(entry)));
+  await Promise.all(promises);
+  return;
 }

--- a/src/service/invoice-service.ts
+++ b/src/service/invoice-service.ts
@@ -165,7 +165,7 @@ export default class InvoiceService {
   }
 
   /**
-   * Creates a Transfer for an Invoice from TransactionResponses
+   * Is a Transfer for an Invoice from TransactionResponses
    * @param forId - The user which receives the Invoice/Transfer
    * @param transactions - The array of transactions which to create the Transfer for
    * @param isCreditInvoice - If the invoice is a credit Invoice

--- a/src/service/invoice-service.ts
+++ b/src/service/invoice-service.ts
@@ -205,7 +205,8 @@ export default class InvoiceService {
     };
 
     if (!saveToDatabase) {
-      return TransferService.createTransferFromRequest(transferRequest);
+      const transfer = TransferService.createTransferFromRequest(transferRequest);
+      return transfer;
     } else {
       return TransferService.postTransfer(transferRequest);
     }

--- a/src/service/transfer-service.ts
+++ b/src/service/transfer-service.ts
@@ -18,10 +18,7 @@
 
 
 import dinero, { Dinero } from 'dinero.js';
-import {
-  EntityManager,
-  FindManyOptions,
-} from 'typeorm';
+import { EntityManager, FindManyOptions } from 'typeorm';
 import Transfer from '../entity/transactions/transfer';
 import { PaginatedTransferResponse, TransferResponse } from '../controller/response/transfer-response';
 import TransferRequest from '../controller/request/transfer-request';
@@ -71,13 +68,19 @@ export default class TransferService {
     };
   }
 
-  public static async createTransfer(request: TransferRequest, manager?: EntityManager) : Promise<Transfer> {
-    const transfer = Object.assign(new Transfer(), {
+  public static async createTransferFromRequest(request: TransferRequest): Promise<Transfer> {
+    return Object.assign(new Transfer(), {
       description: request.description,
       amount: dinero(request.amount as Dinero.Options),
       from: request.fromId ? await User.findOne({ where: { id: request.fromId } }) : undefined,
       to: request.toId ? await User.findOne({ where: { id: request.toId } }) : undefined,
     });
+  }
+
+
+
+  public static async createTransfer(request: TransferRequest, manager?: EntityManager) : Promise<Transfer> {
+    const transfer = await this.createTransferFromRequest(request);
 
     if (manager) {
       await manager.save(transfer);

--- a/test/unit/service/invoice-service.ts
+++ b/test/unit/service/invoice-service.ts
@@ -265,9 +265,11 @@ describe('InvoiceService', () => {
       });
 
       expect(transactions).to.not.be.empty;
-      const transfer: TransferResponse = (
-        await InvoiceService.createTransferFromTransactions(toId, transactions, false));
-      expect(transfer.amount.amount).to.be.equal(value);
+      const transfer: TransferResponse | Transfer = (
+        await InvoiceService.createTransferFromTransactions(toId, transactions, false, true));
+      if ('amount' in transfer.amount) {
+        expect(transfer.amount.amount).to.be.equal(value);
+      }
       expect(transfer.to.id).to.be.equal(toId);
     });
   });
@@ -548,6 +550,8 @@ describe('InvoiceService', () => {
         const creditorBalance = await BalanceService.getBalance(creditor.id);
         const transfer = await Transfer.findOne({ where: { from: { id: creditor.id } } });
         expect(transfer).to.not.be.undefined;
+        // expect(transfer.amount).to.not.be.null;
+        // expect(invoice.transfer.amount).to.not.be.null;
         expect(transfer.amount.getAmount()).to.eq(invoice.transfer.amount.getAmount());
         expect(creditorBalance.amount.amount).to.eq(0);
       });


### PR DESCRIPTION

# Description
This PR is mostly preparing for an eventual "invoice preview" option. Before it was the case that both calculating and saving to the database was in the same function each time, these are now split.
## Related issues/external references
None

## Types of changes
Refactor