### PR TITLE
Fix:issue 193 invoice allow defaults for  ORGANS

### DIFF
--- a/src/controller/invoice-controller.ts
+++ b/src/controller/invoice-controller.ts
@@ -436,8 +436,8 @@ export default class InvoiceController extends BaseController {
         return;
       }
 
-      if (user.type !== UserType.INVOICE) {
-        res.status(400).json(`User is of type ${UserType[user.type]} and not of type INVOICE.`);
+      if (!([UserType.INVOICE, UserType.ORGAN].includes(user.type))) {
+        res.status(400).json(`User is of type ${UserType[user.type]} and not of type INVOICE or ORGAN.`);
         return;
       }
 

--- a/test/unit/service/balance-service.ts
+++ b/test/unit/service/balance-service.ts
@@ -367,7 +367,6 @@ describe('BalanceService', (): void => {
           expect(actualBalance.lastTransfer).to.be.undefined;
         }
 
-        console.error(balance);
         expect(actualBalance.amount.getAmount()).to.equal(balance.amount.amount);
         expect(cachedBalance.amount.getAmount()).to.equal(balance.amount.amount);
       }


### PR DESCRIPTION
# Description
Since the BACPM makes credit invoices for ORGAN users it seems reasonable to also allow defaults for those.

## Related issues/external references
#193 

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
