### PR TITLE
refactor(payoutrequests): move to `getOptions` method

### DIFF
--- a/src/controller/payout-request-controller.ts
+++ b/src/controller/payout-request-controller.ts
@@ -239,6 +239,14 @@ export default class PayoutRequestController extends BaseController {
       return;
     }
 
+    if (body.state === PayoutRequestState.APPROVED) {
+      const balance = await BalanceService.getBalance(payoutRequest.requestedBy.id);
+      if (balance.amount.amount < payoutRequest.amount.amount) {
+        res.status(400).json('Insufficient balance.');
+        return;
+      }
+    }
+
     // Verify validity of new status
     try {
       await PayoutRequestService.canUpdateStatus(id, body.state);

--- a/src/controller/response/payout-request-response.ts
+++ b/src/controller/response/payout-request-response.ts
@@ -48,7 +48,7 @@ export interface PayoutRequestStatusResponse extends BaseResponse {
 
 /**
  * @typedef {allOf|BasePayoutRequestResponse} PayoutRequestResponse
- * @property {Array<PayoutRequestStatusResponse>} status.required - Statuses of this
+ * @property {Array<PayoutRequestStatusResponse>} statuses.required - Statuses of this
  * payout response over time
  * @property {string} bankAccountNumber.required - Bank account number
  * @property {string} bankAccountName.required - Name of the account owner

--- a/src/controller/response/payout-request-response.ts
+++ b/src/controller/response/payout-request-response.ts
@@ -23,23 +23,19 @@ import { PayoutRequestState } from '../../entity/transactions/payout-request-sta
 import { PaginationResult } from '../../helpers/pagination';
 
 /**
- * @typedef {allOf|BaseResponse} BoilerPayoutRequestResponse
+ * @typedef {allOf|BaseResponse} BasePayoutRequestResponse
  * @property {BaseUserResponse} requestedBy.required - The user that requested a payout
  * @property {BaseUserResponse} approvedBy - The user that potentially approved the payout request
  * @property {DineroObjectResponse} amount.required - The amount requested to be paid out
+ * @property {string} status - enum:CREATED,APPROVED,DENIED,CANCELLED - The current status of the payout request
+ * @property {string} pdf - The PDF of the payout request
  */
-interface BoilerPayoutRequestResponse extends BaseResponse {
+export interface BasePayoutRequestResponse extends BaseResponse {
   requestedBy: BaseUserResponse,
   approvedBy?: BaseUserResponse,
   amount: DineroObjectResponse,
-}
-
-/**
- * @typedef {allOf|BoilerPayoutRequestResponse} BasePayoutRequestResponse
- * @property {string} status - The current status of the payout request
- */
-export interface BasePayoutRequestResponse extends BoilerPayoutRequestResponse {
   status?: PayoutRequestState,
+  pdf?: string,
 }
 
 /**
@@ -51,14 +47,14 @@ export interface PayoutRequestStatusResponse extends BaseResponse {
 }
 
 /**
- * @typedef {allOf|BoilerPayoutRequestResponse} PayoutRequestResponse
+ * @typedef {allOf|BasePayoutRequestResponse} PayoutRequestResponse
  * @property {Array<PayoutRequestStatusResponse>} status.required - Statuses of this
  * payout response over time
  * @property {string} bankAccountNumber.required - Bank account number
  * @property {string} bankAccountName.required - Name of the account owner
  */
-export interface PayoutRequestResponse extends BoilerPayoutRequestResponse {
-  status: PayoutRequestStatusResponse[],
+export interface PayoutRequestResponse extends BasePayoutRequestResponse {
+  statuses: PayoutRequestStatusResponse[],
   bankAccountNumber: string,
   bankAccountName: string,
 }

--- a/src/service/payout-request-service.ts
+++ b/src/service/payout-request-service.ts
@@ -92,6 +92,7 @@ export default class PayoutRequestService {
       requestedBy: parseUserToBaseResponse(req.requestedBy, true),
       approvedBy: req.approvedBy == null ? undefined : parseUserToBaseResponse(req.approvedBy, true),
       status,
+      pdf: req.pdf ? req.pdf.downloadName : undefined,
     };
   }
 
@@ -107,7 +108,7 @@ export default class PayoutRequestService {
         firstName: req.approvedBy.firstName,
         lastName: req.approvedBy.lastName,
       },
-      status: req.payoutRequestStatus.map((status): PayoutRequestStatusResponse => ({
+      statuses: req.payoutRequestStatus.map((status): PayoutRequestStatusResponse => ({
         id: status.id,
         createdAt: status.createdAt.toISOString(),
         updatedAt: status.updatedAt.toISOString(),
@@ -195,7 +196,7 @@ export default class PayoutRequestService {
     id: number, state: PayoutRequestState,
   ) {
     const payoutRequest = await PayoutRequestService.getSinglePayoutRequest(id);
-    const currentStates = payoutRequest.status.map((s) => s.state as PayoutRequestState);
+    const currentStates = payoutRequest.statuses.map((s) => s.state as PayoutRequestState);
     const allStatuses = Object.values(PayoutRequestState);
 
     if (!allStatuses.includes(state)) throw Error(`unknown status: ${state}.`);

--- a/test/unit/controller/payout-request-controller.ts
+++ b/test/unit/controller/payout-request-controller.ts
@@ -529,7 +529,7 @@ describe('PayoutRequestController', () => {
 
       const validation = ctx.specification.validateModel('PayoutRequestResponse', payoutRequest, false, true);
       expect(validation.valid).to.be.true;
-      expect(payoutRequest.status.length).to.equal(before.payoutRequestStatus.length + 1);
+      expect(payoutRequest.statuses.length).to.equal(before.payoutRequestStatus.length + 1);
     });
 
     it("should return 403 if admin tries to cancel someone else's payout request", async () => {
@@ -567,7 +567,7 @@ describe('PayoutRequestController', () => {
       expect(res.status).to.equal(200);
 
       const payoutRequest = res.body as PayoutRequestResponse;
-      expect(payoutRequest.status.length).to.equal(before.payoutRequestStatus.length + 1);
+      expect(payoutRequest.statuses.length).to.equal(before.payoutRequestStatus.length + 1);
     });
 
     it('should return 404 if payout request does not exist', async () => {

--- a/test/unit/service/payout-request-service.ts
+++ b/test/unit/service/payout-request-service.ts
@@ -302,7 +302,7 @@ describe('PayoutRequestService', () => {
 
       const payoutRequest = await PayoutRequestService
         .updateStatus(id, PayoutRequestState.CREATED, user);
-      expect(payoutRequest.status.length).to.equal(1);
+      expect(payoutRequest.statuses.length).to.equal(1);
       expect(payoutRequest.statuses[0].state).to.equal(PayoutRequestState.CREATED);
       expect(payoutRequest.status).to.equal(PayoutRequestState.CREATED);
       expect(payoutRequest.approvedBy).to.be.undefined;
@@ -314,7 +314,7 @@ describe('PayoutRequestService', () => {
 
       const payoutRequest = await PayoutRequestService
         .updateStatus(id, PayoutRequestState.CANCELLED, user);
-      expect(payoutRequest.status.length).to.equal(2);
+      expect(payoutRequest.statuses.length).to.equal(2);
       expect(payoutRequest.statuses[1].state).to.equal(PayoutRequestState.CANCELLED);
       expect(payoutRequest.status).to.equal(PayoutRequestState.CANCELLED);
       expect(payoutRequest.approvedBy).to.be.undefined;
@@ -326,7 +326,7 @@ describe('PayoutRequestService', () => {
 
       const payoutRequest = await PayoutRequestService
         .updateStatus(id, PayoutRequestState.DENIED, user);
-      expect(payoutRequest.status.length).to.equal(2);
+      expect(payoutRequest.statuses.length).to.equal(2);
       expect(payoutRequest.statuses[1].state).to.equal(PayoutRequestState.DENIED);
       expect(payoutRequest.status).to.equal(PayoutRequestState.DENIED);
       expect(payoutRequest.approvedBy).to.be.undefined;
@@ -338,7 +338,7 @@ describe('PayoutRequestService', () => {
 
       const payoutRequest = await PayoutRequestService
         .updateStatus(id, PayoutRequestState.APPROVED, user);
-      expect(payoutRequest.status.length).to.equal(2);
+      expect(payoutRequest.statuses.length).to.equal(2);
       expect(payoutRequest.statuses[1].state).to.equal(PayoutRequestState.APPROVED);
       expect(payoutRequest.status).to.equal(PayoutRequestState.APPROVED);
       expect(payoutRequest.approvedBy).to.not.be.undefined;

--- a/test/unit/service/payout-request-service.ts
+++ b/test/unit/service/payout-request-service.ts
@@ -201,8 +201,9 @@ describe('PayoutRequestService', () => {
         .equal(ctx.validPayoutRequestRequest.bankAccountNumber);
       expect(payoutRequest.bankAccountName).to
         .equal(ctx.validPayoutRequestRequest.bankAccountName);
-      expect(payoutRequest.status.length).to.equal(1);
-      expect(payoutRequest.status[0].state).to.equal(PayoutRequestState.CREATED);
+      expect(payoutRequest.statuses.length).to.equal(1);
+      expect(payoutRequest.statuses[0].state).to.equal(PayoutRequestState.CREATED);
+      expect(payoutRequest.status).to.equal(PayoutRequestState.CREATED);
       expect(payoutRequest.requestedBy.id).to.equal(user.id);
     });
   });
@@ -302,7 +303,8 @@ describe('PayoutRequestService', () => {
       const payoutRequest = await PayoutRequestService
         .updateStatus(id, PayoutRequestState.CREATED, user);
       expect(payoutRequest.status.length).to.equal(1);
-      expect(payoutRequest.status[0].state).to.equal(PayoutRequestState.CREATED);
+      expect(payoutRequest.statuses[0].state).to.equal(PayoutRequestState.CREATED);
+      expect(payoutRequest.status).to.equal(PayoutRequestState.CREATED);
       expect(payoutRequest.approvedBy).to.be.undefined;
     });
 
@@ -313,7 +315,8 @@ describe('PayoutRequestService', () => {
       const payoutRequest = await PayoutRequestService
         .updateStatus(id, PayoutRequestState.CANCELLED, user);
       expect(payoutRequest.status.length).to.equal(2);
-      expect(payoutRequest.status[1].state).to.equal(PayoutRequestState.CANCELLED);
+      expect(payoutRequest.statuses[1].state).to.equal(PayoutRequestState.CANCELLED);
+      expect(payoutRequest.status).to.equal(PayoutRequestState.CANCELLED);
       expect(payoutRequest.approvedBy).to.be.undefined;
     });
 
@@ -324,7 +327,8 @@ describe('PayoutRequestService', () => {
       const payoutRequest = await PayoutRequestService
         .updateStatus(id, PayoutRequestState.DENIED, user);
       expect(payoutRequest.status.length).to.equal(2);
-      expect(payoutRequest.status[1].state).to.equal(PayoutRequestState.DENIED);
+      expect(payoutRequest.statuses[1].state).to.equal(PayoutRequestState.DENIED);
+      expect(payoutRequest.status).to.equal(PayoutRequestState.DENIED);
       expect(payoutRequest.approvedBy).to.be.undefined;
     });
 
@@ -335,7 +339,8 @@ describe('PayoutRequestService', () => {
       const payoutRequest = await PayoutRequestService
         .updateStatus(id, PayoutRequestState.APPROVED, user);
       expect(payoutRequest.status.length).to.equal(2);
-      expect(payoutRequest.status[1].state).to.equal(PayoutRequestState.APPROVED);
+      expect(payoutRequest.statuses[1].state).to.equal(PayoutRequestState.APPROVED);
+      expect(payoutRequest.status).to.equal(PayoutRequestState.APPROVED);
       expect(payoutRequest.approvedBy).to.not.be.undefined;
       expect(payoutRequest.approvedBy.id).to.equal(user.id);
 


### PR DESCRIPTION
# Description
Refactors the `payout-request-service` and fixes some bugs

@Yoronex in the invoice setup we use an extra column, here we use a subquery to filter on current states. What is the better setup? Since the invoice needed a migration I suggest not to change it.

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_
