### PR TITLE
ci: warn instead of fail if base coverage is not found.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,7 @@ jobs:
           workflow: build.yml
           workflow_conclusion: success
           name: coverage
+          if_no_artifact_found: warn
           branch: ${{ github.base_ref }}
           path: reports/coverage-base
       - name: "Comment code coverage on PR"


### PR DESCRIPTION
# Description
![image](https://github.com/GEWIS/sudosos-backend/assets/8006954/4d4451b1-e818-46c6-8a9a-5f48a30e05fe)
## Types of changes
- CI/CD _(Changes to the CI/CD configuration)_
