### PR TITLE
feat: add server settings to store global settings in database

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -82,6 +82,7 @@ import RoleUserType from '../entity/rbac/role-user-type';
 import { TransfersVat1721916495084 } from '../migrations/1721916495084-transfers-vat';
 import { PosCashiers1722022351000 } from '../migrations/1722022351000-pos-cashiers';
 import ServerSetting from '../entity/server-setting';
+import { ServerSettings1722083254200 } from '../migrations/1722083254200-server-settings';
 
 // We need to load the dotenv to prevent the env from being undefined.
 dotenv.config();
@@ -106,6 +107,7 @@ const options: DataSourceOptions = {
     DatabaseRbac1720624912620,
     TransfersVat1721916495084,
     PosCashiers1722022351000,
+    ServerSettings1722083254200,
   ],
   extra: {
     authPlugins: {

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -81,6 +81,7 @@ import { DatabaseRbac1720624912620 } from '../migrations/1720624912260-database-
 import RoleUserType from '../entity/rbac/role-user-type';
 import { TransfersVat1721916495084 } from '../migrations/1721916495084-transfers-vat';
 import { PosCashiers1722022351000 } from '../migrations/1722022351000-pos-cashiers';
+import ServerSetting from '../entity/server-setting';
 
 // We need to load the dotenv to prevent the env from being undefined.
 dotenv.config();
@@ -113,6 +114,7 @@ const options: DataSourceOptions = {
   },
   poolSize: 4,
   entities: [
+    ServerSetting,
     ProductCategory,
     VatGroup,
     Product,

--- a/src/entity/server-setting.ts
+++ b/src/entity/server-setting.ts
@@ -34,7 +34,7 @@ export default class ServerSetting<T extends keyof ISettings = keyof ISettings> 
    * JSON-stored value
    */
   @Column({
-    type: 'varchar',
+    type: 'text',
     transformer: {
       from(value: string | null): number[] | null {
         if (value == null) return null;

--- a/src/entity/server-setting.ts
+++ b/src/entity/server-setting.ts
@@ -1,0 +1,50 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Column, Entity } from 'typeorm';
+import BaseEntity from './base-entity';
+
+export interface ISettings {
+  highVatGroupId: number;
+}
+
+/**
+ * Key-value store
+ */
+@Entity()
+export default class ServerSetting<T extends keyof ISettings = keyof ISettings> extends BaseEntity {
+  @Column({ unique: true })
+  public key: T;
+
+  /**
+   * JSON-stored value
+   */
+  @Column({
+    type: 'varchar',
+    transformer: {
+      from(value: string | null): number[] | null {
+        if (value == null) return null;
+        return JSON.parse(value);
+      },
+      to(value: number[] | null): string | null {
+        if (value == null) return null;
+        return JSON.stringify(value);
+      },
+    },
+  })
+  public value: ISettings[T];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ import EventController from './controller/event-controller';
 import EventShiftController from './controller/event-shift-controller';
 import EventService from './service/event-service';
 import DefaultRoles from './rbac/default-roles';
+import ServerSettingsStore from './server-settings/server-settings-store';
 
 export class Application {
   app: express.Express;
@@ -194,6 +195,9 @@ export default async function createApp(): Promise<Application> {
   // Set up monetary value configuration.
   dinero.defaultCurrency = process.env.CURRENCY_CODE as Currency;
   dinero.defaultPrecision = parseInt(process.env.CURRENCY_PRECISION, 10);
+
+  // Initialize database-stored settings
+  await ServerSettingsStore.getInstance().initialize();
 
   // Create express application.
   application.app = express();

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,8 @@ export default async function createApp(): Promise<Application> {
   dinero.defaultPrecision = parseInt(process.env.CURRENCY_PRECISION, 10);
 
   // Initialize database-stored settings
-  await ServerSettingsStore.getInstance().initialize();
+  const store = ServerSettingsStore.getInstance();
+  if (!store.initialized) await store.initialize();
 
   // Create express application.
   application.app = express();

--- a/src/migrations/1722083254200-server-settings.ts
+++ b/src/migrations/1722083254200-server-settings.ts
@@ -1,0 +1,68 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class ServerSettings1722083254200 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(new Table({
+      name: 'server_setting',
+      columns: [
+        {
+          name: 'id',
+          type: 'integer',
+          isPrimary: true,
+          isGenerated: true,
+          generationStrategy: 'increment',
+        },
+        {
+          name: 'createdAt',
+          type: 'datetime(6)',
+          default: 'current_timestamp',
+          isNullable: false,
+        },
+        {
+          name: 'updatedAt',
+          type: 'datetime(6)',
+          default: 'current_timestamp',
+          onUpdate: 'current_timestamp',
+          isNullable: false,
+        },
+        {
+          name: 'version',
+          type: 'integer',
+          isNullable: false,
+        },
+        {
+          name: 'key',
+          type: 'varchar(255)',
+          isNullable: false,
+          isUnique: true,
+        },
+        {
+          name: 'value',
+          type: 'text',
+          isNullable: false,
+        },
+      ],
+    }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('server_setting');
+  }
+}

--- a/src/server-settings/server-settings-store.ts
+++ b/src/server-settings/server-settings-store.ts
@@ -1,0 +1,128 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Repository } from 'typeorm';
+import ServerSetting, { ISettings } from '../entity/server-setting';
+import SettingsDefaults from './setting-defaults';
+
+/**
+ * Store of global server settings, which are key-value pairs stored in the database.
+ * Used for settings that fit a database store better than an environment variable,
+ * as the latter should contain mostly secrets to get things to work, not to
+ * configure stuff.
+ */
+export default class ServerSettingsStore<T extends keyof ISettings = keyof ISettings> {
+  private static instance: ServerSettingsStore;
+
+  private _initialized = false;
+
+  private repo: Repository<ServerSetting>;
+
+  private settings: ISettings;
+
+  constructor() {
+    this.repo = ServerSetting.getRepository();
+  }
+
+  /**
+   * Singleton, because there is only one copy of the core running at a time.
+   * We can therefore simply initialize the store once and keep it up to date
+   * from memory.
+   */
+  public static getInstance() {
+    if (!this.instance) {
+      this.instance = new ServerSettingsStore();
+    }
+    return this.instance;
+  }
+
+  get initialized() {
+    return this._initialized;
+  }
+
+  private isInitialized() {
+    if (!this._initialized) throw new Error('ServerSettingsStore has not been initialized.');
+  }
+
+  /**
+   * Fetch all key-value pairs from the database
+   */
+  public async initialize() {
+    if (this._initialized) {
+      throw new Error('ServerSettingsStore already initialized!');
+    }
+
+    const settings = await this.repo.find();
+    const promises: Promise<ServerSetting>[] = [];
+
+    // Save any new key-value pairs to the database if they don't yet exist
+    Object.entries(SettingsDefaults).forEach((entry) => {
+      const key = entry[0] as keyof ISettings;
+      const value = entry[1];
+      const setting = settings.find((s) => s.key === key);
+      if (!setting) {
+        const promise = this.repo.save({ key, value });
+        // Add the missing setting key with its default value
+        promises.push(promise);
+      }
+    });
+
+    // The settings object now contains all key-value pairs
+    settings.push(...(await Promise.all(promises)));
+
+    const map = new Map<ServerSetting['key'], ServerSetting['value']>();
+    Object.keys(SettingsDefaults).forEach((key) => {
+      const setting = settings.find((s) => s.key === key);
+      // Sanity check
+      if (!setting) throw new Error(`Setting "${key}" missing during initialization`);
+      map.set(setting.key, setting.value);
+    });
+
+    this.settings = Object.fromEntries(map) as any as ISettings;
+    this._initialized = true;
+
+    return this;
+  }
+
+  /**
+   * Get a server setting
+   * @param key
+   */
+  public getSetting(key: T): ISettings[T] {
+    this.isInitialized();
+    if (this.settings[key] === undefined) {
+      throw new Error(`Setting with key "${key}" does not exist.`);
+    }
+    return this.settings[key];
+  }
+
+  /**
+   * Update a server setting
+   * @param key
+   * @param value
+   */
+  public async setSetting(key: T, value: ISettings[T]) {
+    this.isInitialized();
+    const setting = await this.repo.findOne({ where: { key } });
+    if (!setting) {
+      throw new Error(`Setting with key "${key}" does not exist.`);
+    }
+    setting!.value = value;
+    this.settings[key] = value;
+    return this.repo.save(setting!);
+  }
+}

--- a/src/server-settings/setting-defaults.ts
+++ b/src/server-settings/setting-defaults.ts
@@ -1,0 +1,24 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { ISettings } from '../entity/server-setting';
+
+const SettingsDefaults: ISettings = {
+  highVatGroupId: -1,
+};
+
+export default SettingsDefaults;

--- a/test/unit/server-settings/server-settings-store.ts
+++ b/test/unit/server-settings/server-settings-store.ts
@@ -1,0 +1,156 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { DataSource } from 'typeorm';
+import database from '../../../src/database/database';
+import { finishTestDB } from '../../helpers/test-helpers';
+import ServerSettingsStore from '../../../src/server-settings/server-settings-store';
+import ServerSetting, { ISettings } from '../../../src/entity/server-setting';
+import { expect } from 'chai';
+import settingDefaults from '../../../src/server-settings/setting-defaults';
+
+describe('ServerSettingsStore', () => {
+  let ctx: {
+    connection: DataSource,
+  };
+
+  before(async () => {
+    ctx = {
+      connection: await database.initialize(),
+    };
+  });
+
+  afterEach(async () => {
+    await ServerSetting.delete({});
+  });
+
+  after(async () => {
+    await finishTestDB(ctx.connection);
+  });
+
+  describe('#initialize', () => {
+    it('should correctly initialize all settings with their defaults', async () => {
+      // Check precondition
+      let dbSettings = await ServerSetting.find();
+      expect(dbSettings).to.be.lengthOf(0);
+
+      const store = new ServerSettingsStore();
+      await store.initialize();
+
+      // Check precondition
+      dbSettings = await ServerSetting.find();
+      expect(dbSettings).to.be.lengthOf(Object.keys(settingDefaults).length);
+      dbSettings.forEach((setting) => {
+        const hardcodedDefault = settingDefaults[setting.key];
+        expect(hardcodedDefault).to.not.be.undefined;
+        expect(setting.value).to.deep.equal(hardcodedDefault);
+      });
+    });
+    it('should not overwrite existing setting with default if it already exists', async () => {
+      // Check precondition
+      let dbSettings = await ServerSetting.find();
+      expect(dbSettings).to.be.lengthOf(0);
+
+      const key: keyof ISettings = 'highVatGroupId';
+      const value: ISettings[keyof ISettings] = 39;
+      // Sanity check
+      expect(value).to.not.deep.equal(settingDefaults[key]);
+
+      await ServerSetting.save({ key, value });
+
+      const store = new ServerSettingsStore();
+      await store.initialize();
+
+      const dbSetting = await ServerSetting.findOne({ where: { key } });
+      expect(dbSetting.value).to.deep.equal(value);
+      expect(dbSetting.value).to.not.deep.equal(settingDefaults[key]);
+    });
+    it('should throw if already initialized', async () => {
+      const store = new ServerSettingsStore();
+      await store.initialize();
+      await expect(store.initialize()).to.eventually.be.rejectedWith('ServerSettingsStore already initialized!');
+    });
+  });
+  describe('#getSetting', () => {
+    it('should correctly get a setting from store', async () => {
+      const store = await new ServerSettingsStore().initialize();
+
+      const keys = Object.keys(settingDefaults);
+      keys.forEach((key: keyof ISettings) => {
+        const storedValue = store.getSetting(key);
+        expect(storedValue).to.equal(settingDefaults[key]);
+      });
+    });
+    it('should throw if key does not exist', async () => {
+      const store = await new ServerSettingsStore().initialize();
+      const randomKey = '39Vooooo' as any as keyof ISettings;
+      // Sanity check
+      expect(settingDefaults[randomKey]).to.be.undefined;
+
+      expect(() => store.getSetting(randomKey)).to.throw(`Setting with key "${randomKey}" does not exist.`);
+    });
+    it('should throw if not initialized', async () => {
+      const store = new ServerSettingsStore();
+
+      const key: keyof ISettings = 'highVatGroupId';
+      expect(() => store.getSetting(key)).to.throw('ServerSettingsStore has not been initialized.');
+    });
+  });
+  describe('#setSetting', () => {
+    it('should correctly set a setting to the store', async () => {
+      const store = await new ServerSettingsStore().initialize();
+
+      const key: keyof ISettings = 'highVatGroupId';
+      let dbSetting = await ServerSetting.findOne({ where: { key } });
+      // Sanity check
+      expect(dbSetting.value).to.deep.equal(settingDefaults[key]);
+      const value: ISettings[keyof ISettings] = 39;
+
+      await store.setSetting(key, value);
+      expect(store.getSetting(key)).to.deep.equal(value);
+      dbSetting = await ServerSetting.findOne({ where: { key } });
+      expect(dbSetting.value).to.deep.equal(value);
+    });
+    it('should throw if key does not exist', async () => {
+      const store = await new ServerSettingsStore().initialize();
+      const randomKey = '39Vooooo' as any as keyof ISettings;
+      // Sanity check
+      expect(settingDefaults[randomKey]).to.be.undefined;
+
+      await expect(store.setSetting(randomKey, 9)).to.eventually.be.rejectedWith(`Setting with key "${randomKey}" does not exist.`);
+    });
+    it('should throw if not initialized', async () => {
+      const store = new ServerSettingsStore();
+
+      const key: keyof ISettings = 'highVatGroupId';
+      const value: ISettings[keyof ISettings] = 39;
+
+      await expect(store.setSetting(key, value)).to.eventually.be.rejectedWith('ServerSettingsStore has not been initialized.');
+    });
+  });
+  describe('#getInstance', () => {
+    it('should return same instance', async () => {
+      const store = ServerSettingsStore.getInstance();
+      expect(store.initialized).to.be.false;
+
+      await store.initialize();
+      expect(store.initialized).to.be.true;
+
+      expect(ServerSettingsStore.getInstance().initialized).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Helper class to store system global settings in the database (instead of an environment variable). The store is synchronous in fetching settings, but this requires settings to be cached locally. Even though you can dynamically change these settings by using the `setSetting` method, the setting will then only change in that particular worker until SudoSOS is rebooted.

Or we can make the `getSetting` also asynchronous, which would solve this issue. What do you prefer?

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Implements https://github.com/GEWIS/sudosos-backend/issues/226;

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_