### PR TITLE
feat: split StripePaymentIntent and StripeDeposit entities

### DIFF
--- a/src/controller/response/stripe-response.ts
+++ b/src/controller/response/stripe-response.ts
@@ -19,7 +19,7 @@
 
 import BaseResponse from './base-response';
 import { DineroObjectResponse } from './dinero-response';
-import { StripeDepositState } from '../../entity/deposit/stripe-deposit-status';
+import { StripePaymentIntentState } from '../../entity/stripe/stripe-payment-intent-status';
 import { BaseUserResponse } from './user-response';
 
 /**
@@ -50,7 +50,7 @@ export interface StripePaymentIntentResponse extends BaseResponse {
  * @property {integer} state.required - State of the Stripe deposit. It can be 1 ('CREATED'), 2 ('PROCESSING'), 3 ('SUCCEEDED'), or 4 ('FAILED')
  */
 export interface StripeDepositStatusResponse extends BaseResponse {
-  state: StripeDepositState;
+  state: StripePaymentIntentState;
 }
 
 /**

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -50,8 +50,8 @@ import InvoiceStatus from '../entity/invoices/invoice-status';
 import BaseFile from '../entity/file/base-file';
 import ProductImage from '../entity/file/product-image';
 import BannerImage from '../entity/file/banner-image';
-import StripeDeposit from '../entity/deposit/stripe-deposit';
-import StripeDepositStatus from '../entity/deposit/stripe-deposit-status';
+import StripeDeposit from '../entity/stripe/stripe-deposit';
+import StripePaymentIntentStatus from '../entity/stripe/stripe-payment-intent-status';
 import PayoutRequest from '../entity/transactions/payout-request';
 import PayoutRequestStatus from '../entity/transactions/payout-request-status';
 import LDAPAuthenticator from '../entity/authenticator/ldap-authenticator';
@@ -88,6 +88,8 @@ import { PosUsers1722084520361 } from '../migrations/1722084520361-pos-users';
 import { InvoiceRework1622118077157 } from '../migrations/1722118077157-invoice-rework';
 import InvoiceStatusSubscriber from '../subscriber/invoice-status-subscriber';
 import { InvoiceDebitorCreditor1722598638179 } from '../migrations/1722598638179-invoice-debitor-creditor';
+import StripePaymentIntent from '../entity/stripe/stripe-payment-intent';
+import { StripePaymentIntents1722869409448 } from '../migrations/1722869409448-stripe-payment-intents';
 
 // We need to load the dotenv to prevent the env from being undefined.
 dotenv.config();
@@ -117,6 +119,7 @@ const options: DataSourceOptions = {
     WriteOffs1722004753128,
     InvoiceRework1622118077157,
     InvoiceDebitorCreditor1722598638179,
+    StripePaymentIntents1722869409448,
   ],
   extra: {
     authPlugins: {
@@ -136,7 +139,8 @@ const options: DataSourceOptions = {
     PointOfSaleRevision,
     Transfer,
     StripeDeposit,
-    StripeDepositStatus,
+    StripePaymentIntent,
+    StripePaymentIntentStatus,
     PayoutRequest,
     PayoutRequestPdf,
     PayoutRequestStatus,

--- a/src/entity/stripe/stripe-deposit.ts
+++ b/src/entity/stripe/stripe-deposit.ts
@@ -1,0 +1,42 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {
+  Column, Entity, JoinColumn, ManyToOne, OneToOne,
+} from 'typeorm';
+import { Dinero } from 'dinero.js';
+import BaseEntity from '../base-entity';
+import User from '../user/user';
+import DineroTransformer from '../transformer/dinero-transformer';
+import Transfer from '../transactions/transfer';
+import StripePaymentIntent from './stripe-payment-intent';
+
+@Entity()
+export default class StripeDeposit extends BaseEntity {
+  @ManyToOne(() => User, { nullable: false, eager: true, onDelete: 'CASCADE' })
+  @JoinColumn()
+  public to: User;
+
+  @OneToOne(() => Transfer, { nullable: true, onDelete: 'CASCADE' })
+  @JoinColumn()
+  public transfer?: Transfer;
+
+  @OneToOne(() => StripePaymentIntent, { eager: true, onDelete: 'RESTRICT' })
+  @JoinColumn()
+  public stripePaymentIntent: StripePaymentIntent;
+}

--- a/src/entity/stripe/stripe-payment-intent-status.ts
+++ b/src/entity/stripe/stripe-payment-intent-status.ts
@@ -20,10 +20,10 @@ import {
   Column, Entity, ManyToOne,
 } from 'typeorm';
 // eslint-disable-next-line import/no-cycle
-import StripeDeposit from './stripe-deposit';
 import BaseEntity from '../base-entity';
+import StripePaymentIntent from './stripe-payment-intent';
 
-export enum StripeDepositState {
+export enum StripePaymentIntentState {
   CREATED = 1,
   PROCESSING = 2,
   SUCCEEDED = 3,
@@ -31,10 +31,10 @@ export enum StripeDepositState {
 }
 
 @Entity()
-export default class StripeDepositStatus extends BaseEntity {
-  @ManyToOne(() => StripeDeposit, (deposit) => deposit.depositStatus, { nullable: false })
-  public deposit: StripeDeposit;
+export default class StripePaymentIntentStatus extends BaseEntity {
+  @ManyToOne(() => StripePaymentIntent, (intent) => intent.paymentIntentStatuses, { nullable: false })
+  public stripePaymentIntent: StripePaymentIntent;
 
   @Column()
-  public state: StripeDepositState;
+  public state: StripePaymentIntentState;
 }

--- a/src/entity/stripe/stripe-payment-intent.ts
+++ b/src/entity/stripe/stripe-payment-intent.ts
@@ -15,33 +15,20 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
-import {
-  Column, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne,
-} from 'typeorm';
-import { Dinero } from 'dinero.js';
 import BaseEntity from '../base-entity';
-import User from '../user/user';
+import { Column, Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
+import StripePaymentIntentStatus from './stripe-payment-intent-status';
 import DineroTransformer from '../transformer/dinero-transformer';
-// eslint-disable-next-line import/no-cycle
-import StripeDepositStatus from './stripe-deposit-status';
-import Transfer from '../transactions/transfer';
+import { Dinero } from 'dinero.js';
+import StripeDeposit from './stripe-deposit';
 
 @Entity()
-export default class StripeDeposit extends BaseEntity {
-  @ManyToOne(() => User, { nullable: false, eager: true })
-  @JoinColumn()
-  public to: User;
-
-  @OneToOne(() => Transfer, { nullable: true })
-  @JoinColumn()
-  public transfer?: Transfer;
-
-  @OneToMany(() => StripeDepositStatus,
-    (depositStatus) => depositStatus.deposit,
+export default class StripePaymentIntent extends BaseEntity {
+  @OneToMany(() => StripePaymentIntentStatus,
+    (paymentStatus) => paymentStatus.stripePaymentIntent,
     { cascade: true, eager: true })
   @JoinColumn()
-  public depositStatus: StripeDepositStatus[];
+  public paymentIntentStatuses: StripePaymentIntentStatus[];
 
   @Column({ unique: true })
   public stripeId: string;
@@ -51,4 +38,7 @@ export default class StripeDeposit extends BaseEntity {
     transformer: DineroTransformer.Instance,
   })
   public amount: Dinero;
+
+  @OneToOne(() => StripeDeposit, (s) => s.stripePaymentIntent, { nullable: true })
+  public deposit: StripeDeposit | null;
 }

--- a/src/entity/transactions/transfer.ts
+++ b/src/entity/transactions/transfer.ts
@@ -24,7 +24,7 @@ import BaseEntity from '../base-entity';
 import User from '../user/user';
 import DineroTransformer from '../transformer/dinero-transformer';
 import PayoutRequest from './payout-request';
-import StripeDeposit from '../deposit/stripe-deposit';
+import StripeDeposit from '../stripe/stripe-deposit';
 import Invoice from '../invoices/invoice';
 import Fine from '../fine/fine';
 import UserFineGroup from '../fine/userFineGroup';

--- a/src/migrations/1722869409448-stripe-payment-intents.ts
+++ b/src/migrations/1722869409448-stripe-payment-intents.ts
@@ -1,0 +1,191 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { MigrationInterface, QueryRunner, Table, TableColumn, TableForeignKey } from 'typeorm';
+
+export class StripePaymentIntents1722869409448 implements MigrationInterface {
+  private DEPOSIT_TABLE_NAME = 'stripe_deposit';
+
+  private PAYMENT_INTENT_TABLE_NAME = 'stripe_payment_intent';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.renameTable(this.DEPOSIT_TABLE_NAME, this.PAYMENT_INTENT_TABLE_NAME);
+    await queryRunner.createTable(new Table({
+      name: this.DEPOSIT_TABLE_NAME,
+      columns: [
+        {
+          name: 'createdAt',
+          type: 'datetime(6)',
+          default: 'current_timestamp',
+          isNullable: false,
+        },
+        {
+          name: 'updatedAt',
+          type: 'datetime(6)',
+          default: 'current_timestamp',
+          onUpdate: 'current_timestamp',
+          isNullable: false,
+        },
+        {
+          name: 'version',
+          type: 'integer',
+          isNullable: false,
+        },
+        {
+          name: 'id',
+          type: 'integer',
+          isPrimary: true,
+          isGenerated: true,
+          generationStrategy: 'increment',
+        },
+        {
+          name: 'toId',
+          type: 'integer',
+          isNullable: false,
+        },
+        {
+          name: 'transferId',
+          type: 'integer',
+          isNullable: true,
+        },
+        {
+          name: 'stripePaymentIntentId',
+          type: 'integer',
+          isNullable: false,
+        },
+      ],
+    }));
+
+    await queryRunner.createForeignKeys(this.DEPOSIT_TABLE_NAME, [
+      new TableForeignKey({
+        columnNames: ['toId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'user',
+        onDelete: 'CASCADE',
+      }),
+      new TableForeignKey({
+        columnNames: ['transferId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'transfer',
+        onDelete: 'CASCADE',
+      }),
+      new TableForeignKey({
+        columnNames: ['stripePaymentIntentId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: this.PAYMENT_INTENT_TABLE_NAME,
+        onDelete: 'RESTRICT',
+      }),
+    ]);
+
+    await queryRunner.query(`
+INSERT INTO ${this.DEPOSIT_TABLE_NAME} (id, createdAt, updatedAt, version, toId, transferId, stripePaymentIntentId)
+SELECT id, createdAt, updatedAt, version, toId, transferId, id FROM ${this.PAYMENT_INTENT_TABLE_NAME}
+`);
+
+    const table = await queryRunner.getTable(this.PAYMENT_INTENT_TABLE_NAME);
+    const foreignKeys = table.foreignKeys.filter((fk) => fk.columnNames.some((n) => ['toId', 'transferId'].includes(n)));
+    await queryRunner.dropForeignKeys(this.PAYMENT_INTENT_TABLE_NAME, foreignKeys);
+
+    await queryRunner.dropColumns(this.PAYMENT_INTENT_TABLE_NAME, ['toId', 'transferId']);
+
+    await queryRunner.renameTable('stripe_deposit_status', 'stripe_payment_intent_status');
+    await queryRunner.changeColumn('stripe_payment_intent_status', 'depositId', new TableColumn({
+      name: 'stripePaymentIntentId',
+      type: 'integer',
+      isNullable: false,
+    }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.changeColumn('stripe_payment_intent_status', 'stripePaymentIntentId', new TableColumn({
+      name: 'depositId',
+      type: 'integer',
+      isNullable: false,
+    }));
+    await queryRunner.renameTable('stripe_payment_intent_status', 'stripe_deposit_status');
+
+    const depositTable = await queryRunner.getTable(this.DEPOSIT_TABLE_NAME);
+    const foreignKeys = await depositTable.foreignKeys.filter((fk) => fk.referencedTableName === this.PAYMENT_INTENT_TABLE_NAME);
+    await queryRunner.dropForeignKeys(depositTable, foreignKeys);
+
+    const paymentIntentTable = await queryRunner.getTable(this.PAYMENT_INTENT_TABLE_NAME);
+    const paymentIntentStatusTable = await queryRunner.getTable('stripe_deposit_status');
+    await queryRunner.dropForeignKeys(paymentIntentStatusTable, paymentIntentStatusTable.foreignKeys);
+    await queryRunner.dropForeignKeys(paymentIntentTable, paymentIntentTable.foreignKeys);
+    await queryRunner.addColumns(this.PAYMENT_INTENT_TABLE_NAME, [
+      new TableColumn(
+        {
+          name: 'toId',
+          type: 'integer',
+          isNullable: true,
+        }),
+      new TableColumn({
+        name: 'transferId',
+        type: 'integer',
+        isNullable: true,
+      }),
+    ]);
+    await queryRunner.createForeignKeys(this.PAYMENT_INTENT_TABLE_NAME, [
+      ...paymentIntentTable.foreignKeys,
+      new TableForeignKey({
+        columnNames: ['toId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'user',
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        columnNames: ['transferId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'transfer',
+        onDelete: 'RESTRICT',
+      }),
+    ]);
+    await queryRunner.createForeignKeys(paymentIntentStatusTable, paymentIntentStatusTable.foreignKeys);
+
+    await queryRunner.query(`
+UPDATE ${this.PAYMENT_INTENT_TABLE_NAME}
+SET
+  toId=(SELECT toId FROM ${this.DEPOSIT_TABLE_NAME} WHERE ${this.DEPOSIT_TABLE_NAME}.id = ${this.PAYMENT_INTENT_TABLE_NAME}.id),
+  transferId=(SELECT transferId FROM ${this.DEPOSIT_TABLE_NAME} WHERE ${this.DEPOSIT_TABLE_NAME}.id = ${this.PAYMENT_INTENT_TABLE_NAME}.id)
+`);
+
+    await queryRunner.changeColumn(
+      this.PAYMENT_INTENT_TABLE_NAME,
+      'toId',
+      new TableColumn(
+        {
+          name: 'toId',
+          type: 'integer',
+          isNullable: false,
+        }),
+    );
+    await queryRunner.changeColumn(
+      this.PAYMENT_INTENT_TABLE_NAME,
+      'transferId',
+      new TableColumn({
+        name: 'transferId',
+        type: 'integer',
+        isNullable: true,
+      }),
+    );
+
+    const table = await queryRunner.getTable(this.DEPOSIT_TABLE_NAME);
+    await queryRunner.dropForeignKeys(this.DEPOSIT_TABLE_NAME, table.foreignKeys);
+    await queryRunner.dropTable(this.DEPOSIT_TABLE_NAME);
+    await queryRunner.renameTable(this.PAYMENT_INTENT_TABLE_NAME, this.DEPOSIT_TABLE_NAME);
+  }
+}

--- a/src/service/transfer-service.ts
+++ b/src/service/transfer-service.ts
@@ -153,15 +153,16 @@ export default class TransferService {
       whereOptions = whereClause;
     }
 
-    const options: FindManyOptions = {
+    const options: FindManyOptions<Transfer> = {
       where: whereOptions,
-      relations: ['from', 'to',
-        'invoice', 'invoice.invoiceStatus',
-        'deposit', 'deposit.depositStatus',
-        'payoutRequest', 'payoutRequest.payoutRequestStatus', 'payoutRequest.requestedBy',
-        'fine', 'fine.userFineGroup', 'fine.userFineGroup.user',
-        'waivedFines', 'waivedFines.fines', 'waivedFines.fines.userFineGroup', 'vat', 'writeOff', 'invoice.latestStatus',
-      ],
+      relations: {
+        from: true, to: true, vat: true, writeOff: true,
+        invoice: { invoiceStatus: true, latestStatus: true },
+        deposit: { stripePaymentIntent: { paymentIntentStatuses: true } },
+        payoutRequest: { payoutRequestStatus: true, requestedBy: true },
+        fine: { userFineGroup: { user: true } },
+        waivedFines: { fines: { userFineGroup: true } },
+      },
       take,
       skip,
       order: { createdAt: 'DESC' },

--- a/test/seed.ts
+++ b/test/seed.ts
@@ -37,8 +37,8 @@ import ProductImage from '../src/entity/file/product-image';
 import Banner from '../src/entity/banner';
 import BannerImage from '../src/entity/file/banner-image';
 import { BANNER_IMAGE_LOCATION, PRODUCT_IMAGE_LOCATION } from '../src/files/storage';
-import StripeDeposit from '../src/entity/deposit/stripe-deposit';
-import StripeDepositStatus, { StripeDepositState } from '../src/entity/deposit/stripe-deposit-status';
+import StripeDeposit from '../src/entity/stripe/stripe-deposit';
+import StripePaymentIntentStatus, { StripePaymentIntentState } from '../src/entity/stripe/stripe-payment-intent-status';
 import DineroTransformer from '../src/entity/transformer/dinero-transformer';
 import PayoutRequest from '../src/entity/transactions/payout-request';
 import PayoutRequestStatus, { PayoutRequestState } from '../src/entity/transactions/payout-request-status';
@@ -65,6 +65,7 @@ import MemberAuthenticator from '../src/entity/authenticator/member-authenticato
 import Role from '../src/entity/rbac/role';
 import generateBalance from './helpers/test-helpers';
 import WriteOff from '../src/entity/transactions/write-off';
+import StripePaymentIntent from '../src/entity/stripe/stripe-payment-intent';
 
 function getDate(startDate: Date, endDate: Date, i: number): Date {
   const diff = endDate.getTime() - startDate.getTime();
@@ -1072,18 +1073,21 @@ export async function seedStripeDeposits(users: User[]): Promise<{
   for (let i = 0; i < users.length * totalNrOfStatuses + 1; i += 1) {
     const to = users[Math.floor(i / 4)];
     const amount = DineroTransformer.Instance.from(3900);
-    const newDeposit = Object.assign(new StripeDeposit(), {
+    // eslint-disable-next-line no-await-in-loop
+    const stripePaymentIntent = await StripePaymentIntent.save({
       stripeId: `FakeStripeIDDoNotUsePleaseThankYou_${i + 1}`,
-      to,
       amount,
-      depositStatus: [],
+      paymentIntentStatuses: [],
     });
     // eslint-disable-next-line no-await-in-loop
-    await newDeposit.save();
+    const newDeposit = await StripeDeposit.save({
+      stripePaymentIntent,
+      to,
+    });
 
     const succeeded = Math.floor(((i % 8) + 1) / 4) !== 1;
-    const states = [StripeDepositState.CREATED, StripeDepositState.PROCESSING,
-      succeeded ? StripeDepositState.SUCCEEDED : StripeDepositState.FAILED].slice(0, i % 4);
+    const states = [StripePaymentIntentState.CREATED, StripePaymentIntentState.PROCESSING,
+      succeeded ? StripePaymentIntentState.SUCCEEDED : StripePaymentIntentState.FAILED].slice(0, i % 4);
 
     if (succeeded) {
       const transfer = Object.assign(new Transfer(), {
@@ -1094,19 +1098,19 @@ export async function seedStripeDeposits(users: User[]): Promise<{
       });
       await transfer.save();
       newDeposit.transfer = transfer;
-      await newDeposit.save();
+      await StripeDeposit.save(newDeposit);
       transfer.deposit = newDeposit;
       transfers.push(transfer);
     }
 
     const statePromises: Promise<any>[] = [];
     states.forEach((state) => {
-      const newState = Object.assign(new StripeDepositStatus(), {
+      const newState = Object.assign(new StripePaymentIntentStatus(), {
+        stripePaymentIntent,
         state,
-        deposit: newDeposit,
       });
       statePromises.push(newState.save());
-      newDeposit.depositStatus.push(newState);
+      stripePaymentIntent.paymentIntentStatuses.push(newState);
     });
 
     // eslint-disable-next-line no-await-in-loop

--- a/test/unit/controller/stripe-controller.ts
+++ b/test/unit/controller/stripe-controller.ts
@@ -22,7 +22,7 @@ import { json } from 'body-parser';
 import { expect, request } from 'chai';
 import StripeController from '../../../src/controller/stripe-controller';
 import User, { TermsOfServiceStatus, UserType } from '../../../src/entity/user/user';
-import StripeDeposit from '../../../src/entity/deposit/stripe-deposit';
+import StripeDeposit from '../../../src/entity/stripe/stripe-deposit';
 import Database from '../../../src/database/database';
 import { seedStripeDeposits } from '../../seed';
 import TokenHandler from '../../../src/authentication/token-handler';

--- a/test/unit/controller/stripe-webhook-controller.ts
+++ b/test/unit/controller/stripe-webhook-controller.ts
@@ -16,7 +16,7 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import { json } from 'body-parser';
@@ -36,7 +36,7 @@ describe('StripeWebhookController', async (): Promise<void> => {
   let shouldSkip: boolean;
 
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     controller: StripeWebhookController,
@@ -155,9 +155,12 @@ describe('StripeWebhookController', async (): Promise<void> => {
         .post('/stripe/webhook')
         .set('stripe-signature', ctx.signatureHeader)
         .send(ctx.payload);
+      expect(res.status).to.equal(200);
+
+      // Race condition (by design), because the webhook event is and should be handled asynchronously
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
       expect(handleWebhookEventStub).to.have.been.calledOnce;
-      expect(res.status).to.equal(200);
     });
   });
 });

--- a/test/unit/controller/user-controller.ts
+++ b/test/unit/controller/user-controller.ts
@@ -61,7 +61,7 @@ import {
 import UpdateLocalRequest from '../../../src/controller/request/update-local-request';
 import { AcceptTosRequest } from '../../../src/controller/request/accept-tos-request';
 import { CreateUserRequest, UpdateUserRequest } from '../../../src/controller/request/user-request';
-import StripeDeposit from '../../../src/entity/deposit/stripe-deposit';
+import StripeDeposit from '../../../src/entity/stripe/stripe-deposit';
 import { StripeDepositResponse } from '../../../src/controller/response/stripe-response';
 import { TransactionReportResponse } from '../../../src/controller/response/transaction-report-response';
 import { TransactionFilterParameters } from '../../../src/service/transaction-service';


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Creates a separate table of payment intents, so automatic invoices can also use this table and thus all Stripe transactions are handled the same. Depends on https://github.com/GEWIS/sudosos-backend/pull/253.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Step two of https://github.com/GEWIS/sudosos-backend/issues/197.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_
