### PR TITLE
feat: nested product categories

### DIFF
--- a/src/controller/product-category-controller.ts
+++ b/src/controller/product-category-controller.ts
@@ -74,6 +74,7 @@ export default class ProductCategoryController extends BaseController {
    * @operationId getAllProductCategories
    * @tags productCategories - Operations of productcategory controller
    * @security JWT
+   * @param {boolean} onlyRoot.query - Whether to return only root categories
    * @param {integer} take.query - How many product categories the endpoint should return
    * @param {integer} skip.query - How many product categories should be skipped (for pagination)
    * @return {PaginatedProductCategoryResponse} 200 - All existing productcategories
@@ -97,7 +98,9 @@ export default class ProductCategoryController extends BaseController {
     // Handle requestd
     try {
       const productCategories = await ProductCategoryService
-        .getProductCategories({}, { take, skip });
+        .getProductCategories({
+          onlyRoot: req.query.onlyRoot === 'true',
+        }, { take, skip });
       res.json(productCategories);
     } catch (error) {
       this.logger.error('Could not return all product-categories:', error);

--- a/src/controller/product-category-controller.ts
+++ b/src/controller/product-category-controller.ts
@@ -75,6 +75,7 @@ export default class ProductCategoryController extends BaseController {
    * @tags productCategories - Operations of productcategory controller
    * @security JWT
    * @param {boolean} onlyRoot.query - Whether to return only root categories
+   * @param {boolean} onlyLeaf.query - Whether to return only leaf categories
    * @param {integer} take.query - How many product categories the endpoint should return
    * @param {integer} skip.query - How many product categories should be skipped (for pagination)
    * @return {PaginatedProductCategoryResponse} 200 - All existing productcategories
@@ -100,6 +101,7 @@ export default class ProductCategoryController extends BaseController {
       const productCategories = await ProductCategoryService
         .getProductCategories({
           onlyRoot: req.query.onlyRoot === 'true',
+          onlyLeaf: req.query.onlyLeaf === 'true',
         }, { take, skip });
       res.json(productCategories);
     } catch (error) {

--- a/src/controller/request/product-category-request.ts
+++ b/src/controller/request/product-category-request.ts
@@ -16,11 +16,13 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import ProductCategory from '../../entity/product/product-category';
 
 /**
  * @typedef {object} ProductCategoryRequest
- * @property {string} name - Name/label of the productCategory
+ * @property {string} name.required - Name/label of the productCategory
+ * @property {integer} parentCategoryId - ID of the parent product category
  */
-export default interface ProductCategoryRequest {
-  name: string,
+export default interface ProductCategoryRequest extends Pick<ProductCategory, 'name'> {
+  parentCategoryId?: number,
 }

--- a/src/controller/response/product-category-response.ts
+++ b/src/controller/response/product-category-response.ts
@@ -22,9 +22,11 @@ import { PaginationResult } from '../../helpers/pagination';
 /**
  * @typedef {allOf|BaseResponse} ProductCategoryResponse
  * @property {string} name.required - The name of the productCategory.
+ * @property {ProductCategoryResponse} parent - The name of the productCategory.
  */
 export interface ProductCategoryResponse extends BaseResponse {
   name: string,
+  parent?: ProductCategoryResponse,
 }
 
 /**

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -89,6 +89,7 @@ import { InvoiceRework1622118077157 } from '../migrations/1722118077157-invoice-
 import InvoiceStatusSubscriber from '../subscriber/invoice-status-subscriber';
 import StripePaymentIntent from '../entity/stripe/stripe-payment-intent';
 import { StripePaymentIntents1722869409448 } from '../migrations/1722869409448-stripe-payment-intents';
+import { NestedProductCategories1722517212441 } from '../migrations/1722517212441-nested-product-categories';
 
 // We need to load the dotenv to prevent the env from being undefined.
 dotenv.config();
@@ -118,6 +119,7 @@ const options: DataSourceOptions = {
     WriteOffs1722004753128,
     InvoiceRework1622118077157,
     StripePaymentIntents1722869409448,
+    NestedProductCategories1722517212441,
   ],
   extra: {
     authPlugins: {

--- a/src/entity/product/product-category.ts
+++ b/src/entity/product/product-category.ts
@@ -17,7 +17,7 @@
  */
 
 import {
-  Entity, Column, DeleteDateColumn, Tree, TreeChildren, TreeParent,
+  Entity, Column, Tree, TreeChildren, TreeParent,
 } from 'typeorm';
 import BaseEntity from '../base-entity';
 

--- a/src/entity/product/product-category.ts
+++ b/src/entity/product/product-category.ts
@@ -17,7 +17,7 @@
  */
 
 import {
-  Entity, Column,
+  Entity, Column, DeleteDateColumn, Tree, TreeChildren, TreeParent,
 } from 'typeorm';
 import BaseEntity from '../base-entity';
 
@@ -26,6 +26,7 @@ import BaseEntity from '../base-entity';
  * @property {string} name.required - The unique name of the productCategory.
  */
 @Entity()
+@Tree('closure-table')
 export default class ProductCategory extends BaseEntity {
   @Column({
     unique: true,
@@ -33,4 +34,10 @@ export default class ProductCategory extends BaseEntity {
     nullable: false,
   })
   public name: string;
+
+  @TreeChildren()
+  public children: ProductCategory[];
+
+  @TreeParent()
+  public parent: ProductCategory;
 }

--- a/src/migrations/1722517212441-nested-product-categories.ts
+++ b/src/migrations/1722517212441-nested-product-categories.ts
@@ -1,0 +1,55 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from 'typeorm';
+
+export class NestedProductCategories1722517212441 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(new Table({
+      name: 'product_category_closure',
+      columns: [{
+        name: 'id_ancestor',
+        type: 'integer',
+        isNullable: false,
+        isPrimary: true,
+      }, {
+        name: 'id_descendant',
+        type: 'integer',
+        isNullable: false,
+        isPrimary: true,
+      }],
+    }));
+    await queryRunner.createForeignKeys('product_category_closure', [
+      new TableForeignKey({
+        columnNames: ['id_ancestor'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'product_category',
+        onDelete: 'CASCADE',
+      }),
+      new TableForeignKey({
+        columnNames: ['id_descendant'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'product_category',
+        onDelete: 'CASCADE',
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('product_category_closure');
+  }
+}

--- a/src/service/product-category-service.ts
+++ b/src/service/product-category-service.ts
@@ -155,8 +155,12 @@ export default class ProductCategoryService {
    */
   public static async verifyProductCategory(request: ProductCategoryRequest):
   Promise<boolean> {
+    const parent = await ProductCategory.findOne({ where: { id: request.parentCategoryId } });
     return request.name != null && request.name !== ''
         && request.name.length <= 64
-        && !(await ProductCategory.findOne({ where: { name: request.name } }));
+        && !(await ProductCategory.findOne({ where: { name: request.name } }))
+        && !!(request.parentCategoryId !== undefined
+          ? await ProductCategory.findOne({ where: { id: request.parentCategoryId } })
+          : true);
   }
 }

--- a/src/service/product-category-service.ts
+++ b/src/service/product-category-service.ts
@@ -16,7 +16,7 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { FindManyOptions } from 'typeorm';
+import { EntityManager, FindManyOptions } from 'typeorm';
 import ProductCategory from '../entity/product/product-category';
 import {
   PaginatedProductCategoryResponse,
@@ -25,6 +25,7 @@ import {
 import ProductCategoryRequest from '../controller/request/product-category-request';
 import QueryFilter, { FilterMapping } from '../helpers/query-filter';
 import { PaginationParameters } from '../helpers/pagination';
+import { AppDataSource } from '../database/database';
 
 /**
  * Define productCategory filtering parameters used to filter query results.
@@ -44,6 +45,12 @@ export interface ProductCategoryFilterParameters {
  * Wrapper for all Product related logic.
  */
 export default class ProductCategoryService {
+  private manager: EntityManager;
+
+  constructor(manager?: EntityManager) {
+    this.manager = manager ?? AppDataSource.manager;
+  }
+
   /**
    * Creates a productCategoryResponse from a productCategory
    * @param {ProductCategory.model} productCategory - productCategory
@@ -57,6 +64,7 @@ export default class ProductCategoryService {
       name: productCategory.name,
       createdAt: productCategory.createdAt.toISOString(),
       updatedAt: productCategory.updatedAt.toISOString(),
+      parent: productCategory.parent ? this.asProductCategoryResponse(productCategory.parent) : undefined,
     };
   }
 
@@ -78,7 +86,7 @@ export default class ProductCategoryService {
     };
 
     const results = await Promise.all([
-      ProductCategory.find({ ...options, take, skip }),
+      ProductCategory.find({ ...options, take, skip, relations: { parent: true } }),
       ProductCategory.count(options),
     ]);
 
@@ -98,11 +106,18 @@ export default class ProductCategoryService {
    * Saves a ProductCategory to the database.
    * @param request - The ProductCategoryRequest with values.
    */
-  public static async postProductCategory(request: ProductCategoryRequest)
-    : Promise<ProductCategoryResponse> {
-    const productCategory = Object.assign(new ProductCategory(), request);
-    return ProductCategory.save(productCategory)
-      .then(() => this.asProductCategoryResponse(productCategory));
+  public static async postProductCategory(
+    request: ProductCategoryRequest,
+  ): Promise<ProductCategoryResponse> {
+    const parentCategory = request.parentCategoryId
+      ? await ProductCategory.findOne({ where: { id: request.parentCategoryId } })
+      : undefined;
+
+    const category = new ProductCategory();
+    category.name = request.name;
+    category.parent = parentCategory;
+    return ProductCategory.save(category)
+      .then(() => this.asProductCategoryResponse(category));
   }
 
   /**
@@ -110,11 +125,12 @@ export default class ProductCategoryService {
    * @param id - The id of the productCategory that needs to be updated.
    * @param request - The ProductCategoryRequest with updated values.
    */
-  public static async patchProductCategory(id: number, request: ProductCategoryRequest)
-    : Promise<ProductCategoryResponse> {
-    const productCategoryToUpdate = await ProductCategory.findOne({ where: { id } });
-    if (!productCategoryToUpdate) return null;
-    const productCategory = Object.assign(productCategoryToUpdate, request);
+  public static async patchProductCategory(
+    id: number, request: ProductCategoryRequest,
+  ): Promise<ProductCategoryResponse> {
+    const category = await ProductCategory.findOne({ where: { id } });
+    if (!category) return null;
+    const productCategory = Object.assign(category, request);
     await ProductCategory.save(productCategory);
     return this.asProductCategoryResponse(productCategory);
   }
@@ -124,8 +140,8 @@ export default class ProductCategoryService {
    * @param id - The id of the productCategory that needs to be deleted.
    */
   public static async deleteProductCategory(id: number): Promise<ProductCategoryResponse> {
-    const productCategory = await ProductCategory.findOne({ where: { id } });
-    if (!productCategory) {
+    const productCategory = await ProductCategory.findOne({ where: { id }, relations: { children: true } });
+    if (!productCategory || productCategory.children.length > 0) {
       return null;
     }
     return ProductCategory.delete(id).then(() => this.asProductCategoryResponse(productCategory));

--- a/test/seed.ts
+++ b/test/seed.ts
@@ -429,8 +429,6 @@ export async function seedEvents(users: User[]) {
  * Seeds a default dataset of product categories, and stores them in the database.
  */
 export async function seedProductCategories(): Promise<ProductCategory[]> {
-  const category = (data: object) => Object.assign(new ProductCategory(), data) as ProductCategory;
-
   const rootCategories = await ProductCategory.save([
     {
       id: 1,

--- a/test/seed.ts
+++ b/test/seed.ts
@@ -431,20 +431,42 @@ export async function seedEvents(users: User[]) {
 export async function seedProductCategories(): Promise<ProductCategory[]> {
   const category = (data: object) => Object.assign(new ProductCategory(), data) as ProductCategory;
 
-  return ProductCategory.save([
-    category({
+  const rootCategories = await ProductCategory.save([
+    {
       id: 1,
       name: 'Alcoholic',
-    }),
-    category({
+    }, {
       id: 2,
       name: 'Non-alcoholic',
-    }),
-    category({
+    }, {
       id: 3,
       name: 'Food',
-    }),
+    },
   ]);
+  const subCategories = await ProductCategory.save([
+    {
+      id: 4,
+      name: 'Pils',
+      parent: rootCategories[0],
+    }, {
+      id: 5,
+      name: 'Tripel',
+      parent: rootCategories[0],
+    }, {
+      id: 6,
+      name: 'Blond',
+      parent: rootCategories[0],
+    }, {
+      id: 7,
+      name: 'Dubbel',
+      parent: rootCategories[0],
+    }, {
+      id: 8,
+      name: 'Zoete troep',
+      parent: rootCategories[0],
+    },
+  ]);
+  return [...rootCategories, ...subCategories];
 }
 
 /**

--- a/test/unit/controller/product-category-controller.ts
+++ b/test/unit/controller/product-category-controller.ts
@@ -189,6 +189,27 @@ describe('ProductCategoryController', async (): Promise<void> => {
       expect(pagination.skip).to.equal(0);
       expect(pagination.count).to.equal(ctx.categories.length);
     });
+    it('should return an HTTP 200 and only root categories', async () => {
+      const res = await request(ctx.app)
+        .get('/productcategories?onlyRoot=true')
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+      expect(res.status).to.equal(200);
+
+      const actualCategories = ctx.categories.filter((c) => c.parent == null);
+      const categories = res.body.records as ProductCategoryResponse[];
+      // eslint-disable-next-line no-underscore-dangle
+      const pagination = res.body._pagination as PaginationResult;
+
+      // Every productcategory should be returned.
+      expect(categories.length).to.equal(Math.min(actualCategories.length, defaultPagination()));
+      expect(pagination.take).to.equal(defaultPagination());
+      expect(pagination.skip).to.equal(0);
+      expect(pagination.count).to.equal(actualCategories.length);
+
+      categories.forEach((c) => {
+        expect(c.parent).to.be.undefined;
+      });
+    });
     it('should return an HTTP 403 if not admin', async () => {
       const res = await request(ctx.app)
         .get('/productcategories')

--- a/test/unit/controller/product-category-controller.ts
+++ b/test/unit/controller/product-category-controller.ts
@@ -314,7 +314,7 @@ describe('ProductCategoryController', async (): Promise<void> => {
         .set('Authorization', `Bearer ${ctx.adminToken}`)
         .send({
           ...ctx.invalidRequest,
-          name: null,
+          name: '',
         });
 
       expect(await ProductCategory.count()).to.equal(productCategoryCount);

--- a/test/unit/service/product-category-service.ts
+++ b/test/unit/service/product-category-service.ts
@@ -128,6 +128,17 @@ describe('ProductCategoryService', async (): Promise<void> => {
 
       expect(records).to.be.empty;
     });
+    it('should return only root categories', async () => {
+      const rootCategories = ctx.categories.filter((c) => c.parent == null);
+      const { records } = await ProductCategoryService
+        .getProductCategories({ onlyRoot: true });
+
+      expect(records.length).to.equal(rootCategories.length);
+      expect(records.map((r) => r.id)).to.deep.equalInAnyOrder(rootCategories.map((c) => c.id));
+      records.forEach((c) => {
+        expect(c.parent).to.be.undefined;
+      });
+    });
     it('should adhere to pagination', async () => {
       const take = 5;
       const skip = 3;

--- a/test/unit/service/product-category-service.ts
+++ b/test/unit/service/product-category-service.ts
@@ -139,6 +139,20 @@ describe('ProductCategoryService', async (): Promise<void> => {
         expect(c.parent).to.be.undefined;
       });
     });
+    it('should return only leaf categories', async () => {
+      // Find all categories that are not a parent, i.e. have no children
+      const leafCategories = ctx.categories.filter((c) => !ctx.categories
+        .some((c2) => c2.parent?.id === c.id));
+      const { records } = await ProductCategoryService
+        .getProductCategories({ onlyLeaf: true });
+
+      expect(records.length).to.equal(leafCategories.length);
+      expect(records.map((r) => r.id)).to.deep.equalInAnyOrder(leafCategories.map((c) => c.id));
+      records.forEach((c) => {
+        const children = ctx.categories.filter((c2) => c2.parent?.id === c.id);
+        expect(children).to.be.lengthOf(0);
+      });
+    });
     it('should adhere to pagination', async () => {
       const take = 5;
       const skip = 3;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Upgrades product categories from simple, standalone entities to tree entities. This means that each category can now optionally have a parent category, which allows us to further distinguish different types of products. Examples are Wines (white, red, rose) and Beers (pils, tripel, blond, dubbel, etc). The `GET /productcategories` endpoint now has optional query filters to only get root categories (which are the tabs in the POS) or to only get leaf categories. However, for the POS to understand in which root category a subcategory belongs, its best for the POS to simply request all categories from the backend and then create a local mapping of categories to their root category.

Other uses are mostly statistics-related, so we can for example better understand what types of products are most preferred by users.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Fixes https://github.com/GEWIS/sudosos-backend/issues/244.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_