### PR TITLE
feat: separate invoice-transaction relation to support debit and credit invoices

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -87,6 +87,7 @@ import { ServerSettings1722083254200 } from '../migrations/1722083254200-server-
 import { PosUsers1722084520361 } from '../migrations/1722084520361-pos-users';
 import { InvoiceRework1622118077157 } from '../migrations/1722118077157-invoice-rework';
 import InvoiceStatusSubscriber from '../subscriber/invoice-status-subscriber';
+import { InvoiceDebitorCreditor1722598638179 } from '../migrations/1722598638179-invoice-debitor-creditor';
 
 // We need to load the dotenv to prevent the env from being undefined.
 dotenv.config();
@@ -115,6 +116,7 @@ const options: DataSourceOptions = {
     PosUsers1722084520361,
     WriteOffs1722004753128,
     InvoiceRework1622118077157,
+    InvoiceDebitorCreditor1722598638179,
   ],
   extra: {
     authPlugins: {

--- a/src/entity/transactions/sub-transaction-row.ts
+++ b/src/entity/transactions/sub-transaction-row.ts
@@ -43,7 +43,11 @@ export default class SubTransactionRow extends BaseEntity {
 
   @ManyToOne(() => Invoice, { nullable: true })
   @JoinColumn()
-  public invoice?: Invoice;
+  public debitInvoice?: Invoice;
+
+  @ManyToOne(() => Invoice, { nullable: true })
+  @JoinColumn()
+  public creditInvoice?: Invoice;
 
   @ManyToOne(() => SubTransaction,
     (subTransaction) => subTransaction.subTransactionRows,

--- a/src/migrations/1722598638179-invoice-debitor-creditor.ts
+++ b/src/migrations/1722598638179-invoice-debitor-creditor.ts
@@ -1,0 +1,110 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { MigrationInterface, QueryRunner, TableColumn, TableForeignKey } from 'typeorm';
+
+export class InvoiceDebitorCreditor1722598638179 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('sub_transaction_row');
+
+    await queryRunner.addColumns(table, [new TableColumn({
+      name: 'debitInvoiceId',
+      type: 'integer',
+      isNullable: true,
+    }), new TableColumn({
+      name: 'creditInvoiceId',
+      type: 'integer',
+      isNullable: true,
+    })]);
+    await queryRunner.createForeignKeys(table, [
+      new TableForeignKey({
+        columnNames: ['debitInvoiceId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'invoice',
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        columnNames: ['creditInvoiceId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'invoice',
+        onDelete: 'RESTRICT',
+      }),
+    ]);
+
+    await queryRunner.query(`
+UPDATE sub_transaction_row
+SET debitInvoiceID = invoiceId
+WHERE EXISTS (
+  SELECT *
+  FROM sub_transaction_row
+  INNER JOIN invoice ON invoice.id = sub_transaction_row.invoiceId
+  INNER JOIN transfer ON transfer.id = invoice.transferId
+  WHERE transfer.toId IS NULL
+)`);
+    //     await queryRunner.query(`
+    // UPDATE sub_transaction_row
+    // INNER JOIN invoice ON invoice.id = sub_transaction_row.invoiceId
+    // INNER JOIN transfer ON transfer.id = invoice.transferId
+    // SET creditInvoiceId = invoiceId
+    // WHERE transfer.toId IS NOT NULL`);
+    await queryRunner.query(`
+UPDATE sub_transaction_row
+SET creditInvoiceId = invoiceId
+WHERE EXISTS (
+  SELECT *
+  FROM sub_transaction_row
+  INNER JOIN invoice ON invoice.id = sub_transaction_row.invoiceId
+  INNER JOIN transfer ON transfer.id = invoice.transferId
+  WHERE transfer.toId IS NOT NULL
+)`);
+
+    const foreignKey = table.foreignKeys.find((fk) => fk.columnNames.includes('invoiceId'));
+    await queryRunner.dropForeignKey(table, foreignKey);
+
+    await queryRunner.dropColumn(table, 'invoiceId');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('sub_transaction_row');
+    await queryRunner.addColumn(table, new TableColumn({
+      name: 'invoiceId',
+      type: 'integer',
+      isNullable: true,
+    }));
+    await queryRunner.createForeignKey(table,
+      new TableForeignKey({
+        columnNames: ['invoiceId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'invoice',
+        onDelete: 'RESTRICT',
+      }));
+
+    await queryRunner.query(`
+UPDATE sub_transaction_row
+SET invoiceId = debitInvoiceId
+WHERE debitInvoiceId IS NOT NULL`);
+    await queryRunner.query(`
+UPDATE sub_transaction_row
+SET invoiceId = creditInvoiceId
+WHERE creditInvoiceId IS NOT NULL`);
+
+    const foreignKeys = table.foreignKeys.filter((fk) => fk.columnNames.includes('debitInvoiceId') || fk.columnNames.includes('creditInvoiceId'));
+    await queryRunner.dropForeignKeys(table, foreignKeys);
+
+    await queryRunner.dropColumns(table, ['debitInvoiceId', 'creditInvoiceId']);
+  }
+}

--- a/src/service/vat-group-service.ts
+++ b/src/service/vat-group-service.ts
@@ -155,7 +155,7 @@ export default class VatGroupService {
   /**
    * Calculate the collected VAT for the periodic declaration at the tax authorization.
    * The values are calculated as follows (based on rules of the Dutch tax
-   * athorization (De Belastingdienst):
+   * authorization (De Belastingdienst):
    * Every product has a VAT-included price. From this price (e.g. including 21% VAT),
    * we derive the absolute VAT amount by multiplying this incl-price by 21 and then
    * dividing by 121. Of course, we also multiply this number by the number of times
@@ -195,7 +195,7 @@ export default class VatGroupService {
       ])
       .innerJoin(ProductRevision, 'product', 'str.productRevision = product.revision AND str.productProductId = product.productId')
       .innerJoin(VatGroup, 'vatgroup', 'product.vatId = vatgroup.id')
-      .where('str.invoiceId IS NULL')
+      .where('str.debitInvoiceId IS NULL')
       .andWhere(`${process.env.TYPEORM_CONNECTION === 'sqlite'
         ? 'Strftime(\'%Y\', str.createdAt)'
         : 'DATE_FORMAT(str.createdAt, \'%Y\')'} = :year`, { year: params.year.toString() })

--- a/test/unit/controller/invoice-controller.ts
+++ b/test/unit/controller/invoice-controller.ts
@@ -364,12 +364,15 @@ describe('InvoiceController', async () => {
             reference: 'BAC-41',
           };
 
-          const invoiceTransactions = await Transaction.find({ where: { id: In(tIds) }, relations: ['subTransactions', 'subTransactions.subTransactionRows', 'subTransactions.subTransactionRows.invoice'] });
+          const invoiceTransactions = await Transaction.find({
+            where: { id: In(tIds) },
+            relations: { subTransactions: { subTransactionRows: { debitInvoice: true } } },
+          });
           const subIDs: number[] = [];
           invoiceTransactions.forEach((t) => {
             t.subTransactions.forEach((tSub) => {
               tSub.subTransactionRows.forEach((tSubRow) => {
-                if (tSubRow.invoice !== undefined) subIDs.push(tSubRow.id);
+                if (tSubRow.debitInvoice !== undefined) subIDs.push(tSubRow.id);
               });
             });
           });

--- a/test/unit/service/invoice-service.ts
+++ b/test/unit/service/invoice-service.ts
@@ -458,16 +458,15 @@ describe('InvoiceService', () => {
             where: {
               id: In(transactions.map((transaction) => transaction.tId)),
             },
-            relations: [
-              'subTransactions',
-              'subTransactions.subTransactionRows',
-              'subTransactions.subTransactionRows.invoice',
-            ],
+            relations: {
+              subTransactions: { subTransactionRows: { creditInvoice: true, debitInvoice: true } },
+            },
           });
           linkedTransactions.forEach((t) => {
             t.subTransactions.forEach((tSub) => {
               tSub.subTransactionRows.forEach((tSubRow) => {
-                expect(tSubRow.invoice.id).to.equal(invoice.id);
+                expect(tSubRow.debitInvoice.id).to.equal(invoice.id);
+                expect(tSubRow.creditInvoice).to.be.null;
               });
             });
           });
@@ -539,8 +538,11 @@ describe('InvoiceService', () => {
         expect(creditorBalance.amount.amount).to.equal(0);
         expect(otherCreditorBalance.amount.amount).to.equal(transactionB.totalPriceInclVat.amount);
 
-        const subtrans = await SubTransaction.find({ where: { to: { id: otherCreditor.id } }, relations: ['subTransactionRows', 'subTransactionRows.invoice'] });
-        const linkedInvoice = subtrans.map((st) => st.subTransactionRows.map((str) => str.invoice?.id)).flat(1);
+        const subtrans = await SubTransaction.find({
+          where: { to: { id: otherCreditor.id } },
+          relations: { subTransactionRows: { creditInvoice: true } },
+        });
+        const linkedInvoice = subtrans.map((st) => st.subTransactionRows.map((str) => str.creditInvoice?.id)).flat(1);
 
         const entryValue = invoice.invoiceEntries.reduce((acc, curr) => acc + curr.priceInclVat.getAmount() * curr.amount, 0);
         expect(entryValue).to.equal(transactionA.totalPriceInclVat.amount);
@@ -820,16 +822,15 @@ describe('InvoiceService', () => {
             where: {
               id: In(transactions.map((transaction) => transaction.tId)),
             },
-            relations: [
-              'subTransactions',
-              'subTransactions.subTransactionRows',
-              'subTransactions.subTransactionRows.invoice',
-            ],
+            relations: {
+              subTransactions: { subTransactionRows: { debitInvoice: true, creditInvoice: true } },
+            },
           });
           invoiceTransactions.forEach((t) => {
             t.subTransactions.forEach((tSub) => {
               tSub.subTransactionRows.forEach((tSubRow) => {
-                expect(tSubRow.invoice.id).to.equal(invoice.id);
+                expect(tSubRow.debitInvoice.id).to.equal(invoice.id);
+                expect(tSubRow.creditInvoice).to.be.null;
               });
             });
           });
@@ -844,16 +845,15 @@ describe('InvoiceService', () => {
             where: {
               id: In(transactions.map((transaction) => transaction.tId)),
             },
-            relations: [
-              'subTransactions',
-              'subTransactions.subTransactionRows',
-              'subTransactions.subTransactionRows.invoice',
-            ],
+            relations: {
+              subTransactions: { subTransactionRows: { debitInvoice: true, creditInvoice: true } },
+            },
           });
           invoiceTransactions.forEach((t) => {
             t.subTransactions.forEach((tSub) => {
               tSub.subTransactionRows.forEach((tSubRow) => {
-                expect(tSubRow.invoice).to.equal(null);
+                expect(tSubRow.debitInvoice).to.be.null;
+                expect(tSubRow.creditInvoice).to.be.null;
               });
             });
           });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Changes the relation between invoices and subtransactionrows, such that every subtransactionrow can have both a debit invoice and a credit invoice. This was not possible before, but fortunately we have not yet encountered this issue in production (yet).

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Step one of https://github.com/GEWIS/sudosos-backend/issues/197.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_
