### PR TITLE
Feature: add deleting products, containers and points of sale

### DIFF
--- a/src/controller/container-controller.ts
+++ b/src/controller/container-controller.ts
@@ -36,6 +36,7 @@ import {
   UpdateContainerRequest,
 } from './request/container-request';
 import userTokenInOrgan from '../helpers/token-helper';
+import { IsNull, Not } from 'typeorm';
 
 export default class ContainerController extends BaseController {
   private logger: Logger = log4js.getLogger('ContainerController');
@@ -141,7 +142,7 @@ export default class ContainerController extends BaseController {
     // Handle request
     try {
       // Check if we should return a 404.
-      const exist = await ContainerRevision.findOne({ where: { container: { id: containerId } } });
+      const exist = await ContainerRevision.findOne({ where: { container: { id: containerId, deletedAt: IsNull() } } });
       if (!exist) {
         res.status(404).json('Container not found.');
         return;

--- a/src/controller/container-controller.ts
+++ b/src/controller/container-controller.ts
@@ -36,7 +36,6 @@ import {
   UpdateContainerRequest,
 } from './request/container-request';
 import userTokenInOrgan from '../helpers/token-helper';
-import { IsNull } from 'typeorm';
 
 export default class ContainerController extends BaseController {
   private logger: Logger = log4js.getLogger('ContainerController');
@@ -145,15 +144,12 @@ export default class ContainerController extends BaseController {
 
     // Handle request
     try {
-      // Check if we should return a 404.
-      const exist = await ContainerRevision.findOne({ where: { container: { id: containerId, deletedAt: IsNull() } } });
-      if (!exist) {
+      const container = (await ContainerService
+        .getContainers({ containerId, returnProducts: true })).records[0];
+      if (!container) {
         res.status(404).json('Container not found.');
         return;
       }
-
-      const container = (await ContainerService
-        .getContainers({ containerId, returnProducts: true })).records[0];
       res.json(container);
     } catch (error) {
       this.logger.error('Could not return single container:', error);

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -72,8 +72,9 @@ import InvoicePdf from '../entity/file/invoice-pdf';
 import { InvoiceRefactor1707251162194 } from '../migrations/1707251162194-invoice-refactor';
 import dotenv from 'dotenv';
 import { PERSISTENT_TEST_DATABASES } from '../helpers/database';
-import PayoutRequestPdf from "../entity/file/payout-request-pdf";
-import {PayoutRequestPdf1720610649657} from "../migrations/1720610649657-payout-request-pdf";
+import PayoutRequestPdf from '../entity/file/payout-request-pdf';
+import { PayoutRequestPdf1720610649657 } from '../migrations/1720610649657-payout-request-pdf';
+import { SoftDeletes1720608140757 } from '../migrations/1720608140757-soft-deletes';
 
 // We need to load the dotenv to prevent the env from being undefined.
 dotenv.config();
@@ -91,7 +92,7 @@ const options: DataSourceOptions = {
   password: process.env.TYPEORM_PASSWORD,
   synchronize: process.env.TYPEORM_SYNCHRONIZE === 'true',
   logging: process.env.TYPEORM_LOGGING === 'true',
-  migrations: [InvoiceRefactor1707251162194, PayoutRequestPdf1720610649657],
+  migrations: [InvoiceRefactor1707251162194, SoftDeletes1720608140757, PayoutRequestPdf1720610649657],
   extra: {
     authPlugins: {
       mysql_clear_password: () => () => Buffer.from(`${process.env.TYPEORM_PASSWORD}\0`),

--- a/src/entity/container/container-revision.ts
+++ b/src/entity/container/container-revision.ts
@@ -60,7 +60,7 @@ export default class ContainerRevision extends BaseEntityWithoutId {
   })
   public name: string;
 
-  @ManyToMany(() => ProductRevision)
+  @ManyToMany(() => ProductRevision, (product) => product.containers)
   @JoinTable()
   public products: ProductRevision[];
 

--- a/src/entity/container/container.ts
+++ b/src/entity/container/container.ts
@@ -17,7 +17,7 @@
  */
 
 import {
-  Column,
+  Column, DeleteDateColumn,
   Entity,
   ManyToOne,
 } from 'typeorm';
@@ -37,6 +37,9 @@ export default class Container extends BaseEntity {
     nullable: true,
   })
   public currentRevision: number;
+
+  @DeleteDateColumn()
+  public readonly deletedAt: Date | null;
 
   @ManyToOne(() => User, { nullable: false })
   public owner: User;

--- a/src/entity/container/container.ts
+++ b/src/entity/container/container.ts
@@ -41,7 +41,7 @@ export default class Container extends BaseEntity {
   @DeleteDateColumn()
   public readonly deletedAt: Date | null;
 
-  @ManyToOne(() => User, { nullable: false })
+  @ManyToOne(() => User, { nullable: false, eager: true })
   public owner: User;
 
   @Column({

--- a/src/entity/point-of-sale/point-of-sale.ts
+++ b/src/entity/point-of-sale/point-of-sale.ts
@@ -40,6 +40,6 @@ export default class PointOfSale extends BaseEntity {
   @DeleteDateColumn()
   public readonly deletedAt: Date | null;
 
-  @ManyToOne(() => User, { nullable: false })
+  @ManyToOne(() => User, { nullable: false, eager: true })
   public owner: User;
 }

--- a/src/entity/point-of-sale/point-of-sale.ts
+++ b/src/entity/point-of-sale/point-of-sale.ts
@@ -17,7 +17,7 @@
  */
 
 import {
-  Column,
+  Column, DeleteDateColumn,
   Entity,
   ManyToOne,
 } from 'typeorm';
@@ -36,6 +36,9 @@ export default class PointOfSale extends BaseEntity {
     nullable: true,
   })
   public currentRevision: number;
+
+  @DeleteDateColumn()
+  public readonly deletedAt: Date | null;
 
   @ManyToOne(() => User, { nullable: false })
   public owner: User;

--- a/src/entity/product/product-revision.ts
+++ b/src/entity/product/product-revision.ts
@@ -19,7 +19,7 @@
 import {
   BeforeUpdate,
   Column,
-  Entity, JoinColumn,
+  Entity, JoinColumn, ManyToMany,
   ManyToOne, PrimaryColumn,
 } from 'typeorm';
 import Product from './product';
@@ -28,6 +28,7 @@ import { Dinero } from 'dinero.js';
 import VatGroup from '../vat-group';
 import ProductCategory from './product-category';
 import BaseEntityWithoutId from '../base-entity-without-id';
+import ContainerRevision from '../container/container-revision';
 
 /**
  * @typedef {BaseEntityWithoutId} ProductRevision
@@ -105,6 +106,9 @@ export default class ProductRevision extends BaseEntityWithoutId {
     default: false,
   })
   public  priceList: boolean;
+
+  @ManyToMany(() => ContainerRevision, (container) => container.products)
+  public containers: ContainerRevision[];
 
   @BeforeUpdate()
   // eslint-disable-next-line class-methods-use-this

--- a/src/entity/product/product.ts
+++ b/src/entity/product/product.ts
@@ -17,7 +17,7 @@
  */
 
 import {
-  Column,
+  Column, DeleteDateColumn,
   Entity, JoinColumn,
   ManyToOne, OneToOne,
 } from 'typeorm';
@@ -38,6 +38,9 @@ export default class Product extends BaseEntity {
     nullable: true,
   })
   public currentRevision: number;
+
+  @DeleteDateColumn()
+  public readonly deletedAt: Date | null;
 
   @ManyToOne(() => User, { nullable: false })
   public owner: User;

--- a/src/entity/product/product.ts
+++ b/src/entity/product/product.ts
@@ -42,12 +42,12 @@ export default class Product extends BaseEntity {
   @DeleteDateColumn()
   public readonly deletedAt: Date | null;
 
-  @ManyToOne(() => User, { nullable: false })
+  @ManyToOne(() => User, { nullable: false, eager: true })
   public owner: User;
 
   // onDelete: 'CASCADE' is not possible here, because removing the
   // image from the database will not remove it form storage
-  @OneToOne(() => ProductImage, { nullable: true, onDelete: 'RESTRICT' })
+  @OneToOne(() => ProductImage, { nullable: true, eager: true, onDelete: 'RESTRICT' })
   @JoinColumn()
   public image?: ProductImage;
 }

--- a/src/migrations/1720608140757-soft-deletes.ts
+++ b/src/migrations/1720608140757-soft-deletes.ts
@@ -1,0 +1,45 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class SoftDeletes1720608140757 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn('product', new TableColumn({
+      name: 'deletedAt',
+      type: 'datetime(6)',
+      isNullable: true,
+    }));
+    await queryRunner.addColumn('container', new TableColumn({
+      name: 'deletedAt',
+      type: 'datetime(6)',
+      isNullable: true,
+    }));
+    await queryRunner.addColumn('point_of_sale', new TableColumn({
+      name: 'deletedAt',
+      type: 'datetime(6)',
+      isNullable: true,
+    }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('product', 'deletedAt');
+    await queryRunner.dropColumn('container', 'deletedAt');
+    await queryRunner.dropColumn('point_of_sale', 'deletedAt');
+  }
+
+}

--- a/src/migrations/1720608140757-soft-deletes.ts
+++ b/src/migrations/1720608140757-soft-deletes.ts
@@ -37,9 +37,9 @@ export class SoftDeletes1720608140757 implements MigrationInterface {
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.dropColumn('product', 'deletedAt');
-    await queryRunner.dropColumn('container', 'deletedAt');
-    await queryRunner.dropColumn('point_of_sale', 'deletedAt');
+    await queryRunner.query('ALTER TABLE product DROP COLUMN deletedAt');
+    await queryRunner.query('ALTER TABLE container DROP COLUMN deletedAt');
+    await queryRunner.query('ALTER TABLE point_of_sale DROP COLUMN deletedAt');
   }
 
 }

--- a/src/service/container-service.ts
+++ b/src/service/container-service.ts
@@ -201,6 +201,18 @@ export default class ContainerService {
   }
 
   /**
+   * (Soft) delete a container
+   * @param containerId
+   */
+  public static async deleteContainer(containerId: number): Promise<void> {
+    const container = await Container.findOne({ where: { id: containerId } });
+    if (container == null) {
+      throw new Error('Container not found');
+    }
+    await Container.softRemove(container);
+  }
+
+  /**
    * Propagates the container update to all point of sales.
    *
    * All POS that contain the previous version of this container

--- a/src/service/point-of-sale-service.ts
+++ b/src/service/point-of-sale-service.ts
@@ -197,6 +197,18 @@ export default class PointOfSaleService {
   }
 
   /**
+   * (Soft) delete a point of sale
+   * @param pointOfSaleId
+   */
+  public static async deletePointOfSale(pointOfSaleId: number): Promise<void> {
+    const pointOfSale = await PointOfSale.findOne({ where: { id: pointOfSaleId } });
+    if (pointOfSale == null) {
+      throw new Error('Point of sale not found');
+    }
+    await PointOfSale.softRemove(pointOfSale);
+  }
+
+  /**
    * Test to see if the user can view a specified Point of Sale
    * @param userId - The User to test
    * @param pointOfSale - The Point of Sale to view

--- a/src/service/product-service.ts
+++ b/src/service/product-service.ts
@@ -297,6 +297,18 @@ export default class ProductService {
   }
 
   /**
+   * (Soft) delete a product
+   * @param productId
+   */
+  public static async deleteProduct(productId: number): Promise<void> {
+    const product = await Product.findOne({ where: { id: productId } });
+    if (product == null) {
+      throw new Error('Product not found!');
+    }
+    await Product.softRemove(product);
+  }
+
+  /**
    * Returns a FindManyOptions based on the given parameters
    * @param params - The parameters to filter on
    * @param user - The user to filter on

--- a/src/service/product-service.ts
+++ b/src/service/product-service.ts
@@ -19,7 +19,7 @@
 import {
   FindManyOptions,
   FindOptionsRelations,
-  FindOptionsWhere, In,
+  FindOptionsWhere, In, IsNull,
   Raw,
 
 } from 'typeorm';
@@ -32,7 +32,6 @@ import Product from '../entity/product/product';
 import ProductRevision from '../entity/product/product-revision';
 import DineroTransformer from '../entity/transformer/dinero-transformer';
 import QueryFilter, { FilterMapping } from '../helpers/query-filter';
-import ContainerRevision from '../entity/container/container-revision';
 import User from '../entity/user/user';
 import CreateProductParams, { UpdateProductParams } from '../controller/request/product-request';
 import { PaginationParameters } from '../helpers/pagination';
@@ -42,6 +41,7 @@ import { asDate, asNumber } from '../helpers/validators';
 import ContainerService from './container-service';
 import { UpdateContainerParams } from '../controller/request/container-request';
 import AuthenticationService from './authentication-service';
+import { ContainerWithProductsResponse } from '../controller/response/container-response';
 
 /**
  * Define product filtering parameters used to filter query results.
@@ -278,21 +278,19 @@ export default class ProductService {
    * @param productId - The product to propagate
    */
   public static async propagateProductUpdate(productId: number) {
-    const containers = (await ContainerService.getContainers({ productId })).records;
+    const containers = (await ContainerService.getContainers({ productId, returnProducts: true })).records as ContainerWithProductsResponse[];
     // The async-for loop is intentional to prevent race-conditions.
     // To fix this the good way would be shortlived the structure of POS/Containers will be changed
     for (let i = 0; i < containers.length; i += 1) {
       const c = containers[i];
       // eslint-disable-next-line no-await-in-loop
-      await ContainerRevision.findOne({ where: { container: { id: c.id }, revision: c.revision }, relations: ['products', 'products.product'] }).then(async (revision) => {
-        const update: UpdateContainerParams = {
-          products: revision.products.map((p) => p.product.id),
-          public: c.public,
-          name: revision.name,
-          id: c.id,
-        };
-        await ContainerService.updateContainer(update);
-      });
+      const update: UpdateContainerParams = {
+        products: c.products.map((p) => p.id),
+        public: c.public,
+        name: c.name,
+        id: c.id,
+      };
+      await ContainerService.updateContainer(update);
     }
   }
 
@@ -338,12 +336,12 @@ export default class ProductService {
       category: true,
     };
 
-    const userFilter: any = {};
+    let owner: FindOptionsWhere<User> = {};
     if (user) {
       const organIds = (await AuthenticationService.getMemberAuthenticators(user)).map((u) => u.id);
-      userFilter.product = { owner: { id: In(organIds) } };
+      owner = { id: In(organIds) };
     } else if (params.ownerId) {
-      userFilter.product = { owner: { id: params.ownerId } };
+      owner = { id: params.ownerId };
     }
 
     let revisionFilter: any = {};
@@ -353,12 +351,16 @@ export default class ProductService {
     let where: FindOptionsWhere<ProductRevision> = {
       ...QueryFilter.createFilterWhereClause(filterMapping, params),
       ...revisionFilter,
-      ...userFilter,
+      product: {
+        deletedAt: IsNull(),
+        owner,
+      },
     };
 
     const options: FindManyOptions<ProductRevision> = {
       where,
       order: { name: 'ASC' },
+      withDeleted: true,
     };
 
     return { ...options, relations };

--- a/test/helpers/balance.ts
+++ b/test/helpers/balance.ts
@@ -31,12 +31,11 @@ export function calculateBalance(user: User, transactions: Transaction[], subTra
     transactionsOutgoing = transactionsOutgoing
       .filter((t) => t.createdAt.getTime() <= date.getTime());
   }
-  let transactionsIncoming = subTransactions.filter((s) => s.to.id === user.id)
-    .sort((a, b) => b.transaction.createdAt.getTime() - a.transaction.createdAt.getTime())
-    .map((s) => s.transaction);
+  let subTransactionsIncoming = subTransactions.filter((s) => s.to.id === user.id)
+    .sort((a, b) => b.transaction.createdAt.getTime() - a.transaction.createdAt.getTime());
   if (date) {
-    transactionsIncoming = transactionsIncoming
-      .filter((t) => t.createdAt.getTime() <= date.getTime());
+    subTransactionsIncoming = subTransactionsIncoming
+      .filter((t) => t.transaction.createdAt.getTime() <= date.getTime());
   }
   let transfersOutgoing = transfers.filter((t) => t.from && t.from.id === user.id)
     .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
@@ -59,9 +58,8 @@ export function calculateBalance(user: User, transactions: Transaction[], subTra
       prev - (curr.amount * curr.product.priceInclVat.getAmount())
     ), 0);
   const valueTransactionsIncoming: number = Array.prototype
-    .concat(...Array.prototype.concat(...transactionsIncoming
-      .map((t) => t.subTransactions
-        .map((s) => s.subTransactionRows))))
+    .concat(...Array.prototype.concat(...subTransactionsIncoming
+      .map((s) => s.subTransactionRows)))
     .reduce((prev: number, curr: SubTransactionRow) => (
       prev + (curr.amount * curr.product.priceInclVat.getAmount())
     ), 0);
@@ -72,7 +70,7 @@ export function calculateBalance(user: User, transactions: Transaction[], subTra
 
   // Calculate the user's personal last transaction/transfer
   let lastTransaction: Transaction;
-  const allTransactions = transactionsIncoming.concat(transactionsOutgoing)
+  const allTransactions = transactionsOutgoing.concat(subTransactionsIncoming.map((s) => s.transaction))
     .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
   if (allTransactions.length > 0) {
     // eslint-disable-next-line prefer-destructuring

--- a/test/helpers/user-factory.ts
+++ b/test/helpers/user-factory.ts
@@ -18,6 +18,7 @@
 
 import User, { TermsOfServiceStatus, UserType } from '../../src/entity/user/user';
 import generateBalance from './test-helpers';
+import { DeleteResult } from 'typeorm';
 
 export class Builder {
   user: User;
@@ -48,6 +49,10 @@ export class Builder {
 
   public get(): Promise<User> {
     return User.save(this.user as User);
+  }
+
+  public delete(): Promise<DeleteResult> {
+    return User.delete(this.user.id);
   }
 
   public async clone(amount: number): Promise<User[]> {

--- a/test/seed.ts
+++ b/test/seed.ts
@@ -580,7 +580,7 @@ export async function seedProducts(
   let productImages: ProductImage[] = [];
   let productRevisions: ProductRevision[] = [];
 
-  const sellers = users.filter((u) => [UserType.LOCAL_ADMIN, UserType.MEMBER].includes(u.type));
+  const sellers = users.filter((u) => [UserType.LOCAL_ADMIN, UserType.MEMBER, UserType.ORGAN].includes(u.type));
 
   const promises: Promise<any>[] = [];
   for (let i = 0; i < sellers.length; i += 1) {

--- a/test/seed.ts
+++ b/test/seed.ts
@@ -509,6 +509,7 @@ function defineProducts(
     const product = Object.assign(new Product(), {
       id: start + nr,
       owner: user,
+      deletedAt: (nr % 5 === 4) ? new Date() : undefined,
     }) as Product;
 
     products.push(product);
@@ -585,7 +586,7 @@ export async function seedProducts(
   for (let i = 0; i < sellers.length; i += 1) {
     const prod = defineProducts(
       products.length,
-      6,
+      8,
       sellers[i],
     );
 
@@ -646,6 +647,7 @@ function defineContainers(
     const container = Object.assign(new Container(), {
       id: start + nr,
       owner: user,
+      deletedAt: (nr % 3 === 2) ? new Date() : undefined,
       public: nr % 2 > 0,
     }) as Container;
     containers.push(container);
@@ -706,7 +708,7 @@ export async function seedContainers(
   for (let i = 0; i < sellers.length; i += 1) {
     const con = defineContainers(
       containers.length,
-      3,
+      4,
       sellers[i],
     );
     let rev: ContainerRevision[] = [];
@@ -748,6 +750,7 @@ function definePointsOfSale(
     const pointOfSale = Object.assign(new PointOfSale(), {
       id: start + nr,
       owner: user,
+      deletedAt: (nr % 3 === 2) ? new Date() : undefined,
     });
     pointsOfSale.push(pointOfSale);
   }
@@ -816,7 +819,7 @@ export async function seedPointsOfSale(
   for (let i = 0; i < sellers.length; i += 1) {
     const pos = definePointsOfSale(
       pointsOfSale.length,
-      3,
+      4,
       sellers[i],
     );
     let rev: PointOfSaleRevision[] = [];

--- a/test/unit/controller/container-controller.ts
+++ b/test/unit/controller/container-controller.ts
@@ -40,7 +40,7 @@ import {
   ContainerWithProductsResponse,
   PaginatedContainerResponse,
 } from '../../../src/controller/response/container-response';
-import { PaginatedProductResponse } from '../../../src/controller/response/product-response';
+import { PaginatedProductResponse, ProductResponse } from '../../../src/controller/response/product-response';
 import { defaultPagination, PaginationResult } from '../../../src/helpers/pagination';
 import { CreateContainerRequest, UpdateContainerRequest } from '../../../src/controller/request/container-request';
 import { INVALID_ORGAN_ID, INVALID_PRODUCT_ID } from '../../../src/controller/request/validators/validation-errors';
@@ -399,20 +399,21 @@ describe('ContainerController', async (): Promise<void> => {
           true,
         ).valid).to.be.true;
       });
+      expect(res.body.length);
     });
     it('should return an HTTP 200 and all the products in the container if admin', async () => {
       const res = await request(ctx.app)
         .get('/containers/1/products')
         .set('Authorization', `Bearer ${ctx.adminToken}`);
 
-      expect((res.body as PaginatedProductResponse)).to.not.be.empty;
+      expect((res.body as ProductResponse[])).to.not.be.empty;
       expect(res.status).to.equal(200);
 
-      const body = res.body as PaginatedProductResponse;
+      const body = res.body as ProductResponse[];
 
       // Never include deleted containers
       const deletedProductIds = ctx.deletedProducts.map((p) => p.id);
-      body.records.forEach((product) => expect(deletedProductIds).to.not.include(product.id));
+      body.forEach((product) => expect(deletedProductIds).to.not.include(product.id));
     });
     it('should return an HTTP 403 if container not public or own and if not admin', async () => {
       const { id } = await Container.findOne({ relations: ['owner'], where: { owner: { id: ctx.adminUser.id }, public: true } });

--- a/test/unit/controller/container-controller.ts
+++ b/test/unit/controller/container-controller.ts
@@ -365,6 +365,18 @@ describe('ContainerController', async (): Promise<void> => {
       // success code
       expect(res.status).to.equal(403);
     });
+    it('should return an HTTP 404 if the container is soft deleted', async () => {
+      const id = ctx.deletedContainers[0].id;
+      const res = await request(ctx.app)
+        .get(`/containers/${id}`)
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+
+      // check if banner is not returned
+      expect(res.body).to.equal('Container not found.');
+
+      // success code
+      expect(res.status).to.equal(404);
+    });
     it('should return an HTTP 404 if the containerId does not exist', async () => {
       const id = (await Container.count()) + 10;
       const res = await request(ctx.app)

--- a/test/unit/controller/container-controller.ts
+++ b/test/unit/controller/container-controller.ts
@@ -40,7 +40,7 @@ import {
   ContainerWithProductsResponse,
   PaginatedContainerResponse,
 } from '../../../src/controller/response/container-response';
-import { PaginatedProductResponse, ProductResponse } from '../../../src/controller/response/product-response';
+import { ProductResponse } from '../../../src/controller/response/product-response';
 import { defaultPagination, PaginationResult } from '../../../src/helpers/pagination';
 import { CreateContainerRequest, UpdateContainerRequest } from '../../../src/controller/request/container-request';
 import { INVALID_ORGAN_ID, INVALID_PRODUCT_ID } from '../../../src/controller/request/validators/validation-errors';
@@ -399,7 +399,6 @@ describe('ContainerController', async (): Promise<void> => {
           true,
         ).valid).to.be.true;
       });
-      expect(res.body.length);
     });
     it('should return an HTTP 200 and all the products in the container if admin', async () => {
       const res = await request(ctx.app)

--- a/test/unit/controller/point-of-sale-controller.ts
+++ b/test/unit/controller/point-of-sale-controller.ts
@@ -324,6 +324,14 @@ describe('PointOfSaleController', async () => {
         .set('Authorization', `Bearer ${ctx.organ}`);
       expect(res.status).to.equal(403);
     });
+    it('should return an HTTP 404 if the point of sale is soft deleted', async () => {
+      const res = await request(ctx.app)
+        .get(`/pointsofsale/${ctx.deletedPointsOfSale[0].id}`)
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+
+      expect(res.status).to.equal(404);
+      expect(res.body).to.equal('Point of Sale not found.');
+    });
     it('should return an HTTP 404 if the point of sale with given id does not exist', async () => {
       const res = await request(ctx.app)
         .get(`/pointsofsale/${(await PointOfSale.count()) + 1}`)

--- a/test/unit/controller/product-controller.ts
+++ b/test/unit/controller/product-controller.ts
@@ -569,6 +569,18 @@ describe('ProductController', async (): Promise<void> => {
         true,
       ).valid).to.be.true;
     });
+    it('should return an HTTP 404 if the product is soft deleted', async () => {
+      const id = ctx.deletedProducts[0].id;
+      const res = await request(ctx.app)
+        .get(`/products/${id}`)
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+
+      // check if banner is not returned
+      expect(res.body).to.equal('Product not found.');
+
+      // success code
+      expect(res.status).to.equal(404);
+    });
     it('should return an HTTP 404 if the product with the given id does not exist', async () => {
       const id = await Product.count({ withDeleted: true }) + 1;
       const res = await request(ctx.app)

--- a/test/unit/service/container-service.ts
+++ b/test/unit/service/container-service.ts
@@ -41,7 +41,7 @@ import {
   UpdateContainerParams,
 } from '../../../src/controller/request/container-request';
 import PointOfSaleService from '../../../src/service/point-of-sale-service';
-import { CreatePointOfSaleParams, UpdatePointOfSaleParams } from '../../../src/controller/request/point-of-sale-request';
+import { CreatePointOfSaleParams } from '../../../src/controller/request/point-of-sale-request';
 import AuthenticationService from '../../../src/service/authentication-service';
 import MemberAuthenticator from '../../../src/entity/authenticator/member-authenticator';
 import { truncateAllTables } from '../../setup';
@@ -428,6 +428,7 @@ describe('ContainerService', async (): Promise<void> => {
         .some((c) => c.revision === revision.revision && c.containerId === revision.containerId && c.container.deletedAt == null))
         .filter((p) => p.pointOfSale.deletedAt == null)
         .filter((p) => p.revision === p.pointOfSale.currentRevision);
+      expect(stub.callCount).to.be.greaterThan(0);
       expect(stub.callCount).to.equal(pointOfSaleRevisions.length);
       for (let i = 0; i < stub.callCount; i += 1) {
         const call = stub.getCall(i);

--- a/test/unit/service/point-of-sale-service.ts
+++ b/test/unit/service/point-of-sale-service.ts
@@ -86,6 +86,7 @@ describe('PointOfSaleService', async (): Promise<void> => {
     specification: SwaggerSpecification,
     users: User[],
     pointsOfSale: PointOfSale[],
+    deletedPointsOfSale: PointOfSale[],
     validPOSParams: CreatePointOfSaleParams,
   };
 
@@ -114,7 +115,7 @@ describe('PointOfSaleService', async (): Promise<void> => {
     app.use(json());
 
     const validPOSParams: CreatePointOfSaleParams = {
-      containers: [containers[0].id, containers[1].id, containers[2].id],
+      containers: containers.filter((c) => c.deletedAt == null).map((c) => c.id),
       name: 'Valid POS',
       useAuthentication: true,
       ownerId: 1,
@@ -125,7 +126,8 @@ describe('PointOfSaleService', async (): Promise<void> => {
       app,
       specification,
       users,
-      pointsOfSale,
+      pointsOfSale: pointsOfSale.filter((p) => p.deletedAt == null),
+      deletedPointsOfSale: pointsOfSale.filter((p) => p.deletedAt != null),
       validPOSParams,
     };
   });

--- a/test/unit/service/product-service.ts
+++ b/test/unit/service/product-service.ts
@@ -269,22 +269,6 @@ describe('ProductService', async (): Promise<void> => {
 
       returnsAllRevisions(records, products);
     });
-    it('should return the products belonging to a container', async () => {
-      const params: ProductFilterParameters = {
-        containerId: 3,
-      };
-      const { records } = await ProductService.getProducts(params);
-
-      const products = ctx.containerRevisions
-        .filter((rev) => {
-          const container = ctx.containers.filter((cont) => cont.id === 3)[0];
-          return rev.container.id === container.id && rev.revision === container.currentRevision;
-        })
-        .map((rev) => rev.products.map((prod) => prod.product))[0]
-        .filter((p) => p.deletedAt == null);
-
-      returnsAll(records, products);
-    });
     it('should adhere to pagination', async () => {
       const take = 5;
       const skip = 3;
@@ -297,49 +281,6 @@ describe('ProductService', async (): Promise<void> => {
       expect(_pagination.skip).to.equal(skip);
       expect(_pagination.count).to.equal(ctx.products.length);
       expect(records.length).to.be.at.most(take);
-    });
-    it('should return the products belonging to a container revision that is not current', async () => {
-      const revision = ctx.containerRevisions.find((r) => {
-        const container = ctx.containers.find((c) => c.id === r.containerId);
-        expect(container).to.not.be.undefined;
-        return r.revision < container.currentRevision && r.products.length > 0;
-      });
-      const params: ProductFilterParameters = {
-        containerId: revision.containerId,
-        containerRevision: revision.revision,
-      };
-
-      const { records } = await ProductService.getProducts(params);
-      const products = revision.products
-        .filter((p) => p.product.deletedAt == null)
-        .map((p) => p.product.id);
-
-      expect(records.map((prod) => prod.id)).to.deep.equalInAnyOrder(products);
-    });
-    it('should return the products belonging to a point of sale', async () => {
-      const pointOfSaleId = ctx.pointsOfSale[1].id;
-      const { records } = await ProductService
-        .getProducts({ pointOfSaleId });
-
-      const { containers } = ctx.pointOfSaleRevisions.filter((pos) => (
-        (pos.pointOfSale.id === pointOfSaleId && pos.revision === pos.pointOfSale.currentRevision)))[0];
-
-      const productRevisions = (containers.map((p) => p.products.map((pr) => pr)))
-        .reduce((prev, cur) => prev.concat(cur))
-        .filter((p) => p.product.deletedAt == null);
-
-      const products = productRevisions.map((p) => ((
-        { product: p.product, revision: p.revision } as ProductWithRevision)));
-
-      const filteredProducts = products.reduce((acc: ProductWithRevision[], current) => {
-        if (!acc.some((item) => (
-          (item.product.id === current.product.id && item.revision === current.revision)))) {
-          acc.push(current);
-        }
-        return acc;
-      }, []);
-
-      returnsAllRevisions(records, filteredProducts);
     });
     it('should return all points of sale involving a single user and its memberAuthenticator users', async () => {
       const usersOwningAProd = [...new Set(ctx.products.map((prod) => prod.owner))];

--- a/test/unit/service/transaction-service.ts
+++ b/test/unit/service/transaction-service.ts
@@ -22,7 +22,7 @@ import chai, { expect } from 'chai';
 import { Connection, createQueryBuilder } from 'typeorm';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import log4js, { Logger } from 'log4js';
-import { DineroObject } from 'dinero.js';
+import dinero from 'dinero.js';
 import deepEqualInAnyOrder from 'deep-equal-in-any-order';
 import Transaction from '../../../src/entity/transactions/transaction';
 import Database from '../../../src/database/database';
@@ -53,6 +53,7 @@ import generateBalance, { finishTestDB } from '../../helpers/test-helpers';
 import { inUserContext, UserFactory } from '../../helpers/user-factory';
 import { createInvoiceWithTransfers, createTransactions } from './invoice-service';
 import { truncateAllTables } from '../../setup';
+import ProductRevision from '../../../src/entity/product/product-revision';
 
 chai.use(deepEqualInAnyOrder);
 
@@ -64,7 +65,8 @@ describe('TransactionService', (): void => {
     users: User[],
     validTransReq: TransactionRequest,
     pointOfSale: PointOfSaleRevision,
-    container: ContainerRevision,
+    containers: ContainerRevision[],
+    products: ProductRevision[],
     spec: SwaggerSpecification,
     logger: Logger,
   };
@@ -86,110 +88,53 @@ describe('TransactionService', (): void => {
     const { transactions } = await seedTransactions(users, pointOfSaleRevisions);
 
     await generateBalance(1000, 7);
-    const validTransReq = {
-      from: 7,
-      createdBy: 7,
-      subTransactions: [
+
+    const pos = pointOfSaleRevisions.filter((p) => p.pointOfSale.deletedAt == null)[0];
+    const conts = pos.containers.filter((c) => c.container.deletedAt == null).slice(0, 2);
+    const products = conts.map((c) => c.products.filter((p) => p.product.deletedAt == null).slice(0, 2));
+    const validTransReq: TransactionRequest = {
+      from: users[6].id,
+      createdBy: users[6].id,
+      subTransactions: conts.map((c, i) => (
         {
-          to: 8,
+          to: c.container.owner.id,
           container: {
-            id: 1,
-            revision: 2,
+            id: c.containerId,
+            revision: c.revision,
           },
-          subTransactionRows: [
+          subTransactionRows: products[i].map((p, i2) => (
             {
               product: {
-                id: 1,
-                revision: 2,
+                id: p.productId,
+                revision: p.revision,
               },
-              amount: 1,
-              totalPriceInclVat: {
-                amount: 72,
-                currency: 'EUR',
-                precision: 2,
-              },
-            },
-            {
-              product: {
-                id: 2,
-                revision: 2,
-              },
-              amount: 2,
-              totalPriceInclVat: {
-                amount: 146,
-                currency: 'EUR',
-                precision: 2,
-              },
-            },
-          ],
-          totalPriceInclVat: {
-            amount: 218,
-            currency: 'EUR',
-            precision: 2,
-          },
-        },
-        {
-          to: 9,
-          container: {
-            id: 2,
-            revision: 2,
-          },
-          subTransactionRows: [
-            {
-              product: {
-                id: 2,
-                revision: 2,
-              },
-              amount: 4,
-              totalPriceInclVat: {
-                amount: 292,
-                currency: 'EUR',
-                precision: 2,
-              },
-            },
-          ],
-          totalPriceInclVat: {
-            amount: 292,
-            currency: 'EUR',
-            precision: 2,
-          },
-        },
-      ],
+              amount: i2 + 1,
+              totalPriceInclVat: p.priceInclVat.multiply(i2 + 1).toObject(),
+            }
+          )),
+          totalPriceInclVat: products[i].reduce((total, p, i2) => total
+            .add(p.priceInclVat.multiply(i2 + 1)), dinero({ amount: 0 })).toObject(),
+        }
+      )),
       pointOfSale: {
-        id: 1,
-        revision: 2,
+        id: pos.pointOfSaleId,
+        revision: pos.revision,
       },
-      totalPriceInclVat: {
-        amount: 510,
-        currency: 'EUR',
-        precision: 2,
-      },
-    } as TransactionRequest;
-
-    const pointOfSale = await PointOfSaleRevision.findOne({
-      where: {
-        revision: validTransReq.pointOfSale.revision,
-        pointOfSale: { id: validTransReq.pointOfSale.id },
-      },
-      relations: ['pointOfSale', 'containers'],
-    });
-
-    const container = await ContainerRevision.findOne({
-      where: {
-        revision: validTransReq.subTransactions[0].container.revision,
-        container: { id: validTransReq.subTransactions[0].container.id },
-      },
-      relations: ['container', 'products'],
-    });
+      totalPriceInclVat: products.reduce((total1, prods) => total1
+        .add(prods.reduce((total2, p, i) => total2
+          .add(p.priceInclVat.multiply(i + 1)), dinero({ amount: 0 })),
+        ), dinero({ amount: 0 })).toObject(),
+    };
 
     ctx = {
       connection,
       app,
       validTransReq,
-      pointOfSale,
+      pointOfSale: pos,
       transactions,
       users,
-      container,
+      containers: containerRevisions,
+      products: productRevisions,
       spec: await Swagger.importSpecification(),
       logger,
     };
@@ -201,17 +146,11 @@ describe('TransactionService', (): void => {
 
   describe('Get total cost of a transaction', () => {
     it('should return the total cost of a transaction', async () => {
-      const total = {
-        amount: 510,
-        currency: 'EUR',
-        precision: 2,
-      } as DineroObject;
-
       const rows: SubTransactionRowRequest[] = [];
       ctx.validTransReq.subTransactions.forEach(
         (sub) => sub.subTransactionRows.forEach((row) => rows.push(row)),
       );
-      expect((await TransactionService.getTotalCost(rows)).toObject()).to.eql(total);
+      expect((await TransactionService.getTotalCost(rows)).toObject()).to.eql(ctx.validTransReq.totalPriceInclVat);
     });
   });
 
@@ -361,9 +300,11 @@ describe('TransactionService', (): void => {
         .to.be.false;
 
       // container not in point of sale
+      const badContainer = ctx.containers.find((c1) => !ctx.pointOfSale.containers.some((c2) => c2.containerId === c1.containerId));
+      expect(badContainer).to.not.be.undefined;
       badContainerReq.container = {
-        revision: 1,
-        id: 1,
+        revision: badContainer.revision,
+        id: badContainer.containerId,
       };
       expect(await TransactionService.verifySubTransaction(badContainerReq, ctx.pointOfSale), 'container not in point of sale accepted')
         .to.be.false;
@@ -405,7 +346,7 @@ describe('TransactionService', (): void => {
   describe('Verifiy sub transaction row', () => {
     it('should return true if the sub transaction row request is valid', async () => {
       expect(await TransactionService.verifySubTransactionRow(
-        ctx.validTransReq.subTransactions[0].subTransactionRows[0], ctx.container,
+        ctx.validTransReq.subTransactions[0].subTransactionRows[0], ctx.containers[0],
       )).to.be.true;
     });
     it('should return false if the product is invalid', async () => {
@@ -414,21 +355,24 @@ describe('TransactionService', (): void => {
         ...ctx.validTransReq.subTransactions[0].subTransactionRows[0],
         product: undefined,
       } as SubTransactionRowRequest;
-      expect(await TransactionService.verifySubTransactionRow(badProductReq, ctx.container), 'undefined product accepted').to.be.false;
+      expect(await TransactionService.verifySubTransactionRow(badProductReq, ctx.containers[0]), 'undefined product accepted').to.be.false;
 
       // non existent product
       badProductReq.product = {
         revision: 1,
         id: 12345,
       };
-      expect(await TransactionService.verifySubTransactionRow(badProductReq, ctx.container), 'non existent product accepted').to.be.false;
+      expect(await TransactionService.verifySubTransactionRow(badProductReq, ctx.containers[0]), 'non existent product accepted').to.be.false;
 
       // product not in container
+      const badProduct = ctx.products.find((p1) => !ctx.pointOfSale.containers
+        .some((c) => c.products
+          .some((p2) => p1.productId === p2.productId)));
       badProductReq.product = {
-        revision: 1,
-        id: 1,
+        revision: badProduct.revision,
+        id: badProduct.productId,
       };
-      expect(await TransactionService.verifySubTransactionRow(badProductReq, ctx.container), 'product not in container accepted').to.be.false;
+      expect(await TransactionService.verifySubTransactionRow(badProductReq, ctx.containers[0]), 'product not in container accepted').to.be.false;
     });
     it('should return false if the specified amount of the product is invalid', async () => {
       // undefined amount
@@ -436,15 +380,15 @@ describe('TransactionService', (): void => {
         ...ctx.validTransReq.subTransactions[0].subTransactionRows[0],
         amount: undefined,
       } as SubTransactionRowRequest;
-      expect(await TransactionService.verifySubTransactionRow(badAmountReq, ctx.container), 'undefined amount accepted').to.be.false;
+      expect(await TransactionService.verifySubTransactionRow(badAmountReq, ctx.containers[0]), 'undefined amount accepted').to.be.false;
 
       // amount not greater than 0
       badAmountReq.amount = 0;
-      expect(await TransactionService.verifySubTransactionRow(badAmountReq, ctx.container), 'amount not greater than 0 accepted').to.be.false;
+      expect(await TransactionService.verifySubTransactionRow(badAmountReq, ctx.containers[0]), 'amount not greater than 0 accepted').to.be.false;
 
       // amount not an integer
       badAmountReq.amount = 1.1;
-      expect(await TransactionService.verifySubTransactionRow(badAmountReq, ctx.container), 'non integer amount accepted').to.be.false;
+      expect(await TransactionService.verifySubTransactionRow(badAmountReq, ctx.containers[0]), 'non integer amount accepted').to.be.false;
     });
     it('should return false if the price is set incorrectly', async () => {
       // undefined price
@@ -452,7 +396,7 @@ describe('TransactionService', (): void => {
         ...ctx.validTransReq.subTransactions[0].subTransactionRows[0],
         totalPriceInclVat: undefined,
       } as SubTransactionRowRequest;
-      expect(await TransactionService.verifySubTransactionRow(badPriceReq, ctx.container), 'undefined accepted').to.be.false;
+      expect(await TransactionService.verifySubTransactionRow(badPriceReq, ctx.containers[0]), 'undefined accepted').to.be.false;
 
       // incorrect price
       badPriceReq.totalPriceInclVat = {
@@ -460,7 +404,7 @@ describe('TransactionService', (): void => {
         currency: 'EUR',
         precision: 2,
       };
-      expect(await TransactionService.verifySubTransactionRow(badPriceReq, ctx.container), 'incorrect accepted').to.be.false;
+      expect(await TransactionService.verifySubTransactionRow(badPriceReq, ctx.containers[0]), 'incorrect accepted').to.be.false;
     });
   });
 
@@ -800,86 +744,13 @@ describe('TransactionService', (): void => {
       // create a transaction
       const savedTransaction = await TransactionService.createTransaction(ctx.validTransReq);
 
-      // update previously created transaction
-      const updateReq = {
-        from: 12,
-        createdBy: 11,
-        subTransactions: [
-          {
-            to: 10,
-            container: {
-              id: 1,
-              revision: 2,
-            },
-            subTransactionRows: [
-              {
-                product: {
-                  id: 1,
-                  revision: 2,
-                },
-                amount: 2,
-                totalPriceInclVat: {
-                  amount: 144,
-                  currency: 'EUR',
-                  precision: 2,
-                },
-              },
-              {
-                product: {
-                  id: 2,
-                  revision: 2,
-                },
-                amount: 1,
-                totalPriceInclVat: {
-                  amount: 73,
-                  currency: 'EUR',
-                  precision: 2,
-                },
-              },
-            ],
-            totalPriceInclVat: {
-              amount: 217,
-              currency: 'EUR',
-              precision: 2,
-            },
-          },
-          {
-            to: 9,
-            container: {
-              id: 2,
-              revision: 2,
-            },
-            subTransactionRows: [
-              {
-                product: {
-                  id: 2,
-                  revision: 2,
-                },
-                amount: 4,
-                totalPriceInclVat: {
-                  amount: 292,
-                  currency: 'EUR',
-                  precision: 2,
-                },
-              },
-            ],
-            totalPriceInclVat: {
-              amount: 292,
-              currency: 'EUR',
-              precision: 2,
-            },
-          },
-        ],
-        pointOfSale: {
-          id: 1,
-          revision: 2,
-        },
-        totalPriceInclVat: {
-          amount: 509,
-          currency: 'EUR',
-          precision: 2,
-        },
-      } as TransactionRequest;
+      const updateReq = { ...ctx.validTransReq };
+      const price = Math.round(updateReq.subTransactions[0].subTransactionRows[0].totalPriceInclVat.amount / updateReq.subTransactions[0].subTransactionRows[0].amount);
+      updateReq.subTransactions[0].subTransactionRows[0].amount += 1;
+      updateReq.subTransactions[0].subTransactionRows[0].totalPriceInclVat.amount += price;
+      updateReq.subTransactions[0].totalPriceInclVat.amount += price;
+      updateReq.totalPriceInclVat.amount += price;
+
       const updatedTransaction = await TransactionService.updateTransaction(
         savedTransaction.id, updateReq,
       );


### PR DESCRIPTION
Adds endpoints for deleting products, containers and points of sale.

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
The three aforementioned entities could not be deleted from the database, because that would invalidate the data, as transactions have a reference to their point of sale, container and product. To solve this, products, containers and points of sale are soft deleted under the hood. When they are soft deleted, they will never be returned in any endpoint except in the context of transactions. Soft deleted products, containers and points of sale can also not be used as correlated entities or within transactions.

When soft deleting, the entity corresponding entity is only marked as soft deleted. However, due to the aforementioned restrictions, it will never be shown again (even though a soft deleted product might still be included in a container). However, when a container is updated, it cannot be included any more.

Note that the seeder now also includes these soft deleted products, containers and points of sale. 

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
https://github.com/GEWIS/sudosos-backend/issues/20

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_
