### PR TITLE
feat: POS cashier roles

### DIFF
--- a/src/controller/request/point-of-sale-request.ts
+++ b/src/controller/request/point-of-sale-request.ts
@@ -20,7 +20,8 @@
 export interface BasePointOfSaleParams {
   containers: number[],
   name: string,
-  useAuthentication: boolean;
+  useAuthentication: boolean,
+  cashierRoleIds?: number[],
 }
 
 export interface CreatePointOfSaleParams extends BasePointOfSaleParams {
@@ -28,7 +29,7 @@ export interface CreatePointOfSaleParams extends BasePointOfSaleParams {
 }
 
 export interface UpdatePointOfSaleParams extends BasePointOfSaleParams {
-  id: number
+  id: number,
 }
 
 /**
@@ -36,10 +37,12 @@ export interface UpdatePointOfSaleParams extends BasePointOfSaleParams {
  * @property {string} name.required - Name of the POS
  * @property {boolean} useAuthentication.required - Whether this POS requires users to
  * authenticate themselves before making a transaction
- * @property {Array<integer>} containers -
+ * @property {Array<integer>} containers.required -
  * IDs or Requests of the containers to add to the POS
- * @property {integer} ownerId - ID of the user who will own the POS, if undefined it will
+ * @property {integer} ownerId.required - ID of the user who will own the POS, if undefined it will
  *    default to the token ID.
+ * @property {Array<integer>} cashierRoleIds - Users that have at least one of the given roles
+ * can create transactions in this POS (but not open/close/edit it)
  */
 export interface CreatePointOfSaleRequest extends BasePointOfSaleParams {
   ownerId?: number,
@@ -50,8 +53,10 @@ export interface CreatePointOfSaleRequest extends BasePointOfSaleParams {
  * @property {string} name.required - Name of the POS
  * @property {boolean} useAuthentication.required - Whether this POS requires users to
  * authenticate themselves before making a transaction
- * @property {Array<integer>} containers -
+ * @property {Array<integer>} containers.required -
  * IDs or Requests of the containers to add to the POS
  * @property {integer} id.required - ID of the POS to update.
+ * @property {Array<integer>} cashierRoleIds - Users that have at least one of the given roles
+ * can create transactions in this POS (but not open/close/edit it)
  */
 export type UpdatePointOfSaleRequest = BasePointOfSaleParams & { id: number };

--- a/src/controller/request/validators/point-of-sale-request-spec.ts
+++ b/src/controller/request/validators/point-of-sale-request-spec.ts
@@ -29,7 +29,7 @@ import stringSpec from './string-spec';
 import {
   INVALID_CONTAINER_ID,
 } from './validation-errors';
-import { userMustExist } from './general-validators';
+import { rolesCannotBeSystemDefault, rolesMustExist, userMustExist } from './general-validators';
 import { verifyContainerRequest } from './container-request-spec';
 
 /**
@@ -53,6 +53,7 @@ const basePointOfSaleRequestSpec:<T extends BasePointOfSaleParams>() =>
 Specification<T, ValidationError> = () => [
   [stringSpec(), 'name', new ValidationError('Name:')],
   [[createArrayRule([validContainerRequestOrId])], 'containers', new ValidationError('Containers:')],
+  [[rolesMustExist, rolesCannotBeSystemDefault], 'cashierRoleIds', new ValidationError('cashierRoleIds:')],
 ];
 
 /**

--- a/src/controller/request/validators/validation-errors.ts
+++ b/src/controller/request/validators/validation-errors.ts
@@ -63,3 +63,7 @@ export const INVALID_PIN = () => new ValidationError('PIN is not 4 numbers');
 export const WEAK_PASSWORD = () => new ValidationError('Password not strong enough.');
 
 export const EMPTY_ARRAY = () => new ValidationError('is empty.');
+
+export const INVALID_ROLE_ID = (id: number) => new ValidationError(`Role with ID ${id} does not exist.`);
+
+export const INVALID_CUSTOM_ROLE_ID = (id: number) => new ValidationError(`Role with ID ${id} is a system default role.`);

--- a/src/controller/response/point-of-sale-response.ts
+++ b/src/controller/response/point-of-sale-response.ts
@@ -20,6 +20,7 @@ import BaseResponse from './base-response';
 import { ContainerWithProductsResponse } from './container-response';
 import { BaseUserResponse } from './user-response';
 import { PaginationResult } from '../../helpers/pagination';
+import RoleResponse from './rbac/role-response';
 
 /**
  * @typedef {allOf|BaseResponse} BasePointOfSaleResponse
@@ -34,11 +35,14 @@ export interface BasePointOfSaleResponse extends BaseResponse {
  * @property {number} revision.required - Revision of the POS
  * @property {boolean} useAuthentication.required - Whether this POS requires users to
  * authenticate themselves before making a transaction
+ * @property {Array.<RoleResponse>} cashierRoles.required - The roles that are
+ * cashiers of this POS
  */
 export interface PointOfSaleResponse extends BasePointOfSaleResponse {
   owner: BaseUserResponse,
   revision: number,
   useAuthentication: boolean;
+  cashierRoles: RoleResponse[]
 }
 
 /**

--- a/src/controller/response/point-of-sale-response.ts
+++ b/src/controller/response/point-of-sale-response.ts
@@ -63,3 +63,16 @@ export interface PaginatedPointOfSaleResponse {
 export interface PointOfSaleWithContainersResponse extends PointOfSaleResponse {
   containers: ContainerWithProductsResponse[],
 }
+
+/**
+ * @typedef {object} PointOfSaleAssociateUsersResponse
+ * @property {BaseUserResponse} owner.required - Owner of the POS
+ * @property {Array.<BaseUserResponse>} ownerMembers.required - Members that belong to the owner
+ * @property {Array.<BaseUserResponse>} cashiers.required - Users that belong to at least one
+ * cashier role of this point of sale
+ */
+export interface PointOfSaleAssociateUsersResponse {
+  owner: BaseUserResponse,
+  ownerMembers: BaseUserResponse[],
+  cashiers: BaseUserResponse[],
+}

--- a/src/controller/response/transaction-response.ts
+++ b/src/controller/response/transaction-response.ts
@@ -18,7 +18,7 @@
 
 import { DineroObject } from 'dinero.js';
 import BaseResponse from './base-response';
-import { BasePointOfSaleResponse, PointOfSaleResponse } from './point-of-sale-response';
+import { BasePointOfSaleResponse } from './point-of-sale-response';
 import { BaseContainerResponse } from './container-response';
 import { BaseProductResponse } from './product-response';
 import { BaseUserResponse } from './user-response';
@@ -50,7 +50,7 @@ export interface BaseTransactionResponse extends BaseResponse {
  * same as 'from'.
  * @property {Array<SubTransactionResponse>} subTransactions.required - The subtransactions
  * belonging to this transaction.
- * @property {PointOfSaleResponse} pointOfSale.required - The POS at which this transaction
+ * @property {BasePointOfSaleResponse} pointOfSale.required - The POS at which this transaction
  * has been created
  * @property {DineroObjectResponse} totalPriceInclVat.required - The total cost of the
  * transaction
@@ -59,7 +59,7 @@ export interface TransactionResponse extends BaseResponse {
   from: BaseUserResponse,
   createdBy?: BaseUserResponse,
   subTransactions: SubTransactionResponse[],
-  pointOfSale: PointOfSaleResponse,
+  pointOfSale: BasePointOfSaleResponse,
   totalPriceInclVat: DineroObjectResponse,
 }
 

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -80,6 +80,7 @@ import Permission from '../entity/rbac/permission';
 import { DatabaseRbac1720624912620 } from '../migrations/1720624912260-database-rbac';
 import RoleUserType from '../entity/rbac/role-user-type';
 import {TransfersVat1721916495084} from "../migrations/1721916495084-transfers-vat";
+import { PosCashiers1721835613950 } from '../migrations/1721835613950-pos-cashiers';
 
 // We need to load the dotenv to prevent the env from being undefined.
 dotenv.config();
@@ -103,6 +104,7 @@ const options: DataSourceOptions = {
     PayoutRequestPdf1720610649657,
     DatabaseRbac1720624912620,
     TransfersVat1721916495084,
+    PosCashiers1721835613950,
   ],
   extra: {
     authPlugins: {

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -79,8 +79,8 @@ import Role from '../entity/rbac/role';
 import Permission from '../entity/rbac/permission';
 import { DatabaseRbac1720624912620 } from '../migrations/1720624912260-database-rbac';
 import RoleUserType from '../entity/rbac/role-user-type';
-import {TransfersVat1721916495084} from "../migrations/1721916495084-transfers-vat";
-import { PosCashiers1721835613950 } from '../migrations/1721835613950-pos-cashiers';
+import { TransfersVat1721916495084 } from '../migrations/1721916495084-transfers-vat';
+import { PosCashiers1722022351000 } from '../migrations/1722022351000-pos-cashiers';
 
 // We need to load the dotenv to prevent the env from being undefined.
 dotenv.config();
@@ -104,7 +104,7 @@ const options: DataSourceOptions = {
     PayoutRequestPdf1720610649657,
     DatabaseRbac1720624912620,
     TransfersVat1721916495084,
-    PosCashiers1721835613950,
+    PosCashiers1722022351000,
   ],
   extra: {
     authPlugins: {

--- a/src/entity/point-of-sale/point-of-sale.ts
+++ b/src/entity/point-of-sale/point-of-sale.ts
@@ -18,11 +18,12 @@
 
 import {
   Column, DeleteDateColumn,
-  Entity,
+  Entity, JoinTable, ManyToMany,
   ManyToOne,
 } from 'typeorm';
 import BaseEntity from '../base-entity';
 import User from '../user/user';
+import Role from "../rbac/role";
 
 /**
  * @typedef {BaseEntity} PointOfSale
@@ -42,4 +43,8 @@ export default class PointOfSale extends BaseEntity {
 
   @ManyToOne(() => User, { nullable: false, eager: true })
   public owner: User;
+
+  @ManyToMany(() => Role)
+  @JoinTable()
+  public cashierRoles: Role[];
 }

--- a/src/entity/point-of-sale/point-of-sale.ts
+++ b/src/entity/point-of-sale/point-of-sale.ts
@@ -23,7 +23,7 @@ import {
 } from 'typeorm';
 import BaseEntity from '../base-entity';
 import User from '../user/user';
-import Role from "../rbac/role";
+import Role from '../rbac/role';
 
 /**
  * @typedef {BaseEntity} PointOfSale
@@ -44,6 +44,12 @@ export default class PointOfSale extends BaseEntity {
   @ManyToOne(() => User, { nullable: false, eager: true })
   public owner: User;
 
+  /**
+   * Every user that belongs to at least one of such cashier roles can create
+   * transactions in this POS, if the POS does not require authentication.
+   * In contrary to owners, cashiers should not be able to open this POS or
+   * make changes to it. Note that owners are always able to create transactions.
+   */
   @ManyToMany(() => Role)
   @JoinTable()
   public cashierRoles: Role[];

--- a/src/helpers/revision-to-response.ts
+++ b/src/helpers/revision-to-response.ts
@@ -66,8 +66,6 @@ export function parsePOSToBasePOS(
   return {
     id: pos.pointOfSale.id,
     name: pos.name,
-    useAuthentication: pos.useAuthentication,
-    revision: pos.revision,
     createdAt: timestamps ? pos.createdAt.toISOString() : undefined,
     updatedAt: timestamps ? pos.updatedAt.toISOString() : undefined,
   } as BasePointOfSaleResponse;

--- a/src/migrations/1721835613950-pos-cashiers.ts
+++ b/src/migrations/1721835613950-pos-cashiers.ts
@@ -1,0 +1,53 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { MigrationInterface, QueryRunner, Table, TableColumn, TableForeignKey } from 'typeorm';
+
+export class PosCashiers1721835613950 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(new Table({
+      name: 'point_of_sale_cashier_roles_role',
+      columns: [new TableColumn({
+        name: 'pointOfSaleId',
+        type: 'integer',
+        isNullable: false,
+        isPrimary: true,
+      }), new TableColumn({
+        name: 'roleId',
+        type: 'integer',
+        isNullable: false,
+        isPrimary: true,
+      })],
+    }));
+    await queryRunner.createForeignKey('point_of_sale_cashier_roles_role', new TableForeignKey({
+      columnNames: ['pointOfSaleId'],
+      referencedColumnNames: ['id'],
+      referencedTableName: 'point_of_sale',
+      onDelete: 'CASCADE',
+    }));
+    await queryRunner.createForeignKey('point_of_sale_cashier_roles_role', new TableForeignKey({
+      columnNames: ['roleId'],
+      referencedColumnNames: ['id'],
+      referencedTableName: 'roles',
+      onDelete: 'CASCADE',
+    }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('point_of_sale_cashier_roles_role');
+  }
+}

--- a/src/migrations/1721835613950-pos-cashiers.ts
+++ b/src/migrations/1721835613950-pos-cashiers.ts
@@ -42,7 +42,7 @@ export class PosCashiers1721835613950 implements MigrationInterface {
     await queryRunner.createForeignKey('point_of_sale_cashier_roles_role', new TableForeignKey({
       columnNames: ['roleId'],
       referencedColumnNames: ['id'],
-      referencedTableName: 'roles',
+      referencedTableName: 'role',
       onDelete: 'CASCADE',
     }));
   }

--- a/src/migrations/1722022351000-pos-cashiers.ts
+++ b/src/migrations/1722022351000-pos-cashiers.ts
@@ -17,7 +17,7 @@
  */
 import { MigrationInterface, QueryRunner, Table, TableColumn, TableForeignKey } from 'typeorm';
 
-export class PosCashiers1721835613950 implements MigrationInterface {
+export class PosCashiers1722022351000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.createTable(new Table({
       name: 'point_of_sale_cashier_roles_role',

--- a/src/service/user-service.ts
+++ b/src/service/user-service.ts
@@ -59,12 +59,19 @@ export interface UserFilterParameters {
  * @param req - Request to parse
  */
 export function parseGetUsersFilters(req: RequestWithToken): UserFilterParameters {
+  let assignedRoleIds: number[];
+  if (req.query.assignedRoleIds && Array.isArray(req.query.assignedRoleIds)) {
+    assignedRoleIds = req.query.assignedRoleIds.map((r) => Number(r));
+  } else if (req.query.assignedRoleIds) {
+    assignedRoleIds = [Number(req.query.assignedRoleIds)];
+  }
+
   return {
     search: req.query.search as string,
     active: req.query.active ? asBoolean(req.query.active) : undefined,
     ofAge: req.query.active ? asBoolean(req.query.ofAge) : undefined,
     id: asNumber(req.query.id),
-    assignedRoleIds: req.query.roleIds && Array.isArray(req.query.roleIds) ? req.query.roleIds.map((r) => Number(r)) : [Number(req.query.roleIds)],
+    assignedRoleIds,
     organId: asNumber(req.query.organ),
     deleted: req.query.active ? asBoolean(req.query.deleted) : false,
     type: asUserType(req.query.type),

--- a/src/service/user-service.ts
+++ b/src/service/user-service.ts
@@ -36,8 +36,9 @@ import { AcceptTosRequest } from '../controller/request/accept-tos-request';
 import Bindings from '../helpers/bindings';
 import AuthenticationService from './authentication-service';
 import WelcomeWithReset from '../mailer/templates/welcome-with-reset';
-import { Brackets } from 'typeorm';
+import { Brackets, In } from 'typeorm';
 import BalanceService from './balance-service';
+import AssignedRole from '../entity/rbac/assigned-role';
 
 /**
  * Parameters used to filter on Get Users functions.
@@ -50,6 +51,7 @@ export interface UserFilterParameters {
   deleted?: boolean,
   type?: UserType,
   organId?: number,
+  assignedRoleIds?: number | number[],
 }
 
 /**
@@ -62,6 +64,7 @@ export function parseGetUsersFilters(req: RequestWithToken): UserFilterParameter
     active: req.query.active ? asBoolean(req.query.active) : undefined,
     ofAge: req.query.active ? asBoolean(req.query.ofAge) : undefined,
     id: asNumber(req.query.id),
+    assignedRoleIds: req.query.roleIds && Array.isArray(req.query.roleIds) ? req.query.roleIds.map((r) => Number(r)) : [Number(req.query.roleIds)],
     organId: asNumber(req.query.organ),
     deleted: req.query.active ? asBoolean(req.query.deleted) : false,
     type: asUserType(req.query.type),
@@ -93,6 +96,22 @@ export default class UserService {
       const userIds = await MemberAuthenticator
         .find({ where: { authenticateAs: { id: filters.organId } }, relations: ['user'] });
       f.id = userIds.map((auth) => auth.user.id);
+    }
+    if (filters.assignedRoleIds) {
+      // Get all user IDs of the user belonging to any of the given roles
+      const assignedRoles = await AssignedRole
+        .find({ where: { roleId: In(filters.assignedRoleIds as number[]) } });
+      const userIds = assignedRoles.map((r) => r.userId);
+      if (f.id && Array.isArray(f.id)) {
+        // If we already have a list of IDs to filter on, we need to filter on the intersection
+        f.id = f.id.filter((id) => userIds.includes(id));
+      } else if (f.id) {
+        // If we only have a single ID to filter on, only keep it if it exists in one of the roles
+        f.id = userIds.includes(f.id as number) ? f.id : [];
+      } else {
+        // No existing filter on user ID, so we set the filter to the list of users in these groups
+        f.id = userIds;
+      }
     }
 
     const builder = Bindings.Users.getBuilder();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds a many-to-many relation between POSs and roles, allowing to associate groups of users with POSs. There already exist a way to do this, namely via ownership using the `MemberAuthenticator`. However, this is ownership, so all users are (in theory) able to make changes to the POS. 

This PR allows a second group of users to be linked to a POS, namely "cashiers". In practice, this will be the BAC feuten, so they can also create transactions in their own name during borrels. Right now, they do this in the name of a BAC member, which is confusing. To keep changes to SudoPOS minimal, there is a new endpoint that returns all users associated with a POS, seperated by their relation with the POS.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_