### PR TITLE
Feature: create payout request for others

### DIFF
--- a/src/controller/request/payout-request-request.ts
+++ b/src/controller/request/payout-request-request.ts
@@ -23,9 +23,11 @@ import { DineroObjectRequest } from './dinero-request';
  * @property {DineroObjectRequest} amount.required - The requested amount to be paid out
  * @property {string} bankAccountNumber.required - The bank account number to transfer the money to
  * @property {string} bankAccountName.required - The name of the owner of the bank account
+ * @property {integer} forId.required - The ID of the user who requested the payout
  */
 export default interface PayoutRequestRequest {
   amount: DineroObjectRequest;
   bankAccountNumber: string;
   bankAccountName: string;
+  forId: number;
 }

--- a/test/unit/service/payout-request-service.ts
+++ b/test/unit/service/payout-request-service.ts
@@ -28,6 +28,7 @@ import { PayoutRequestState } from '../../../src/entity/transactions/payout-requ
 import PayoutRequestRequest from '../../../src/controller/request/payout-request-request';
 import { truncateAllTables } from '../../setup';
 import { finishTestDB } from '../../helpers/test-helpers';
+import BalanceService from "../../../src/service/balance-service";
 
 describe('PayoutRequestService', () => {
   let ctx: {
@@ -38,6 +39,20 @@ describe('PayoutRequestService', () => {
     validPayoutRequestRequest: PayoutRequestRequest,
   };
 
+  async function getValidPayoutRequest(id: number): Promise<PayoutRequestRequest> {
+    const balance = await BalanceService.getBalance(id);
+    return {
+      amount: {
+        amount: balance.amount.amount,
+        precision: balance.amount.precision,
+        currency: balance.amount.currency,
+      },
+      bankAccountNumber: 'NL22 ABNA 0528195913',
+      bankAccountName: 'Studievereniging GEWIS',
+      forId: id,
+    };
+  }
+
   before(async () => {
     const connection = await Database.initialize();
     await truncateAllTables(connection);
@@ -47,15 +62,7 @@ describe('PayoutRequestService', () => {
 
     const dineroTransformer = DineroTransformer.Instance;
 
-    const validPayoutRequestRequest: PayoutRequestRequest = {
-      amount: {
-        amount: 3900,
-        precision: 2,
-        currency: 'EUR',
-      },
-      bankAccountNumber: 'NL22 ABNA 0528195913',
-      bankAccountName: 'Studievereniging GEWIS',
-    };
+    const validPayoutRequestRequest: PayoutRequestRequest = await getValidPayoutRequest(users[0].id);
 
     ctx = {
       connection,


### PR DESCRIPTION
# Description
Currently the BACPM is unable to create payout requests for other users, which is a bummer if those accounts are blocked and or deactivated. 

## Types of changes
- New feature _(non-breaking change which adds functionality)_
