### PR TITLE
fix: return before balance to prevent AppDataSource based errors

### DIFF
--- a/src/gewis/service/gewisdb-service.ts
+++ b/src/gewis/service/gewisdb-service.ts
@@ -118,10 +118,10 @@ export default class GewisDBService {
     if (expired) {
       try {
         logger.log(`User ${gewisUser.gewisId} has expired, closing account.`);
-        const currentBalance = await BalanceService.getBalance(gewisUser.user.id);
-        const isZero = currentBalance.amount.amount === 0;
         if (!commit) return null;
 
+        const currentBalance = await BalanceService.getBalance(gewisUser.user.id);
+        const isZero = currentBalance.amount.amount === 0;
         const user = await UserService.closeUser(gewisUser.user.id, isZero);
         Mailer.getInstance().send(gewisUser.user, new MembershipExpiryNotification({
           name: user.firstName,


### PR DESCRIPTION
# Description
Since this uses `AppDataSource` you cannot use other services (yet), as they use the default connection.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
