### PR TITLE
feat: add vat to transfers

### DIFF
--- a/src/controller/request/transfer-request.ts
+++ b/src/controller/request/transfer-request.ts
@@ -23,9 +23,8 @@ import { DineroObjectRequest } from './dinero-request';
  * @typedef {object} TransferRequest
  * @property {string} description.required - Description of the transfer.
  * @property {DineroObjectRequest} amount.required - Amount of money being transferred.
- * @property {integer} type.required - Type of transfer.
- * @property {integer} fromId.required - from which user the money is being transferred.
- * @property {integer} toId.required - to which user the money is being transferred.
+ * @property {integer} fromId - from which user the money is being transferred.
+ * @property {integer} toId - to which user the money is being transferred.
  * @property {integer} vatId - The vat group id for the transfer.
  */
 export default interface TransferRequest {

--- a/src/controller/request/transfer-request.ts
+++ b/src/controller/request/transfer-request.ts
@@ -21,15 +21,17 @@ import { DineroObjectRequest } from './dinero-request';
 
 /**
  * @typedef {object} TransferRequest
- * @property {string} description - Description of the transfer
- * @property {DineroObjectRequest} amount - Amount of money being transferred
- * @property {integer} type - Type of transfer
- * @property {integer} fromId - from which user the money is being transferred
- * @property {integer} toId - to which user the money is being transferred.
+ * @property {string} description.required - Description of the transfer.
+ * @property {DineroObjectRequest} amount.required - Amount of money being transferred.
+ * @property {integer} type.required - Type of transfer.
+ * @property {integer} fromId.required - from which user the money is being transferred.
+ * @property {integer} toId.required - to which user the money is being transferred.
+ * @property {integer} vatId - The vat group id for the transfer.
  */
 export default interface TransferRequest {
   amount: DineroObjectRequest;
   description: string;
   fromId: number;
   toId: number;
+  vatId?: number;
 }

--- a/src/controller/response/transfer-response.ts
+++ b/src/controller/response/transfer-response.ts
@@ -25,21 +25,23 @@ import { BaseInvoiceResponse } from './invoice-response';
 import { StripeDepositResponse } from './stripe-response';
 import { BasePayoutRequestResponse } from './payout-request-response';
 import { FineResponse, UserFineGroupResponse } from './debtor-response';
+import { BaseVatGroupResponse } from './vat-group-response';
 
 /**
  * @typedef {allOf|BaseResponse} TransferResponse
  * @property {string} description.required - Description of the transfer
- * @property {Dinero} amount.required - Amount of money being transferred
+ * @property {Dinero} amountInclVat.required - Amount of money being transferred
  * @property {BaseUserResponse} from - from which user the money is being transferred
  * @property {BaseUserResponse} to - to which user the money is being transferred.
  * @property {BaseInvoiceResponse} invoice - invoice belonging to this transfer
  * @property {StripeDepositResponse} deposit - deposit belonging to this transfer
  * @property {BasePayoutRequestResponse} payoutRequest - payout request belonging to this transfer
  * @property {FineResponse} fine - fine belonging to this transfer
+ * @property {VatGroupResponse} vat - vat group belonging to this transfer
  * @property {UserFineGroupResponse} waivedFines - fines that have been waived by this transfer
  */
 export interface TransferResponse extends BaseResponse {
-  amount: DineroObjectResponse;
+  amountInclVat: DineroObjectResponse;
   description: string;
   from: BaseUserResponse;
   to: BaseUserResponse;
@@ -47,6 +49,7 @@ export interface TransferResponse extends BaseResponse {
   deposit?: StripeDepositResponse;
   payoutRequest?: BasePayoutRequestResponse;
   fine?: FineResponse;
+  vat?: BaseVatGroupResponse;
   waivedFines?: UserFineGroupResponse;
 }
 

--- a/src/controller/response/transfer-response.ts
+++ b/src/controller/response/transfer-response.ts
@@ -31,6 +31,7 @@ import { BaseVatGroupResponse } from './vat-group-response';
  * @typedef {allOf|BaseResponse} TransferResponse
  * @property {string} description.required - Description of the transfer
  * @property {Dinero} amountInclVat.required - Amount of money being transferred
+ * @property {Dinero} amount.required - (@deprecated) Amount of money being transferred
  * @property {BaseUserResponse} from - from which user the money is being transferred
  * @property {BaseUserResponse} to - to which user the money is being transferred.
  * @property {BaseInvoiceResponse} invoice - invoice belonging to this transfer
@@ -42,6 +43,10 @@ import { BaseVatGroupResponse } from './vat-group-response';
  */
 export interface TransferResponse extends BaseResponse {
   amountInclVat: DineroObjectResponse;
+  /**
+   * @deprecated
+   */
+  amount: DineroObjectResponse;
   description: string;
   from: BaseUserResponse;
   to: BaseUserResponse;

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -79,6 +79,7 @@ import Role from '../entity/rbac/role';
 import Permission from '../entity/rbac/permission';
 import { DatabaseRbac1720624912620 } from '../migrations/1720624912260-database-rbac';
 import RoleUserType from '../entity/rbac/role-user-type';
+import {TransfersVat1721916495084} from "../migrations/1721916495084-transfers-vat";
 
 // We need to load the dotenv to prevent the env from being undefined.
 dotenv.config();
@@ -101,6 +102,7 @@ const options: DataSourceOptions = {
     SoftDeletes1720608140757,
     PayoutRequestPdf1720610649657,
     DatabaseRbac1720624912620,
+    TransfersVat1721916495084,
   ],
   extra: {
     authPlugins: {

--- a/src/entity/transactions/transfer.ts
+++ b/src/entity/transactions/transfer.ts
@@ -28,6 +28,7 @@ import StripeDeposit from '../deposit/stripe-deposit';
 import Invoice from '../invoices/invoice';
 import Fine from '../fine/fine';
 import UserFineGroup from '../fine/userFineGroup';
+import VatGroup from '../vat-group';
 
 /**
  * @typedef {BaseEntity} Transfer
@@ -35,7 +36,8 @@ import UserFineGroup from '../fine/userFineGroup';
  * null if money was deposited.
  * @property {User.model} to - The account to which the transaction is added. Can be null if
  * money was paid out.
- * @property {Dinero.model} amount.required - The amount of money transferred.
+ * @property {VatGroup.model} vat - The vat group of the transfer
+ * @property {Dinero.model} amountInclVat.required - The amount of money transferred.
  * @property {integer} type.required - The type of transfer.
  * @property {string} description - If the transfer is of type 'custom', this contains a
  * description of the transfer.
@@ -64,7 +66,10 @@ export default class Transfer extends BaseEntity {
     type: 'integer',
     transformer: DineroTransformer.Instance,
   })
-  public amount: Dinero;
+  public amountInclVat: Dinero;
+
+  @ManyToOne(() => VatGroup, { nullable: true })
+  public vat?: VatGroup;
 
   @Column({
     nullable: true,

--- a/src/migrations/1721916495084-transfers-vat.ts
+++ b/src/migrations/1721916495084-transfers-vat.ts
@@ -1,0 +1,32 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class TransfersVat1721916495084 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "transfer" RENAME COLUMN "amount" TO "amountInclVat"');
+    await queryRunner.query('ALTER TABLE "transfer" ADD "vatId" integer');
+    await queryRunner.query('ALTER TABLE "transfer" ADD CONSTRAINT "FK_vatGroup" FOREIGN KEY ("vatId") REFERENCES "vat_group"("id") ON DELETE NO ACTION ON UPDATE NO ACTION');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "transfer" DROP CONSTRAINT "FK_vatGroup"');
+    await queryRunner.query('ALTER TABLE "transfer" DROP COLUMN "vatId"');
+    await queryRunner.query('ALTER TABLE "transfer" RENAME COLUMN "amountInclVat" TO "amount"');
+  }
+}

--- a/src/migrations/1721916495084-transfers-vat.ts
+++ b/src/migrations/1721916495084-transfers-vat.ts
@@ -15,7 +15,7 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import {MigrationInterface, QueryRunner, TableColumn, TableForeignKey} from 'typeorm';
+import { MigrationInterface, QueryRunner, TableColumn, TableForeignKey } from 'typeorm';
 
 export class TransfersVat1721916495084 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/service/balance-service.ts
+++ b/src/service/balance-service.ts
@@ -140,10 +140,10 @@ export default class BalanceService {
           + 'where 1 ';
     query = this.addWhereClauseForIds(query, parameters, 'st2.toId', params.ids);
     query += 'UNION ALL '
-        + 'select t2.fromId as `id`, amount*-1 as `amount`, null as `createdAt1`, t2.createdAt as `createdAt2` from `transfer` t2 where t2.fromId is not null ';
+        + 'select t2.fromId as `id`, amountInclVat*-1 as `amount`, null as `createdAt1`, t2.createdAt as `createdAt2` from `transfer` t2 where t2.fromId is not null ';
     query = this.addWhereClauseForIds(query, parameters, 'fromId', params.ids);
     query += 'UNION ALL '
-        + 'select t2.toId as `id`, amount as `amount`, null as `createdAt1`, t2.createdAt as `createdAt2` from `transfer` t2 where t2.toId is not null ';
+        + 'select t2.toId as `id`, amountInclVat as `amount`, null as `createdAt1`, t2.createdAt as `createdAt2` from `transfer` t2 where t2.toId is not null ';
     query = this.addWhereClauseForIds(query, parameters, 'toId', params.ids);
     query += ') as moneys '
         + 'group by moneys.id '
@@ -252,13 +252,13 @@ export default class BalanceService {
     query = this.addWhereClauseForIds(query, parameters, 'st2.toId', ids);
     query = this.addWhereClauseForDate(query, parameters, 't.createdAt', d);
     query += 'UNION ALL '
-      + 'select t2.fromId as `id`, t2.amount*-1 as `totalValue`, null as `transactionId`, t2.id as `transferId` from transfer t2 '
+      + 'select t2.fromId as `id`, t2.amountInclVat*-1 as `totalValue`, null as `transactionId`, t2.id as `transferId` from transfer t2 '
       + `left join ${balanceSubquery()} b on t2.fromId=b.userId `
       + 'where t2.createdAt > COALESCE(b.lastTransferDate, 0) ';
     query = this.addWhereClauseForIds(query, parameters, 't2.fromId', ids);
     query = this.addWhereClauseForDate(query, parameters, 't2.createdAt', d);
     query += 'UNION ALL '
-      + 'select t3.toId as `id`, t3.amount as `totalValue`, null as `transactionId`, t3.id as `transferId` from transfer t3 '
+      + 'select t3.toId as `id`, t3.amountInclVat as `totalValue`, null as `transactionId`, t3.id as `transferId` from transfer t3 '
       + `left join ${balanceSubquery()} b on t3.toId=b.userId `
       + 'where t3.createdAt > COALESCE(b.lastTransferDate, 0) ';
     query = this.addWhereClauseForIds(query, parameters, 't3.toId', ids);

--- a/src/service/debtor-service.ts
+++ b/src/service/debtor-service.ts
@@ -374,7 +374,7 @@ export default class DebtorService {
         count.count++;
       }
       if (transfer.waivedFines != null) {
-        waivedAmount = waivedAmount.add(transfer.amount);
+        waivedAmount = waivedAmount.add(transfer.amountInclVat);
         count.waivedCount++;
       }
     });

--- a/src/service/invoice-service.ts
+++ b/src/service/invoice-service.ts
@@ -259,9 +259,9 @@ export default class InvoiceService {
 
     // Extract amount from transfer
     const amount: DineroObjectRequest = {
-      amount: invoice.transfer.amount.getAmount(),
-      currency: invoice.transfer.amount.getCurrency(),
-      precision: invoice.transfer.amount.getPrecision(),
+      amount: invoice.transfer.amountInclVat.getAmount(),
+      currency: invoice.transfer.amountInclVat.getCurrency(),
+      precision: invoice.transfer.amountInclVat.getPrecision(),
     };
 
     // We create an undo transfer that sends the money back to the void.

--- a/src/service/transfer-service.ts
+++ b/src/service/transfer-service.ts
@@ -30,7 +30,7 @@ import QueryFilter, { FilterMapping } from '../helpers/query-filter';
 import { PaginationParameters } from '../helpers/pagination';
 import { RequestWithToken } from '../middleware/token-middleware';
 import { asNumber } from '../helpers/validators';
-import { parseUserToBaseResponse } from '../helpers/revision-to-response';
+import { parseUserToBaseResponse, parseVatGroupToResponse } from '../helpers/revision-to-response';
 import InvoiceService from './invoice-service';
 import StripeService from './stripe-service';
 import PayoutRequestService from './payout-request-service';
@@ -56,7 +56,7 @@ export function parseGetTransferFilters(req: RequestWithToken): TransferFilterPa
 export default class TransferService {
   public static asTransferResponse(transfer: Transfer) : TransferResponse {
     return {
-      amount: transfer.amount.toObject(),
+      amountInclVat: transfer.amountInclVat.toObject(),
       from: parseUserToBaseResponse(transfer.from, false),
       to: parseUserToBaseResponse(transfer.to, false),
       id: transfer.id,
@@ -68,6 +68,7 @@ export default class TransferService {
       payoutRequest: transfer.payoutRequest ? PayoutRequestService.asBasePayoutRequestResponse(transfer.payoutRequest) : null,
       fine: transfer.fine ? DebtorService.asFineResponse(transfer.fine) : null,
       waivedFines: transfer.waivedFines ? DebtorService.asUserFineGroupResponse(transfer.waivedFines) : null,
+      vat: transfer.vat ? parseVatGroupToResponse(transfer.vat) : null,
     };
   }
 

--- a/src/service/transfer-service.ts
+++ b/src/service/transfer-service.ts
@@ -35,7 +35,7 @@ import InvoiceService from './invoice-service';
 import StripeService from './stripe-service';
 import PayoutRequestService from './payout-request-service';
 import DebtorService from './debtor-service';
-import VatGroup from "../entity/vat-group";
+import VatGroup from '../entity/vat-group';
 
 export interface TransferFilterParameters {
   id?: number;
@@ -131,7 +131,7 @@ export default class TransferService {
         'deposit', 'deposit.depositStatus',
         'payoutRequest', 'payoutRequest.payoutRequestStatus', 'payoutRequest.requestedBy',
         'fine', 'fine.userFineGroup', 'fine.userFineGroup.user',
-        'waivedFines', 'waivedFines.fines', 'waivedFines.fines.userFineGroup',
+        'waivedFines', 'waivedFines.fines', 'waivedFines.fines.userFineGroup', 'vat',
       ],
       take,
       skip,

--- a/src/service/transfer-service.ts
+++ b/src/service/transfer-service.ts
@@ -75,7 +75,7 @@ export default class TransferService {
   public static async createTransfer(request: TransferRequest, manager?: EntityManager) : Promise<Transfer> {
     const transfer = Object.assign(new Transfer(), {
       description: request.description,
-      amount: dinero(request.amount as Dinero.Options),
+      amountInclVat: dinero(request.amount as Dinero.Options),
       from: request.fromId ? await User.findOne({ where: { id: request.fromId } }) : undefined,
       to: request.toId ? await User.findOne({ where: { id: request.toId } }) : undefined,
     });

--- a/src/service/transfer-service.ts
+++ b/src/service/transfer-service.ts
@@ -35,6 +35,7 @@ import InvoiceService from './invoice-service';
 import StripeService from './stripe-service';
 import PayoutRequestService from './payout-request-service';
 import DebtorService from './debtor-service';
+import VatGroup from "../entity/vat-group";
 
 export interface TransferFilterParameters {
   id?: number;
@@ -78,6 +79,7 @@ export default class TransferService {
       amountInclVat: dinero(request.amount as Dinero.Options),
       from: request.fromId ? await User.findOne({ where: { id: request.fromId } }) : undefined,
       to: request.toId ? await User.findOne({ where: { id: request.toId } }) : undefined,
+      vat: request.vatId ? await VatGroup.findOne({ where: { id: request.vatId } }) : undefined,
     });
 
     if (manager) {

--- a/src/service/transfer-service.ts
+++ b/src/service/transfer-service.ts
@@ -58,6 +58,7 @@ export default class TransferService {
   public static asTransferResponse(transfer: Transfer) : TransferResponse {
     return {
       amountInclVat: transfer.amountInclVat.toObject(),
+      amount: transfer.amountInclVat.toObject(),
       from: parseUserToBaseResponse(transfer.from, false),
       to: parseUserToBaseResponse(transfer.to, false),
       id: transfer.id,

--- a/src/service/voucher-group-service.ts
+++ b/src/service/voucher-group-service.ts
@@ -79,7 +79,7 @@ export default class VoucherGroupService {
   static async updateBalance(users: User[], balance: DineroFactory.Dinero, isPositive = true) {
     const transfers = users.map((user) => Object.assign(new Transfer(), {
       description: '',
-      amount: balance,
+      amountInclVat: balance,
       from: isPositive ? undefined : user,
       to: isPositive ? user : undefined,
     }));

--- a/src/subscriber/transfer-subscriber.ts
+++ b/src/subscriber/transfer-subscriber.ts
@@ -38,7 +38,7 @@ export default class TransferSubscriber implements EntitySubscriberInterface {
     // If the new transfer is not included in the balance calculation, add it manually
     let currentBalance = balance.amount.amount;
     if (balance.lastTransferId < event.entity.id) {
-      currentBalance += event.entity.amount.getAmount();
+      currentBalance += event.entity.amountInclVat.getAmount();
     }
 
     // Remove currently unpaid fines when new balance is positive.

--- a/test/helpers/balance.ts
+++ b/test/helpers/balance.ts
@@ -64,9 +64,9 @@ export function calculateBalance(user: User, transactions: Transaction[], subTra
       prev + (curr.amount * curr.product.priceInclVat.getAmount())
     ), 0);
   const valueTransfersOutgoing = transfersOutgoing
-    .reduce((prev, curr) => prev - curr.amount.getAmount(), 0);
+    .reduce((prev, curr) => prev - curr.amountInclVat.getAmount(), 0);
   const valueTransfersIncoming = transfersIncoming
-    .reduce((prev, curr) => prev + curr.amount.getAmount(), 0);
+    .reduce((prev, curr) => prev + curr.amountInclVat.getAmount(), 0);
 
   // Calculate the user's personal last transaction/transfer
   let lastTransaction: Transaction;

--- a/test/helpers/transaction-helpers.ts
+++ b/test/helpers/transaction-helpers.ts
@@ -109,7 +109,7 @@ export async function addTransfer(
   const transfer = Object.assign(new Transfer(), {
     createdAt,
     updatedAt: createdAt,
-    amount: Dinero(amount),
+    amountInclVat: Dinero(amount),
     description: '',
     from,
     to,

--- a/test/seed.ts
+++ b/test/seed.ts
@@ -1105,11 +1105,11 @@ export async function seedSingleFines(users: User[], transactions: Transaction[]
     }
 
     // Fine everyone 5 euros
-    const amount = dinero({ amount: 500 });
+    const amountInclVat = dinero({ amount: 500 });
     const transfer = Object.assign(new Transfer(), {
       from: u,
       fromId: u.id,
-      amount,
+      amountInclVat,
       description: 'Seeded fine',
     } as Transfer);
     const fine = await transfer.save().then(async (t) => {
@@ -1117,7 +1117,7 @@ export async function seedSingleFines(users: User[], transactions: Transaction[]
         fineHandoutEvent,
         userFineGroup,
         transfer: t,
-        amount,
+        amount: amountInclVat,
       } as Fine);
       return f.save();
     });

--- a/test/seed.ts
+++ b/test/seed.ts
@@ -252,7 +252,7 @@ export async function seedInvoices(users: User[], transactions: Transaction[]): 
     const transfer = Object.assign(new Transfer(), {
       from: null,
       to,
-      amount: dinero({
+      amountInclVat: dinero({
         amount: cost,
       }),
       description: `Invoice Transfer for ${cost}`,
@@ -1032,7 +1032,7 @@ export async function seedStripeDeposits(users: User[]): Promise<{
       const transfer = Object.assign(new Transfer(), {
         from: null,
         to,
-        amount,
+        amountInclVat:amount,
         description: `Deposit transfer for ${amount}`,
       });
       await transfer.save();
@@ -1239,7 +1239,7 @@ export async function seedPayoutRequests(users: User[]): Promise<{
       const transfer = Object.assign(new Transfer(), {
         from: requestedBy,
         to: null,
-        amount,
+        amountInclVat: amount,
         description: `Payout request for ${amount}`,
       });
       await transfer.save();
@@ -1278,7 +1278,7 @@ export async function seedTransfers(users: User[],
     }
     let newTransfer = Object.assign(new Transfer(), {
       description: '',
-      amount: dinero({ amount: 100 * (i + 1) }),
+      amountInclVat: dinero({ amount: 100 * (i + 1) }),
       from: undefined,
       to: users[i],
       createdAt: date,
@@ -1288,7 +1288,7 @@ export async function seedTransfers(users: User[],
 
     newTransfer = Object.assign(new Transfer(), {
       description: '',
-      amount: dinero({ amount: 50 * (i + 1) }),
+      amountInclVat: dinero({ amount: 50 * (i + 1) }),
       from: users[i],
       to: undefined,
       createdAt: date,

--- a/test/unit/service/debtor-service.ts
+++ b/test/unit/service/debtor-service.ts
@@ -367,7 +367,7 @@ describe('DebtorService', (): void => {
 
       const dbUserFineGroupNew = await UserFineGroup.findOne({ where: { id: userFineGroup.id }, relations: ['fines', 'waivedTransfer', 'user', 'user.currentFines'] });
       expect(dbUserFineGroupNew.waivedTransfer).to.not.be.null;
-      expect(dbUserFineGroupNew.waivedTransfer.amount.getAmount()).to.equal(amount);
+      expect(dbUserFineGroupNew.waivedTransfer.amountInclVat.getAmount()).to.equal(amount);
       expect(dbUserFineGroupNew.user.currentFines).to.be.null;
 
       // Cleanup
@@ -478,7 +478,7 @@ describe('DebtorService', (): void => {
       expect(f.transfer).to.not.be.undefined;
       expect(f.transfer.from.id).to.equal(f.userFineGroup.userId);
       expect(f.transfer.to).to.be.undefined;
-      expect(f.transfer.amount.getAmount()).to.equal(f.amount.getAmount());
+      expect(f.transfer.amountInclVat.getAmount()).to.equal(f.amount.getAmount());
       const balString = '-€' + (b.amount.getAmount() / 100).toFixed(2).substring(1);
       expect(f.transfer.description).to.equal(`Fine for balance of ${balString} on ${date.toLocaleDateString()}.`);
     }

--- a/test/unit/service/invoice-pdf-service.ts
+++ b/test/unit/service/invoice-pdf-service.ts
@@ -241,7 +241,7 @@ describe('InvoicePdfService', async (): Promise<void> => {
       const total = 500 + 3 * 1090 + 5 * 1210;
       const lowVat = 270;
       const highVat = 1050;
-      invoice.transfer = { amount: DineroTransformer.Instance.from(total) } as Transfer;
+      invoice.transfer = { amountInclVat: DineroTransformer.Instance.from(total) } as Transfer;
 
       invoice.invoiceEntries = [{
         description: 'Product no VAT',

--- a/test/unit/service/invoice-service.ts
+++ b/test/unit/service/invoice-service.ts
@@ -267,7 +267,7 @@ describe('InvoiceService', () => {
       expect(transactions).to.not.be.empty;
       const transfer: TransferResponse = (
         await InvoiceService.createTransferFromTransactions(toId, transactions, false));
-      expect(transfer.amount.amount).to.be.equal(value);
+      expect(transfer.amountInclVat.amount).to.be.equal(value);
       expect(transfer.to.id).to.be.equal(toId);
     });
   });
@@ -326,7 +326,7 @@ describe('InvoiceService', () => {
           const invoice = await InvoiceService.createInvoice(
             createInvoiceRequest,
           );
-          expect(invoice.transfer.amount.getAmount()).is.equal(total);
+          expect(invoice.transfer.amountInclVat.getAmount()).is.equal(total);
           expect(
             (await BalanceService.getBalance(debtor.id)).amount.amount,
           ).is.equal(-1 * transactionsBeforeDate.total);
@@ -366,7 +366,7 @@ describe('InvoiceService', () => {
           const invoice = await InvoiceService.createInvoice(
             createInvoiceRequest,
           );
-          expect(invoice.transfer.amount.getAmount()).is.equal(
+          expect(invoice.transfer.amountInclVat.getAmount()).is.equal(
             chosenTransactions.reduce(
               (sum, current) => sum + current.amount,
               0,
@@ -411,7 +411,7 @@ describe('InvoiceService', () => {
             createInvoiceRequest,
           );
 
-          expect(invoice.transfer.amount.getAmount()).is.equal(total);
+          expect(invoice.transfer.amountInclVat.getAmount()).is.equal(total);
           expect(
             (await BalanceService.getBalance(debtor.id)).amount.amount,
             'balance after final invoice',
@@ -548,7 +548,7 @@ describe('InvoiceService', () => {
         const creditorBalance = await BalanceService.getBalance(creditor.id);
         const transfer = await Transfer.findOne({ where: { from: { id: creditor.id } } });
         expect(transfer).to.not.be.undefined;
-        expect(transfer.amount.getAmount()).to.eq(invoice.transfer.amount.getAmount());
+        expect(transfer.amountInclVat.getAmount()).to.eq(invoice.transfer.amountInclVat.getAmount());
         expect(creditorBalance.amount.amount).to.eq(0);
       });
     });
@@ -761,7 +761,7 @@ describe('InvoiceService', () => {
           // Check if the balance has been decreased
           expect(
             (await BalanceService.getBalance(debtor.id)).amount.amount,
-          ).is.equal(-1 * invoice.transfer.amount.getAmount());
+          ).is.equal(-1 * invoice.transfer.amountInclVat.getAmount());
         },
       );
     });
@@ -776,9 +776,9 @@ describe('InvoiceService', () => {
         await InvoiceService
           .updateInvoice(makeParamsState(invoice.addressee, invoice.description, creditor, invoice.id, InvoiceState.DELETED));
         expect((await BalanceService.getBalance(debtor.id)).amount.amount)
-          .is.equal(-1 * invoice.transfer.amount.getAmount());
+          .is.equal(-1 * invoice.transfer.amountInclVat.getAmount());
         expect((await BalanceService.getBalance(creditorBalance.id)).amount.amount)
-          .is.equal(invoice.transfer.amount.getAmount());
+          .is.equal(invoice.transfer.amountInclVat.getAmount());
       });
     });
     it('should delete invoice reference from subTransactions when Invoice is deleted', async () => {

--- a/test/unit/service/stripe-service.ts
+++ b/test/unit/service/stripe-service.ts
@@ -148,7 +148,7 @@ describe('StripeService', async (): Promise<void> => {
       await testStatusCreation(id, StripeDepositState.SUCCEEDED);
 
       deposit = await StripeService.getStripeDeposit(id, ['transfer', 'transfer.to', 'to']);
-      expect(ctx.dineroTransformer.to(deposit.transfer.amount))
+      expect(ctx.dineroTransformer.to(deposit.transfer.amountInclVat))
         .to.equal(ctx.dineroTransformer.to(deposit.amount));
       expect(deposit.transfer.to.id).to.equal(deposit.to.id);
     });

--- a/test/unit/service/transfer-service.ts
+++ b/test/unit/service/transfer-service.ts
@@ -164,13 +164,13 @@ describe('TransferService', async (): Promise<void> => {
     it('should return corresponding waived fines if transfer has any', async () => {
       const user = ctx.users.find((u) => u.currentFines != null);
       const userFineGroup = user.currentFines;
-      const amount = userFineGroup.fines.reduce((sum, f) => sum.add(f.amount), DineroTransformer.Instance.from(0));
+      const amountInclVat = userFineGroup.fines.reduce((sum, f) => sum.add(f.amount), DineroTransformer.Instance.from(0));
 
       const t = await Transfer.save({
         toId: user.id,
         version: 1,
         description: '',
-        amount,
+        amountInclVat,
         waivedFines: userFineGroup,
       } as Transfer);
 
@@ -201,9 +201,9 @@ describe('TransferService', async (): Promise<void> => {
       const res: PaginatedTransferResponse = await TransferService.getTransfers();
       const transfers = res.records;
       const lastEntry = transfers.reduce((prev, curr) => (prev.id < curr.id ? curr : prev));
-      expect(lastEntry.amount.amount).to.equal(req.amount.amount);
-      expect(lastEntry.amount.currency).to.equal(req.amount.currency);
-      expect(lastEntry.amount.precision).to.equal(req.amount.precision);
+      expect(lastEntry.amountInclVat.amount).to.equal(req.amount.amount);
+      expect(lastEntry.amountInclVat.currency).to.equal(req.amount.currency);
+      expect(lastEntry.amountInclVat.precision).to.equal(req.amount.precision);
       expect(lastEntry.description).to.equal(req.description);
       expect(lastEntry.from.id).to.equal(req.fromId);
       expect(lastEntry.to).to.be.undefined;

--- a/test/unit/service/voucher-group-service.ts
+++ b/test/unit/service/voucher-group-service.ts
@@ -231,7 +231,7 @@ describe('VoucherGroupService', async (): Promise<void> => {
         expect(user.active, 'user inactive').to.equal(false);
         expect(user.acceptedToS).to.equal(TermsOfServiceStatus.NOT_REQUIRED);
         const transfers = await Transfer.find({ where: { toId: user.id } });
-        const balanceAmounts = transfers.map((transfer) => transfer.amount.getAmount());
+        const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
         const balance = balanceAmounts.reduce((a, b) => a + b);
         expect(balance, 'correct transfers').to.equal(params.balance.getAmount());
       }));
@@ -254,7 +254,7 @@ describe('VoucherGroupService', async (): Promise<void> => {
       await Promise.all(bkgRes.users.map(async (user) => {
         expect(user.active, 'user active').to.equal(true);
         const transfers = await Transfer.find({ where: { toId: user.id } });
-        const balanceAmounts = transfers.map((transfer) => transfer.amount.getAmount());
+        const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
         const balance = balanceAmounts.reduce((a, b) => a + b);
         expect(balance, 'correct transfers').to.equal(params.balance.getAmount());
       }));
@@ -298,7 +298,7 @@ describe('VoucherGroupService', async (): Promise<void> => {
       await Promise.all(bkgRes.users.map(async (user) => {
         expect(user.active, 'user inactive').to.equal(false);
         const transfers = await Transfer.find({ where: { toId: user.id } });
-        const balanceAmounts = transfers.map((transfer) => transfer.amount.getAmount());
+        const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
         const balance = balanceAmounts.reduce((a, b) => a + b);
         expect(balance, 'correct transfers').to.equal(params.balance.getAmount());
       }));
@@ -322,7 +322,7 @@ describe('VoucherGroupService', async (): Promise<void> => {
       await Promise.all(bkgRes.users.map(async (user) => {
         expect(user.active, 'user inactive').to.equal(false);
         const transfers = await Transfer.find({ where: { toId: user.id } });
-        const balanceAmounts = transfers.map((transfer) => transfer.amount.getAmount());
+        const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
         const balance = balanceAmounts.reduce((a, b) => a + b);
         expect(balance, 'correct transfers').to.equal(params.balance.getAmount());
       }));
@@ -346,7 +346,7 @@ describe('VoucherGroupService', async (): Promise<void> => {
       await Promise.all(bkgRes.users.map(async (user) => {
         expect(user.active, 'user inactive').to.equal(false);
         const transfers = await Transfer.find({ where: { toId: user.id } });
-        const balanceAmounts = transfers.map((transfer) => transfer.amount.getAmount());
+        const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
         const balance = balanceAmounts.reduce((a, b) => a + b);
         expect(balance, 'correct transfers').to.equal(params.balance.getAmount());
       }));
@@ -370,7 +370,7 @@ describe('VoucherGroupService', async (): Promise<void> => {
       await Promise.all(bkgRes.users.map(async (user) => {
         expect(user.active, 'user active').to.equal(true);
         const transfers = await Transfer.find({ where: { toId: user.id } });
-        const balanceAmounts = transfers.map((transfer) => transfer.amount.getAmount());
+        const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
         const balance = balanceAmounts.reduce((a, b) => a + b);
         expect(balance, 'correct transfers').to.equal(params.balance.getAmount());
       }));
@@ -394,7 +394,7 @@ describe('VoucherGroupService', async (): Promise<void> => {
       await Promise.all(bkgRes.users.map(async (user) => {
         expect(user.active, 'user active').to.equal(false);
         const transfers = await Transfer.find({ where: { toId: user.id } });
-        const balanceAmounts = transfers.map((transfer) => transfer.amount.getAmount());
+        const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
         const balance = balanceAmounts.reduce((a, b) => a + b);
         expect(balance, 'correct transfers').to.equal(params.balance.getAmount());
       }));
@@ -418,7 +418,7 @@ describe('VoucherGroupService', async (): Promise<void> => {
       await Promise.all(bkgRes.users.map(async (user) => {
         expect(user.active, 'user active').to.equal(false);
         const transfers = await Transfer.find({ where: { toId: user.id } });
-        const balanceAmounts = transfers.map((transfer) => transfer.amount.getAmount());
+        const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
         const balance = balanceAmounts.reduce((a, b) => a + b);
         expect(balance, 'correct transfers').to.equal(params.balance.getAmount());
       }));
@@ -444,8 +444,8 @@ describe('VoucherGroupService', async (): Promise<void> => {
         const transfersPos = await Transfer.find({ where: { toId: user.id } });
         const transfersNeg = await Transfer.find({ where: { fromId: user.id } });
         const balanceAmounts = [
-          ...transfersPos.map((transfer) => transfer.amount.getAmount()),
-          ...transfersNeg.map((transfer) => -transfer.amount.getAmount()),
+          ...transfersPos.map((transfer) => transfer.amountInclVat.getAmount()),
+          ...transfersNeg.map((transfer) => -transfer.amountInclVat.getAmount()),
         ];
         const balance = balanceAmounts.reduce((a, b) => a + b);
         expect(balance, 'correct transfers').to.equal(params.balance.getAmount());
@@ -486,7 +486,7 @@ describe('VoucherGroupService', async (): Promise<void> => {
       await Promise.all(bkgRes.users.map(async (user) => {
         expect(user.active, 'user inactive').to.equal(false);
         const transfers = await Transfer.find({ where: { toId: user.id } });
-        const balanceAmounts = transfers.map((transfer) => transfer.amount.getAmount());
+        const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
         const balance = balanceAmounts.reduce((a, b) => a + b);
         expect(balance, 'correct transfers').to.equal(paramss[0].balance.getAmount());
       }));
@@ -505,7 +505,7 @@ describe('VoucherGroupService', async (): Promise<void> => {
         await Promise.all(res.users.map(async (user) => {
           expect(user.active, 'user inactive').to.equal(false);
           const transfers = await Transfer.find({ where: { toId: user.id } });
-          const balanceAmounts = transfers.map((transfer) => transfer.amount.getAmount());
+          const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
           const balance = balanceAmounts.reduce((a, b) => a + b);
           expect(balance, 'correct transfers').to.equal(paramss[i].balance.getAmount());
         }));


### PR DESCRIPTION
# Description
Since `WriteOffs` and `Inactivity Fees` have a VAT percentage but are not products, we have a need for adding VAT groups to transfers. This PR implements the bases of this. 

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
- New feature _(non-breaking change which adds functionality)_