### PR TITLE
feat: add dry-run cli option for GEWISDB sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "bcrypt": "^5.1.0",
         "body-parser": "^1.20.2",
+        "commander": "^12.1.0",
         "date-fns": "^2.29.3",
         "dinero.js": "^1.9.0",
         "dotenv": "^16.0.3",
@@ -2753,6 +2754,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/commondir": {

--- a/package.json
+++ b/package.json
@@ -21,13 +21,15 @@
     "coverage-ci": "nyc npm run test-ci",
     "lint": "eslint",
     "lint-fix": "eslint package.json src test --ext .js --ext .ts --fix",
-    "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js"
+    "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js",
+    "cli": "ts-node ./src/gewis/service/cli-service.ts"
   },
   "author": "",
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "bcrypt": "^5.1.0",
     "body-parser": "^1.20.2",
+    "commander": "^12.1.0",
     "date-fns": "^2.29.3",
     "dinero.js": "^1.9.0",
     "dotenv": "^16.0.3",

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -91,7 +91,7 @@ async function createCronTasks(): Promise<void> {
     application.tasks.push(syncADGroups);
   }
 
-  if (process.env.GEWISDB_API_KEY && process.env.GEWISDB_API_URL) {
+  if (process.env.GEWISDB_API_KEY && process.env.GEWISDB_API_URL && process.env.ENABLE_GEWISDB_SYNC) {
     await GewisDBService.syncAll();
     const syncGewis = cron.schedule('41 4 * * *', async () => {
       logger.debug('Syncing users with GEWISDB.');

--- a/src/gewis/service/cli-service.ts
+++ b/src/gewis/service/cli-service.ts
@@ -1,0 +1,61 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import 'reflect-metadata';
+import { Command } from 'commander';
+import log4js from 'log4js';
+import { AppDataSource } from '../../database/database';
+import GewisDBService from './gewisdb-service';
+
+// Load environment variables
+require('dotenv').config();
+
+// Logger setup
+const logger = log4js.getLogger('CLIService');
+logger.level = 'info';
+
+
+// Define the CLI program
+const program = new Command();
+
+async function dryRunSyncAll() {
+  try {
+    // Initialize the datasource
+    await AppDataSource.initialize();
+    logger.info('Datasource initialized successfully.');
+
+    // Call syncAll and log the results
+    const updatedUsers = await GewisDBService.syncAll(false);
+    logger.info('Updated users:', updatedUsers);
+  } catch (error) {
+    logger.error('Error during dry-run sync:', error);
+  } finally {
+    // Close the datasource connection
+    await AppDataSource.destroy();
+    logger.info('Datasource connection closed.');
+  }
+}
+program
+  .command('db-sync')
+  .description('Dry ryun sync users with GEWIS DB')
+  .action(async () => {
+    await dryRunSyncAll();
+  });
+
+
+// Parse the CLI arguments
+program.parse(process.argv);

--- a/src/gewis/service/gewisdb-service.ts
+++ b/src/gewis/service/gewisdb-service.ts
@@ -84,7 +84,7 @@ export default class GewisDBService {
 
     logger.info(`Syncing ${gewisUsers.length} users with GEWIS DB`);
     const updates: UserResponse[] = [];
-    const promises = gewisUsers.map(user => GewisDBService.updateUser(user).then((u) => {
+    const promises = gewisUsers.map(user => GewisDBService.updateUser(user, commit).then((u: UserResponse) => {
       if (u) updates.push(u);
     }));
 

--- a/src/gewis/service/gewisdb-service.ts
+++ b/src/gewis/service/gewisdb-service.ts
@@ -48,20 +48,22 @@ export default class GewisDBService {
   /**
    * Synchronizes ALL users with GEWIS DB user data.
    * This method only returns users that were actually updated during the synchronization process.
+   * @param {boolean} commit - Whether to commit the changes to the database.
    * @returns {Promise<UserResponse[]>} A promise that resolves with an array of UserResponses for users that were updated. Returns null if the API is unhealthy.
    */
-  public static async syncAll(): Promise<UserResponse[]> {
+  public static async syncAll(commit: boolean = true): Promise<UserResponse[]> {
     const gewisUsers = await GewisUser.find({ where: { user: { deleted: false } }, relations: ['user'] });
-    return this.sync(gewisUsers);
+    return this.sync(gewisUsers, commit);
   }
 
   /**
    * Synchronizes users with GEWIS DB user data.
    * This method only returns users that were actually updated during the synchronization process.
    * @param {GewisUser[]} gewisUsers - Array of users to sync.
+   * @param {boolean} commit - Whether to commit the changes to the database.
    * @returns {Promise<UserResponse[]>} A promise that resolves with an array of UserResponses for users that were updated. Returns null if the API is unhealthy.
    */
-  public static async sync(gewisUsers: GewisUser[]): Promise<UserResponse[]> {
+  public static async sync(gewisUsers: GewisUser[], commit: boolean = true): Promise<UserResponse[]> {
     let ping: Health;
     try {
       ping = await GewisDBService.pinger.healthGet().then(health => health.data);
@@ -80,6 +82,7 @@ export default class GewisDBService {
       return null;
     }
 
+    logger.info(`Syncing ${gewisUsers.length} users with GEWIS DB`);
     const updates: UserResponse[] = [];
     const promises = gewisUsers.map(user => GewisDBService.updateUser(user).then((u) => {
       if (u) updates.push(u);
@@ -91,9 +94,10 @@ export default class GewisDBService {
 
   /**
    * Updates a user in the local database based on the GEWIS DB data.
+   * @param commit - Whether to commit the changes to the database.
    * @param {GewisUser} gewisUser - The user to be updated.
    */
-  private static async updateUser(gewisUser: GewisUser) {
+  private static async updateUser(gewisUser: GewisUser, commit: boolean = true) {
     logger.trace(`Syncing GEWIS User ${gewisUser.gewisId}`);
     let dbMember;
     try {
@@ -114,11 +118,11 @@ export default class GewisDBService {
     if (expired) {
       try {
         logger.log(`User ${gewisUser.gewisId} has expired, closing account.`);
-        const balance = await BalanceService.getBalance(gewisUser.user.id);
-        const isZero = balance.amount.amount === 0;
+        const currentBalance = await BalanceService.getBalance(gewisUser.user.id);
+        const isZero = currentBalance.amount.amount === 0;
+        if (!commit) return null;
 
         const user = await UserService.closeUser(gewisUser.user.id, isZero);
-        const currentBalance = await BalanceService.getBalance(user.id);
         Mailer.getInstance().send(gewisUser.user, new MembershipExpiryNotification({
           name: user.firstName,
           balance: DineroTransformer.Instance.from(currentBalance.amount.amount),
@@ -133,6 +137,8 @@ export default class GewisDBService {
     const update = webResponseToUpdate(dbMember);
     if (GewisDBService.isUpdateNeeded(gewisUser, update)) {
       logger.log(`Updated user m${gewisUser.gewisId} (id ${gewisUser.userId}) with `, update);
+      if (!commit) return null;
+
       return UserService.updateUser(gewisUser.user.id, update);
     }
   }

--- a/src/service/user-service.ts
+++ b/src/service/user-service.ts
@@ -37,7 +37,7 @@ import Bindings from '../helpers/bindings';
 import AuthenticationService from './authentication-service';
 import WelcomeWithReset from '../mailer/templates/welcome-with-reset';
 import { Brackets } from 'typeorm';
-import BalanceService from "./balance-service";
+import BalanceService from './balance-service';
 
 /**
  * Parameters used to filter on Get Users functions.

--- a/test/unit/gewis/gewisdb.ts
+++ b/test/unit/gewis/gewisdb.ts
@@ -26,7 +26,7 @@ import GewisDBService from '../../../src/gewis/service/gewisdb-service';
 import { BasicApi, MemberAllAttributes, MembersApi } from 'gewisdb-ts-client';
 import nodemailer, { Transporter } from 'nodemailer';
 import Mailer from '../../../src/mailer';
-import {In} from "typeorm";
+import { In } from 'typeorm';
 
 describe('GEWISDB Service', () => {
 

--- a/test/unit/gewis/gewisdb.ts
+++ b/test/unit/gewis/gewisdb.ts
@@ -26,6 +26,7 @@ import GewisDBService from '../../../src/gewis/service/gewisdb-service';
 import { BasicApi, MemberAllAttributes, MembersApi } from 'gewisdb-ts-client';
 import nodemailer, { Transporter } from 'nodemailer';
 import Mailer from '../../../src/mailer';
+import {In} from "typeorm";
 
 describe('GEWISDB Service', () => {
 
@@ -300,6 +301,35 @@ describe('GEWISDB Service', () => {
       });
 
       expect(sendMailFake).to.be.callCount(res.length);
+    });
+    it('should not commit changes to the database if commit is false', async function () {
+      const users = await GewisUser.find({ where: { user: { deleted: false, active: true } }, relations: ['user'], take: 5 });
+
+      const updates: { [key: number]: MemberAllAttributes; } = {};
+      membersApiStub.membersLidnrGet.callsFake((async (gewisId: number) => {
+        const user = users.find(u => u.gewisId === gewisId);
+        if (!user) return Promise.resolve({ data: null });
+
+        const update = toWebResponse(user);
+        update.expiration = new Date(2020, 1, 1).toISOString();
+        updates[user.userId] = update;
+
+        return Promise.resolve({
+          data: { data: update },
+        });
+      }) as any);
+
+
+      await GewisDBService.sync(users, false);
+      const res = await User.find({ where: { id: In(users.map(u => u.userId)) } });
+      expect(res).to.not.be.empty;
+      expect(res.length).to.eq(users.length);
+      res.forEach((u) => {
+        expect(u.active).to.be.true;
+        expect(u.deleted).to.be.false;
+      });
+
+      expect(sendMailFake).to.be.callCount(0);
     });
   });
 });


### PR DESCRIPTION
# Description
Since syncing the complete SudoSOS user list might be a bit much, I suggest a dry-run from cli to inspect the results.

## Types of changes
- New feature _(non-breaking change which adds functionality)_
