### PR TITLE
feat: add sales-report-service

### DIFF
--- a/src/controller/response/report-response.ts
+++ b/src/controller/response/report-response.ts
@@ -17,7 +17,7 @@
  */
 import { DineroObjectResponse } from './dinero-response';
 import { BaseVatGroupResponse } from './vat-group-response';
-import { ProductResponse } from './product-response';
+import { BaseProductResponse, ProductResponse } from './product-response';
 import { ProductCategoryResponse } from './product-category-response';
 import { BasePointOfSaleResponse } from './point-of-sale-response';
 import { BaseContainerResponse } from './container-response';
@@ -35,11 +35,11 @@ export interface ReportEntryResponse {
 /**
  * @typedef {allOf|ReportEntryResponse} ReportProductEntryResponse
  * @property {integer} count.required - count
- * @property {ProductResponse} product.required - product
+ * @property {BaseProductResponse} product.required - product
  */
 export interface ReportProductEntryResponse extends ReportEntryResponse {
   count: number,
-  product: ProductResponse,
+  product: BaseProductResponse,
 }
 
 /**

--- a/src/controller/response/report-response.ts
+++ b/src/controller/response/report-response.ts
@@ -16,11 +16,6 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { DineroObjectResponse } from './dinero-response';
-import ProductRevision from '../../entity/product/product-revision';
-import VatGroup from '../../entity/vat-group';
-import ProductCategory from '../../entity/product/product-category';
-import PointOfSaleRevision from '../../entity/point-of-sale/point-of-sale-revision';
-import ContainerRevision from '../../entity/container/container-revision';
 import { BaseVatGroupResponse } from './vat-group-response';
 import { ProductResponse } from './product-response';
 import { ProductCategoryResponse } from './product-category-response';

--- a/src/controller/response/report-response.ts
+++ b/src/controller/response/report-response.ts
@@ -17,7 +17,7 @@
  */
 import { DineroObjectResponse } from './dinero-response';
 import { BaseVatGroupResponse } from './vat-group-response';
-import { BaseProductResponse, ProductResponse } from './product-response';
+import { BaseProductResponse } from './product-response';
 import { ProductCategoryResponse } from './product-category-response';
 import { BasePointOfSaleResponse } from './point-of-sale-response';
 import { BaseContainerResponse } from './container-response';

--- a/src/controller/response/report-response.ts
+++ b/src/controller/response/report-response.ts
@@ -1,0 +1,114 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { DineroObjectResponse } from './dinero-response';
+import ProductRevision from '../../entity/product/product-revision';
+import VatGroup from '../../entity/vat-group';
+import ProductCategory from '../../entity/product/product-category';
+import PointOfSaleRevision from '../../entity/point-of-sale/point-of-sale-revision';
+import ContainerRevision from '../../entity/container/container-revision';
+import { BaseVatGroupResponse } from './vat-group-response';
+import { ProductResponse } from './product-response';
+import { ProductCategoryResponse } from './product-category-response';
+import { BasePointOfSaleResponse, PointOfSaleResponse } from './point-of-sale-response';
+import { BaseContainerResponse } from './container-response';
+
+/**
+ * @typedef {object} ReportEntryResponse
+ * @property {DineroObjectResponse} totalExclVat.required - totalExclVat
+ * @property {DineroObjectResponse} totalInclVat.required - totalInclVat
+ */
+export interface ReportEntryResponse {
+  totalExclVat: DineroObjectResponse,
+  totalInclVat: DineroObjectResponse
+}
+
+/**
+ * @typedef {allOf|ReportEntryResponse} ReportProductEntryResponse
+ * @property {integer} count.required - count
+ * @property {ProductResponse} product.required - product
+ */
+export interface ReportProductEntryResponse extends ReportEntryResponse {
+  count: number,
+  product: ProductResponse,
+}
+
+/**
+ * @typedef {allOf|ReportEntryResponse} ReportVatEntryResponse
+ * @property {BaseVatGroupResponse} vat.required - vat
+ */
+export interface ReportVatEntryResponse extends ReportEntryResponse {
+  vat: BaseVatGroupResponse,
+}
+
+/**
+ * @typedef {allOf|ReportEntryResponse} ReportCategoryEntryResponse
+ * @property {ProductCategoryResponse} category.required - category
+ */
+export interface ReportCategoryEntryResponse extends ReportEntryResponse {
+  category: ProductCategoryResponse,
+}
+
+/**
+ * @typedef {allOf|ReportEntryResponse} ReportPosEntryResponse
+ * @property {BasePointOfSaleResponse} pos.required - pos
+ */
+export interface ReportPosEntryResponse extends ReportEntryResponse {
+  pos: BasePointOfSaleResponse,
+}
+
+/**
+ * @typedef {allOf|ReportEntryResponse} ReportContainerEntryResponse
+ * @property {BaseContainerResponse} container.required - container
+ */
+export interface ReportContainerEntryResponse extends ReportEntryResponse {
+  container: BaseContainerResponse,
+}
+
+/**
+ * @typedef {object} ReportDataResponse
+ * @property {Array<ReportProductEntryResponse>} products - products
+ * @property {Array<ReportCategoryEntryResponse>} categories - categories
+ * @property {Array<ReportVatEntryResponse>} vat - vat
+ * @property {Array<ReportPosEntryResponse>} pos - pos
+ * @property {Array<ReportContainerEntryResponse>} containers - containers
+ */
+export interface ReportDataResponse {
+  products?: ReportProductEntryResponse[],
+  categories?: ReportCategoryEntryResponse[],
+  vat?: ReportVatEntryResponse[],
+  pos?: ReportPosEntryResponse[],
+  containers?: ReportContainerEntryResponse[],
+}
+
+/**
+ * @typedef {object} ReportResponse
+ * @property {integer} forId.required - forId
+ * @property {string} fromDate.required - fromDate
+ * @property {string} tillDate.required - tillDate
+ * @property {ReportDataResponse} data.required - data
+ * @property {DineroObjectResponse} totalExclVat.required - totalExclVat
+ * @property {DineroObjectResponse} totalInclVat.required - totalInclVat
+ */
+export interface ReportResponse {
+  forId: number,
+  fromDate: string,
+  tillDate: string,
+  data: ReportDataResponse,
+  totalExclVat: DineroObjectResponse,
+  totalInclVat: DineroObjectResponse,
+}

--- a/src/controller/response/report-response.ts
+++ b/src/controller/response/report-response.ts
@@ -16,15 +16,10 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { DineroObjectResponse } from './dinero-response';
-import ProductRevision from '../../entity/product/product-revision';
-import VatGroup from '../../entity/vat-group';
-import ProductCategory from '../../entity/product/product-category';
-import PointOfSaleRevision from '../../entity/point-of-sale/point-of-sale-revision';
-import ContainerRevision from '../../entity/container/container-revision';
 import { BaseVatGroupResponse } from './vat-group-response';
 import { ProductResponse } from './product-response';
 import { ProductCategoryResponse } from './product-category-response';
-import { BasePointOfSaleResponse, PointOfSaleResponse } from './point-of-sale-response';
+import { BasePointOfSaleResponse } from './point-of-sale-response';
 import { BaseContainerResponse } from './container-response';
 
 /**

--- a/src/controller/response/report-response.ts
+++ b/src/controller/response/report-response.ts
@@ -16,6 +16,11 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { DineroObjectResponse } from './dinero-response';
+import ProductRevision from '../../entity/product/product-revision';
+import VatGroup from '../../entity/vat-group';
+import ProductCategory from '../../entity/product/product-category';
+import PointOfSaleRevision from '../../entity/point-of-sale/point-of-sale-revision';
+import ContainerRevision from '../../entity/container/container-revision';
 import { BaseVatGroupResponse } from './vat-group-response';
 import { ProductResponse } from './product-response';
 import { ProductCategoryResponse } from './product-category-response';

--- a/src/controller/response/vat-group-response.ts
+++ b/src/controller/response/vat-group-response.ts
@@ -33,9 +33,13 @@ export interface BaseVatGroupResponse extends BaseResponse {
 
 /**
  * @typedef {allOf|BaseVatGroupResponse} VatGroupResponse
- * @property {string} name.rquired - Name of the VAT group
+ * @property {string} name.required - Name of the VAT group
  * @property {boolean} deleted.required - Whether this group is soft-deleted
  */
+export interface VatGroupResponse extends BaseVatGroupResponse {
+  name: string,
+  deleted: boolean,
+}
 
 /**
  * @typedef {object} PaginatedVatGroupResponse

--- a/src/controller/user-controller.ts
+++ b/src/controller/user-controller.ts
@@ -1432,6 +1432,7 @@ export default class UserController extends BaseController {
    * @param {integer} fromId.query - From-user for selected transactions
    * @param {integer} toId.query - To-user for selected transactions
    * @param {boolean} exclusiveToId.query - If all sub-transactions should be to the toId user, default true
+   * @deprecated - Use /users/{id}/transactions/sales/report or /users/{id}/transactions/purchases/report instead
    * @return {string} 404 - User not found error.
    */
   public async getUsersTransactionsReport(req: RequestWithToken, res: Response): Promise<void> {

--- a/src/controller/user-controller.ts
+++ b/src/controller/user-controller.ts
@@ -41,7 +41,7 @@ import UserService, {
   parseGetUsersFilters,
   UserFilterParameters,
 } from '../service/user-service';
-import { asDate, asNumber } from '../helpers/validators';
+import { asDate, asFromAndTillDate, asNumber } from '../helpers/validators';
 import { verifyCreateUserRequest } from './request/validators/user-request-spec';
 import userTokenInOrgan from '../helpers/token-helper';
 import { parseUserToResponse } from '../helpers/revision-to-response';
@@ -249,7 +249,7 @@ export default class UserController extends BaseController {
           handler: this.getUsersTransactions.bind(this),
         },
       },
-      'id(\\d+)/transactions/sales/report': {
+      '/:id(\\d+)/transactions/sales/report': {
         GET: {
           policy: async (req) => this.roleManager.can(
             req.token.roles, 'get', UserController.getRelation(req), 'Transaction', ['*'],
@@ -257,7 +257,7 @@ export default class UserController extends BaseController {
           handler: this.getUsersSalesReport.bind(this),
         },
       },
-      'id(\\d+)/transactions/purchases/report': {
+      '/:id(\\d+)/transactions/purchases/report': {
         GET: {
           policy: async (req) => this.roleManager.can(
             req.token.roles, 'get', UserController.getRelation(req), 'Transaction', ['*'],
@@ -1100,10 +1100,7 @@ export default class UserController extends BaseController {
 
     let filters: { fromDate: Date, tillDate: Date };
     try {
-      filters = {
-        fromDate: asDate(req.query.fromDate),
-        tillDate: asDate(req.query.tillDate),
-      };
+      filters = asFromAndTillDate(req.query.fromDate, req.query.tillDate);
     } catch (e) {
       res.status(400).json(e.message);
       return;
@@ -1143,10 +1140,7 @@ export default class UserController extends BaseController {
 
     let filters: { fromDate: Date, tillDate: Date };
     try {
-      filters = {
-        fromDate: asDate(req.query.fromDate),
-        tillDate: asDate(req.query.tillDate),
-      };
+      filters = asFromAndTillDate(req.query.fromDate, req.query.tillDate);
     } catch (e) {
       res.status(400).json(e.message);
       return;

--- a/src/controller/user-controller.ts
+++ b/src/controller/user-controller.ts
@@ -41,7 +41,7 @@ import UserService, {
   parseGetUsersFilters,
   UserFilterParameters,
 } from '../service/user-service';
-import { asDate, asFromAndTillDate, asNumber } from '../helpers/validators';
+import { asFromAndTillDate, asNumber } from '../helpers/validators';
 import { verifyCreateUserRequest } from './request/validators/user-request-spec';
 import userTokenInOrgan from '../helpers/token-helper';
 import { parseUserToResponse } from '../helpers/revision-to-response';

--- a/src/entity/report/report.ts
+++ b/src/entity/report/report.ts
@@ -1,0 +1,72 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import PointOfSaleRevision from '../point-of-sale/point-of-sale-revision';
+import ProductRevision from '../product/product-revision';
+import VatGroup from '../vat-group';
+import ProductCategory from '../product/product-category';
+import ContainerRevision from '../container/container-revision';
+import Dinero from 'dinero.js';
+
+export interface ReportEntry {
+  totalExclVat: Dinero.Dinero,
+  totalInclVat: Dinero.Dinero
+}
+
+export interface ReportProductEntry extends ReportEntry {
+  count: number,
+  product: ProductRevision,
+}
+
+export interface ReportVatEntry extends ReportEntry {
+  vat: VatGroup,
+}
+
+export interface ReportCategoryEntry extends ReportEntry {
+  category: ProductCategory,
+}
+
+export interface ReportPosEntry extends ReportEntry {
+  pos: PointOfSaleRevision,
+}
+
+export interface ReportContainerEntry extends ReportEntry {
+  container: ContainerRevision,
+}
+
+export interface ReportData {
+  products?: ReportProductEntry[],
+  categories?: ReportCategoryEntry[],
+  vat?: ReportVatEntry[],
+  pos?: ReportPosEntry[],
+  containers?: ReportContainerEntry[],
+}
+
+export interface Report {
+  forId: number,
+  fromDate: Date,
+  tillDate: Date,
+  data: ReportData,
+  totalExclVat: Dinero.Dinero,
+  totalInclVat: Dinero.Dinero,
+}
+
+export interface SalesReport extends Report {
+}
+
+export interface BuyerReport extends Report {
+}

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -63,7 +63,7 @@ export function isDate(date: any, canBeUndefined?: boolean): boolean {
  */
 export function asNumber(input: any): number | undefined {
   if (!isNumber(input, true)) throw new TypeError(`Input '${input}' is not a number.`);
-  return (input ? Number(input) : undefined);
+  return (input !== undefined ? Number(input) : undefined);
 }
 
 /**

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -235,9 +235,6 @@ export function asFromAndTillDate(fromDate: any, tillDate: any): { fromDate: Dat
     fromDate: asDate(fromDate),
     tillDate: asDate(tillDate),
   };
-  filters.fromDate.setUTCHours(0, 0, 0, 0);
-  filters.tillDate.setUTCHours(0, 0, 0, 0);
-
   if (filters.fromDate >= filters.tillDate) {
     throw new Error('tillDate must be after fromDate');
   }

--- a/src/helpers/validators.ts
+++ b/src/helpers/validators.ts
@@ -222,3 +222,25 @@ export function asArrayOfDates(input: any): Date[] | undefined {
   if (dates.some((d: (Date | undefined)[]) => d === undefined)) throw new TypeError('Array contains invalid date');
   return dates;
 }
+
+/**
+ * Converts the inputs to a from and till date
+ * @param fromDate
+ * @param tillDate
+ * @throws Error - If tillDate is before fromDate
+ * @throws TypeError - If any of the inputs is not a valid date
+ */
+export function asFromAndTillDate(fromDate: any, tillDate: any): { fromDate: Date, tillDate: Date } {
+  const filters = {
+    fromDate: asDate(fromDate),
+    tillDate: asDate(tillDate),
+  };
+  filters.fromDate.setUTCHours(0, 0, 0, 0);
+  filters.tillDate.setUTCHours(0, 0, 0, 0);
+
+  if (filters.fromDate >= filters.tillDate) {
+    throw new Error('tillDate must be after fromDate');
+  }
+
+  return filters;
+}

--- a/src/service/container-service.ts
+++ b/src/service/container-service.ts
@@ -18,6 +18,7 @@
 
 import { FindManyOptions, FindOptionsRelations, FindOptionsWhere, In, IsNull, Raw } from 'typeorm';
 import {
+  BaseContainerResponse,
   ContainerResponse,
   ContainerWithProductsResponse,
   PaginatedContainerResponse,
@@ -81,6 +82,14 @@ export interface ContainerFilterParameters {
 }
 
 export default class ContainerService {
+
+  public static revisionToBaseResponse(revision: ContainerRevision): BaseContainerResponse {
+    return {
+      id: revision.containerId,
+      name: revision.name,
+    };
+  }
+
   public static revisionToResponse(revision: ContainerRevision): ContainerResponse | ContainerWithProductsResponse {
     const response: ContainerResponse = {
       id: revision.containerId,

--- a/src/service/point-of-sale-service.ts
+++ b/src/service/point-of-sale-service.ts
@@ -18,6 +18,7 @@
 
 import { FindManyOptions, FindOptionsRelations, FindOptionsWhere, In, IsNull, Raw } from 'typeorm';
 import {
+  BasePointOfSaleResponse,
   PaginatedPointOfSaleResponse,
   PointOfSaleResponse,
   PointOfSaleWithContainersResponse,
@@ -69,6 +70,13 @@ export interface PointOfSaleParameters {
 
 export default class PointOfSaleService {
 
+  public static revisionToBaseResponse(revision: PointOfSaleRevision): BasePointOfSaleResponse {
+    return {
+      id: revision.pointOfSaleId,
+      name: revision.name,
+    };
+  }
+
   /**
    * Transforms a point of sale revision into a response.
    * @param revision
@@ -76,12 +84,11 @@ export default class PointOfSaleService {
    */
   public static revisionToResponse(revision: PointOfSaleRevision): PointOfSaleResponse | PointOfSaleWithContainersResponse {
     const response: PointOfSaleResponse = {
-      id: revision.pointOfSale.id,
-      revision: revision.revision,
-      name: revision.name,
-      useAuthentication: revision.useAuthentication,
+      ...PointOfSaleService.revisionToBaseResponse(revision),
       createdAt: revision.pointOfSale.createdAt.toISOString(),
       updatedAt: revision.pointOfSale.updatedAt.toISOString(),
+      revision: revision.revision,
+      useAuthentication: revision.useAuthentication,
       owner: {
         id: revision.pointOfSale.owner.id,
         firstName: revision.pointOfSale.owner.firstName,

--- a/src/service/point-of-sale-service.ts
+++ b/src/service/point-of-sale-service.ts
@@ -74,7 +74,7 @@ export default class PointOfSaleService {
    * @param revision
    * @private
    */
-  private static revisionToResponse(revision: PointOfSaleRevision): PointOfSaleResponse | PointOfSaleWithContainersResponse {
+  public static revisionToResponse(revision: PointOfSaleRevision): PointOfSaleResponse | PointOfSaleWithContainersResponse {
     const response: PointOfSaleResponse = {
       id: revision.pointOfSale.id,
       revision: revision.revision,

--- a/src/service/product-service.ts
+++ b/src/service/product-service.ts
@@ -25,6 +25,7 @@ import {
 } from 'typeorm';
 import { DineroObject } from 'dinero.js';
 import {
+  BaseProductResponse,
   PaginatedProductResponse,
   ProductResponse,
 } from '../controller/response/product-response';
@@ -137,6 +138,19 @@ export function parseGetProductFilters(req: RequestWithToken): ProductFilterPara
  * Wrapper for all Product related logic.
  */
 export default class ProductService {
+
+  public static revisionToBaseResponse(revision: ProductRevision): BaseProductResponse {
+    return {
+      id: revision.productId,
+      name: revision.name,
+      priceInclVat: revision.priceInclVat.toObject(),
+      vat: {
+        id: revision.vat.id,
+        percentage: revision.vat.percentage,
+        hidden: revision.vat.hidden,
+      },
+    };
+  }
 
   public static revisionToResponse(revision: ProductRevision): ProductResponse {
     const priceInclVat = revision.priceInclVat.toObject();

--- a/src/service/report-service.ts
+++ b/src/service/report-service.ts
@@ -21,7 +21,7 @@ import ProductRevision from '../entity/product/product-revision';
 import Dinero from 'dinero.js';
 import VatGroup from '../entity/vat-group';
 import ProductCategory from '../entity/product/product-category';
-import { toLocalMySQLString, toMySQLString } from '../helpers/timestamps';
+import { toMySQLString } from '../helpers/timestamps';
 import SubTransactionRow from '../entity/transactions/sub-transaction-row';
 import SubTransaction from '../entity/transactions/sub-transaction';
 import { asDinero, asNumber } from '../helpers/validators';

--- a/src/service/report-service.ts
+++ b/src/service/report-service.ts
@@ -37,7 +37,6 @@ import {
 } from '../controller/response/report-response';
 import ProductService from './product-service';
 import VatGroupService from './vat-group-service';
-import { BaseVatGroupResponse } from '../controller/response/vat-group-response';
 import ProductCategoryService from './product-category-service';
 import PointOfSaleService from './point-of-sale-service';
 import ContainerService from './container-service';

--- a/src/service/report-service.ts
+++ b/src/service/report-service.ts
@@ -21,7 +21,7 @@ import ProductRevision from '../entity/product/product-revision';
 import Dinero from 'dinero.js';
 import VatGroup from '../entity/vat-group';
 import ProductCategory from '../entity/product/product-category';
-import {toLocalMySQLString, toMySQLString} from '../helpers/timestamps';
+import { toLocalMySQLString, toMySQLString } from '../helpers/timestamps';
 import SubTransactionRow from '../entity/transactions/sub-transaction-row';
 import SubTransaction from '../entity/transactions/sub-transaction';
 import { asDinero, asNumber } from '../helpers/validators';
@@ -76,7 +76,7 @@ export interface SalesReport extends Report {}
 
 export interface BuyerReport extends Report {}
 
-interface ReportParameters {
+export interface ReportParameters {
   fromDate: Date,
   tillDate: Date,
   forId: number,

--- a/src/service/report-service.ts
+++ b/src/service/report-service.ts
@@ -37,6 +37,7 @@ import {
 } from '../controller/response/report-response';
 import ProductService from './product-service';
 import VatGroupService from './vat-group-service';
+import { BaseVatGroupResponse } from '../controller/response/vat-group-response';
 import ProductCategoryService from './product-category-service';
 import PointOfSaleService from './point-of-sale-service';
 import ContainerService from './container-service';

--- a/src/service/sales-report-service.ts
+++ b/src/service/sales-report-service.ts
@@ -1,0 +1,227 @@
+import { AppDataSource } from "../database/database";
+import {EntityManager, SelectQueryBuilder} from "typeorm";
+import ProductRevision from "../entity/product/product-revision";
+import Dinero from "dinero.js";
+import VatGroup from "../entity/vat-group";
+import ProductCategory from "../entity/product/product-category";
+import {toMySQLString} from "../helpers/timestamps";
+import SubTransactionRow from "../entity/transactions/sub-transaction-row";
+import SubTransaction from "../entity/transactions/sub-transaction";
+import {asDinero, asNumber} from "../helpers/validators";
+
+
+export interface SalesReportProductEntry {
+    count: number,
+    product: ProductRevision,
+    totalExclVat: Dinero.Dinero,
+    totalInclVat: Dinero.Dinero
+}
+
+export interface SalesReportVatEntry {
+    vat: VatGroup,
+    totalExclVat: Dinero.Dinero,
+    totalInclVat: Dinero.Dinero
+}
+
+export interface SalesReportCategoryEntry {
+    category: ProductCategory,
+    totalExclVat: Dinero.Dinero,
+    totalInclVat: Dinero.Dinero
+}
+
+export interface SalesReportData {
+    entries?: SalesReportProductEntry[],
+    categories?: SalesReportCategoryEntry[],
+    vat?: SalesReportVatEntry[],
+}
+
+export interface SalesReport {
+    forId: number,
+    fromDate: Date,
+    tillDate: Date,
+    data: SalesReportData,
+    totalExclVat: Dinero.Dinero,
+    totalInclVat: Dinero.Dinero,
+}
+
+export default class SalesReportService {
+
+    private manager: EntityManager;
+
+    constructor(manager?: EntityManager) {
+        this.manager = manager ? manager : AppDataSource.manager;
+    }
+
+
+    /**
+     * Adds the totals to the given query
+     * Note that the VAT is rounded per product, not per transaction.
+     * @param query - The query to add the totals to
+     * @private
+     */
+    private addSelectTotals<T>(query: SelectQueryBuilder<T>): SelectQueryBuilder<T> {
+        return query
+            .addSelect('sum(subTransactionRow.amount * ROUND(productRevision.priceInclVat * (1 - (vatGroup.percentage / 100))))', 'total_excl_vat')
+            .addSelect('sum(subTransactionRow.amount * productRevision.priceInclVat)', 'total_incl_vat');
+    }
+
+    /**
+     * Adds a filter on the sub transaction row to the given query
+     * @param query - The query to add the filter to
+     * @param toId - The user ID to filter on
+     * @param fromDate - The from date to filter on (inclusive)
+     * @param tillDate - The till date to filter on (exclusive)
+     * @private
+     */
+    private addSubTransactionRowFilter<T>(query: SelectQueryBuilder<T>, toId: number, fromDate: Date, tillDate: Date): SelectQueryBuilder<T> {
+        return query
+            .where('subTransaction.toId = :userId', {userId: toId})
+            .andWhere('subTransaction.createdAt >= :fromDate', {fromDate: toMySQLString(fromDate)})
+            .andWhere('subTransaction.createdAt < :tillDate', {tillDate: toMySQLString(tillDate)});
+    }
+
+    /**
+     * Gets the product sales for the given user
+     * @param forId - The user ID to get the entries for
+     * @param fromDate - The from date to get the entries for (inclusive)
+     * @param tillDate - The till date to get the entries for (exclusive)
+     * @returns {Promise<SalesReportProductEntry[]>} - The product sales
+     */
+    public async getProductEntries(forId: number, fromDate: Date, tillDate: Date): Promise<SalesReportProductEntry[]> {
+        const query = this.manager.createQueryBuilder(ProductRevision, 'productRevision')
+            .innerJoinAndSelect('productRevision.vat', 'vatGroup')
+            .innerJoin(SubTransactionRow, 'subTransactionRow', 'subTransactionRow.productProductId = productRevision.productId AND subTransactionRow.productRevision = productRevision.revision')
+            .innerJoin(SubTransaction, 'subTransaction', 'subTransaction.id = subTransactionRow.subTransactionId')
+            .addSelect('sum(subTransactionRow.amount)', 'sum_amount');
+        this.addSelectTotals(query);
+
+        const data = await this.addSubTransactionRowFilter(query, forId, fromDate, tillDate)
+            .groupBy('subTransactionRow.productProductId, subTransactionRow.productRevision')
+            .getRawAndEntities();
+
+        return data.entities.map((productRevision, index) => {
+            const count = asNumber(data.raw[index].sum_amount)
+            const totalInclVat = asDinero(data.raw[index].total_incl_vat);
+            const totalExclVat = asDinero(data.raw[index].total_excl_vat);
+            return {
+                count,
+                product: productRevision,
+                totalInclVat,
+                totalExclVat,
+            };
+        });
+    }
+
+    /**
+     * Gets the VAT sales for the given user
+     * @param forId - The user ID to get the entries for
+     * @param fromDate - The from date to get the entries for (inclusive)
+     * @param tillDate - The till date to get the entries for (exclusive)
+     * @returns {Promise<SalesReportVatEntry[]>} - The VAT sales
+     */
+    public async getVatEntries(forId: number, fromDate: Date, tillDate: Date): Promise<SalesReportVatEntry[]> {
+        const query = this.manager.createQueryBuilder(VatGroup, 'vatGroup')
+            .innerJoin(ProductRevision, 'productRevision', 'productRevision.vat = vatGroup.id')
+            .innerJoin(SubTransactionRow, 'subTransactionRow', 'subTransactionRow.productProductId = productRevision.productId AND subTransactionRow.productRevision = productRevision.revision')
+            .innerJoin(SubTransaction, 'subTransaction', 'subTransaction.id = subTransactionRow.subTransactionId');
+        this.addSelectTotals(query);
+
+        const data = await this.addSubTransactionRowFilter(query, forId, fromDate, tillDate)
+            .groupBy('vatGroup.id')
+            .getRawAndEntities();
+
+        return data.entities.map((vatGroup, index) => {
+            const totalInclVat = asDinero(data.raw[index].total_incl_vat);
+            const totalExclVat = asDinero(data.raw[index].total_excl_vat);
+            return {
+                vat: vatGroup,
+                totalExclVat,
+                totalInclVat
+            };
+        });
+    }
+
+    /**
+     * Gets the category sales for the given user
+     * @param forId - The user ID to get the entries for
+     * @param fromDate - The from date to get the entries for (inclusive)
+     * @param tillDate - The till date to get the entries for (exclusive)
+     * @returns {Promise<SalesReportCategoryEntry[]>} - The category sales
+     */
+    public async getCategoryEntries(forId: number, fromDate: Date, tillDate: Date): Promise<SalesReportCategoryEntry[]> {
+        const query = this.manager.createQueryBuilder(ProductCategory, 'productCategory')
+            .innerJoin(ProductRevision, 'productRevision', 'productRevision.category = productCategory.id')
+            .innerJoin(VatGroup, 'vatGroup', 'vatGroup.id = productRevision.vat')
+            .innerJoin(SubTransactionRow, 'subTransactionRow', 'subTransactionRow.productProductId = productRevision.productId AND subTransactionRow.productRevision = productRevision.revision')
+            .innerJoin(SubTransaction, 'subTransaction', 'subTransaction.id = subTransactionRow.subTransactionId')
+        this.addSelectTotals(query);
+
+        const data = await this.addSubTransactionRowFilter(query, forId, fromDate, tillDate)
+            .groupBy('productCategory.id')
+            .getRawAndEntities();
+
+        return data.entities.map((productCategory, index) => {
+            const totalInclVat = asDinero(data.raw[index].total_incl_vat);
+            const totalExclVat = asDinero(data.raw[index].total_excl_vat);
+            return {
+                category: productCategory,
+                totalExclVat,
+                totalInclVat
+            };
+        });
+    }
+
+    /**
+     * Gets the totals for the given user
+     * @param forId - The user ID to get the totals for
+     * @param fromDate - The from date to get the totals for (inclusive)
+     * @param tillDate - The till date to get the totals for (exclusive)
+     * @returns {Promise<{ totalExclVat: Dinero.Dinero, totalInclVat: Dinero.Dinero }>} - The totals
+     */
+    public async getTotals(forId: number, fromDate: Date, tillDate: Date): Promise<{ totalExclVat: Dinero.Dinero, totalInclVat: Dinero.Dinero }> {
+        const query = this.manager.createQueryBuilder(ProductRevision, 'productRevision')
+            .innerJoin('productRevision.vat', 'vatGroup')
+            .innerJoin(SubTransactionRow, 'subTransactionRow', 'subTransactionRow.productProductId = productRevision.productId AND subTransactionRow.productRevision = productRevision.revision')
+            .innerJoin(SubTransaction, 'subTransaction', 'subTransaction.id = subTransactionRow.subTransactionId')
+        this.addSelectTotals(query);
+
+        const data = await this.addSubTransactionRowFilter(query, forId, fromDate, tillDate)
+            .getRawAndEntities();
+
+        const totalExclVat = asDinero(data.raw[0].total_excl_vat);
+        const totalInclVat = asDinero(data.raw[0].total_incl_vat);
+        return {
+            totalExclVat,
+            totalInclVat
+        };
+    }
+
+    /**
+     * Gets the sales report for the given user
+     * @param forId - The user ID to get the report for
+     * @param fromDate - The from date to get the report for (inclusive)
+     * @param tillDate - The till date to get the report for (exclusive)
+     * @returns {Promise<SalesReport>} - The sales report
+     */
+    public async getSalesReport(forId: number, fromDate: Date, tillDate: Date): Promise<SalesReport> {
+        console.error(forId, fromDate, tillDate);
+
+        const productEntries = await this.getProductEntries(forId, fromDate, tillDate);
+        const vatEntries = await this.getVatEntries(forId, fromDate, tillDate);
+        const categoryEntries = await this.getCategoryEntries(forId, fromDate, tillDate);
+        const totals = await this.getTotals(forId, fromDate, tillDate);
+
+        return {
+            forId,
+            fromDate,
+            tillDate,
+            data: {
+                entries: productEntries,
+                categories: categoryEntries,
+                vat: vatEntries,
+            },
+            totalExclVat: totals.totalExclVat,
+            totalInclVat: totals.totalInclVat,
+        }
+    }
+}

--- a/src/service/sales-report-service.ts
+++ b/src/service/sales-report-service.ts
@@ -1,71 +1,88 @@
-import { AppDataSource } from "../database/database";
-import {EntityManager, SelectQueryBuilder} from "typeorm";
-import ProductRevision from "../entity/product/product-revision";
-import Dinero from "dinero.js";
-import VatGroup from "../entity/vat-group";
-import ProductCategory from "../entity/product/product-category";
-import {toMySQLString} from "../helpers/timestamps";
-import SubTransactionRow from "../entity/transactions/sub-transaction-row";
-import SubTransaction from "../entity/transactions/sub-transaction";
-import {asDinero, asNumber} from "../helpers/validators";
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { AppDataSource } from '../database/database';
+import { EntityManager, SelectQueryBuilder } from 'typeorm';
+import ProductRevision from '../entity/product/product-revision';
+import Dinero from 'dinero.js';
+import VatGroup from '../entity/vat-group';
+import ProductCategory from '../entity/product/product-category';
+import { toMySQLString } from '../helpers/timestamps';
+import SubTransactionRow from '../entity/transactions/sub-transaction-row';
+import SubTransaction from '../entity/transactions/sub-transaction';
+import { asDinero, asNumber } from '../helpers/validators';
 
 
 export interface SalesReportProductEntry {
-    count: number,
-    product: ProductRevision,
-    totalExclVat: Dinero.Dinero,
-    totalInclVat: Dinero.Dinero
+  count: number,
+  product: ProductRevision,
+  totalExclVat: Dinero.Dinero,
+  totalInclVat: Dinero.Dinero
 }
 
 export interface SalesReportVatEntry {
-    vat: VatGroup,
-    totalExclVat: Dinero.Dinero,
-    totalInclVat: Dinero.Dinero
+  vat: VatGroup,
+  totalExclVat: Dinero.Dinero,
+  totalInclVat: Dinero.Dinero
 }
 
 export interface SalesReportCategoryEntry {
-    category: ProductCategory,
-    totalExclVat: Dinero.Dinero,
-    totalInclVat: Dinero.Dinero
+  category: ProductCategory,
+  totalExclVat: Dinero.Dinero,
+  totalInclVat: Dinero.Dinero
 }
 
 export interface SalesReportData {
-    entries?: SalesReportProductEntry[],
-    categories?: SalesReportCategoryEntry[],
-    vat?: SalesReportVatEntry[],
+  entries?: SalesReportProductEntry[],
+  categories?: SalesReportCategoryEntry[],
+  vat?: SalesReportVatEntry[],
 }
 
 export interface SalesReport {
-    forId: number,
-    fromDate: Date,
-    tillDate: Date,
-    data: SalesReportData,
-    totalExclVat: Dinero.Dinero,
-    totalInclVat: Dinero.Dinero,
+  forId: number,
+  fromDate: Date,
+  tillDate: Date,
+  data: SalesReportData,
+  totalExclVat: Dinero.Dinero,
+  totalInclVat: Dinero.Dinero,
 }
 
 export default class SalesReportService {
 
-    private manager: EntityManager;
+  private manager: EntityManager;
 
-    constructor(manager?: EntityManager) {
-        this.manager = manager ? manager : AppDataSource.manager;
-    }
+  constructor(manager?: EntityManager) {
+    this.manager = manager ? manager : AppDataSource.manager;
+  }
 
 
-    /**
+  /**
      * Adds the totals to the given query
      * Note that the VAT is rounded per product, not per transaction.
      * @param query - The query to add the totals to
      * @private
      */
-    private addSelectTotals<T>(query: SelectQueryBuilder<T>): SelectQueryBuilder<T> {
-        return query
-            .addSelect('sum(subTransactionRow.amount * ROUND(productRevision.priceInclVat * (1 - (vatGroup.percentage / 100))))', 'total_excl_vat')
-            .addSelect('sum(subTransactionRow.amount * productRevision.priceInclVat)', 'total_incl_vat');
-    }
+  private addSelectTotals<T>(query: SelectQueryBuilder<T>): SelectQueryBuilder<T> {
+    return query
+      .addSelect('sum(subTransactionRow.amount * ROUND(productRevision.priceInclVat * (1 - (vatGroup.percentage / 100))))', 'total_excl_vat')
+      .addSelect('sum(subTransactionRow.amount * productRevision.priceInclVat)', 'total_incl_vat');
+  }
 
-    /**
+  /**
      * Adds a filter on the sub transaction row to the given query
      * @param query - The query to add the filter to
      * @param toId - The user ID to filter on
@@ -73,155 +90,155 @@ export default class SalesReportService {
      * @param tillDate - The till date to filter on (exclusive)
      * @private
      */
-    private addSubTransactionRowFilter<T>(query: SelectQueryBuilder<T>, toId: number, fromDate: Date, tillDate: Date): SelectQueryBuilder<T> {
-        return query
-            .where('subTransaction.toId = :userId', {userId: toId})
-            .andWhere('subTransaction.createdAt >= :fromDate', {fromDate: toMySQLString(fromDate)})
-            .andWhere('subTransaction.createdAt < :tillDate', {tillDate: toMySQLString(tillDate)});
-    }
+  private addSubTransactionRowFilter<T>(query: SelectQueryBuilder<T>, toId: number, fromDate: Date, tillDate: Date): SelectQueryBuilder<T> {
+    return query
+      .where('subTransaction.toId = :userId', { userId: toId })
+      .andWhere('subTransaction.createdAt >= :fromDate', { fromDate: toMySQLString(fromDate) })
+      .andWhere('subTransaction.createdAt < :tillDate', { tillDate: toMySQLString(tillDate) });
+  }
 
-    /**
+  /**
      * Gets the product sales for the given user
      * @param forId - The user ID to get the entries for
      * @param fromDate - The from date to get the entries for (inclusive)
      * @param tillDate - The till date to get the entries for (exclusive)
      * @returns {Promise<SalesReportProductEntry[]>} - The product sales
      */
-    public async getProductEntries(forId: number, fromDate: Date, tillDate: Date): Promise<SalesReportProductEntry[]> {
-        const query = this.manager.createQueryBuilder(ProductRevision, 'productRevision')
-            .innerJoinAndSelect('productRevision.vat', 'vatGroup')
-            .innerJoin(SubTransactionRow, 'subTransactionRow', 'subTransactionRow.productProductId = productRevision.productId AND subTransactionRow.productRevision = productRevision.revision')
-            .innerJoin(SubTransaction, 'subTransaction', 'subTransaction.id = subTransactionRow.subTransactionId')
-            .addSelect('sum(subTransactionRow.amount)', 'sum_amount');
-        this.addSelectTotals(query);
+  public async getProductEntries(forId: number, fromDate: Date, tillDate: Date): Promise<SalesReportProductEntry[]> {
+    const query = this.manager.createQueryBuilder(ProductRevision, 'productRevision')
+      .innerJoinAndSelect('productRevision.vat', 'vatGroup')
+      .innerJoin(SubTransactionRow, 'subTransactionRow', 'subTransactionRow.productProductId = productRevision.productId AND subTransactionRow.productRevision = productRevision.revision')
+      .innerJoin(SubTransaction, 'subTransaction', 'subTransaction.id = subTransactionRow.subTransactionId')
+      .addSelect('sum(subTransactionRow.amount)', 'sum_amount');
+    this.addSelectTotals(query);
 
-        const data = await this.addSubTransactionRowFilter(query, forId, fromDate, tillDate)
-            .groupBy('subTransactionRow.productProductId, subTransactionRow.productRevision')
-            .getRawAndEntities();
+    const data = await this.addSubTransactionRowFilter(query, forId, fromDate, tillDate)
+      .groupBy('subTransactionRow.productProductId, subTransactionRow.productRevision')
+      .getRawAndEntities();
 
-        return data.entities.map((productRevision, index) => {
-            const count = asNumber(data.raw[index].sum_amount)
-            const totalInclVat = asDinero(data.raw[index].total_incl_vat);
-            const totalExclVat = asDinero(data.raw[index].total_excl_vat);
-            return {
-                count,
-                product: productRevision,
-                totalInclVat,
-                totalExclVat,
-            };
-        });
-    }
+    return data.entities.map((productRevision, index) => {
+      const count = asNumber(data.raw[index].sum_amount);
+      const totalInclVat = asDinero(data.raw[index].total_incl_vat);
+      const totalExclVat = asDinero(data.raw[index].total_excl_vat);
+      return {
+        count,
+        product: productRevision,
+        totalInclVat,
+        totalExclVat,
+      };
+    });
+  }
 
-    /**
+  /**
      * Gets the VAT sales for the given user
      * @param forId - The user ID to get the entries for
      * @param fromDate - The from date to get the entries for (inclusive)
      * @param tillDate - The till date to get the entries for (exclusive)
      * @returns {Promise<SalesReportVatEntry[]>} - The VAT sales
      */
-    public async getVatEntries(forId: number, fromDate: Date, tillDate: Date): Promise<SalesReportVatEntry[]> {
-        const query = this.manager.createQueryBuilder(VatGroup, 'vatGroup')
-            .innerJoin(ProductRevision, 'productRevision', 'productRevision.vat = vatGroup.id')
-            .innerJoin(SubTransactionRow, 'subTransactionRow', 'subTransactionRow.productProductId = productRevision.productId AND subTransactionRow.productRevision = productRevision.revision')
-            .innerJoin(SubTransaction, 'subTransaction', 'subTransaction.id = subTransactionRow.subTransactionId');
-        this.addSelectTotals(query);
+  public async getVatEntries(forId: number, fromDate: Date, tillDate: Date): Promise<SalesReportVatEntry[]> {
+    const query = this.manager.createQueryBuilder(VatGroup, 'vatGroup')
+      .innerJoin(ProductRevision, 'productRevision', 'productRevision.vat = vatGroup.id')
+      .innerJoin(SubTransactionRow, 'subTransactionRow', 'subTransactionRow.productProductId = productRevision.productId AND subTransactionRow.productRevision = productRevision.revision')
+      .innerJoin(SubTransaction, 'subTransaction', 'subTransaction.id = subTransactionRow.subTransactionId');
+    this.addSelectTotals(query);
 
-        const data = await this.addSubTransactionRowFilter(query, forId, fromDate, tillDate)
-            .groupBy('vatGroup.id')
-            .getRawAndEntities();
+    const data = await this.addSubTransactionRowFilter(query, forId, fromDate, tillDate)
+      .groupBy('vatGroup.id')
+      .getRawAndEntities();
 
-        return data.entities.map((vatGroup, index) => {
-            const totalInclVat = asDinero(data.raw[index].total_incl_vat);
-            const totalExclVat = asDinero(data.raw[index].total_excl_vat);
-            return {
-                vat: vatGroup,
-                totalExclVat,
-                totalInclVat
-            };
-        });
-    }
+    return data.entities.map((vatGroup, index) => {
+      const totalInclVat = asDinero(data.raw[index].total_incl_vat);
+      const totalExclVat = asDinero(data.raw[index].total_excl_vat);
+      return {
+        vat: vatGroup,
+        totalExclVat,
+        totalInclVat,
+      };
+    });
+  }
 
-    /**
+  /**
      * Gets the category sales for the given user
      * @param forId - The user ID to get the entries for
      * @param fromDate - The from date to get the entries for (inclusive)
      * @param tillDate - The till date to get the entries for (exclusive)
      * @returns {Promise<SalesReportCategoryEntry[]>} - The category sales
      */
-    public async getCategoryEntries(forId: number, fromDate: Date, tillDate: Date): Promise<SalesReportCategoryEntry[]> {
-        const query = this.manager.createQueryBuilder(ProductCategory, 'productCategory')
-            .innerJoin(ProductRevision, 'productRevision', 'productRevision.category = productCategory.id')
-            .innerJoin(VatGroup, 'vatGroup', 'vatGroup.id = productRevision.vat')
-            .innerJoin(SubTransactionRow, 'subTransactionRow', 'subTransactionRow.productProductId = productRevision.productId AND subTransactionRow.productRevision = productRevision.revision')
-            .innerJoin(SubTransaction, 'subTransaction', 'subTransaction.id = subTransactionRow.subTransactionId')
-        this.addSelectTotals(query);
+  public async getCategoryEntries(forId: number, fromDate: Date, tillDate: Date): Promise<SalesReportCategoryEntry[]> {
+    const query = this.manager.createQueryBuilder(ProductCategory, 'productCategory')
+      .innerJoin(ProductRevision, 'productRevision', 'productRevision.category = productCategory.id')
+      .innerJoin(VatGroup, 'vatGroup', 'vatGroup.id = productRevision.vat')
+      .innerJoin(SubTransactionRow, 'subTransactionRow', 'subTransactionRow.productProductId = productRevision.productId AND subTransactionRow.productRevision = productRevision.revision')
+      .innerJoin(SubTransaction, 'subTransaction', 'subTransaction.id = subTransactionRow.subTransactionId');
+    this.addSelectTotals(query);
 
-        const data = await this.addSubTransactionRowFilter(query, forId, fromDate, tillDate)
-            .groupBy('productCategory.id')
-            .getRawAndEntities();
+    const data = await this.addSubTransactionRowFilter(query, forId, fromDate, tillDate)
+      .groupBy('productCategory.id')
+      .getRawAndEntities();
 
-        return data.entities.map((productCategory, index) => {
-            const totalInclVat = asDinero(data.raw[index].total_incl_vat);
-            const totalExclVat = asDinero(data.raw[index].total_excl_vat);
-            return {
-                category: productCategory,
-                totalExclVat,
-                totalInclVat
-            };
-        });
-    }
+    return data.entities.map((productCategory, index) => {
+      const totalInclVat = asDinero(data.raw[index].total_incl_vat);
+      const totalExclVat = asDinero(data.raw[index].total_excl_vat);
+      return {
+        category: productCategory,
+        totalExclVat,
+        totalInclVat,
+      };
+    });
+  }
 
-    /**
+  /**
      * Gets the totals for the given user
      * @param forId - The user ID to get the totals for
      * @param fromDate - The from date to get the totals for (inclusive)
      * @param tillDate - The till date to get the totals for (exclusive)
      * @returns {Promise<{ totalExclVat: Dinero.Dinero, totalInclVat: Dinero.Dinero }>} - The totals
      */
-    public async getTotals(forId: number, fromDate: Date, tillDate: Date): Promise<{ totalExclVat: Dinero.Dinero, totalInclVat: Dinero.Dinero }> {
-        const query = this.manager.createQueryBuilder(ProductRevision, 'productRevision')
-            .innerJoin('productRevision.vat', 'vatGroup')
-            .innerJoin(SubTransactionRow, 'subTransactionRow', 'subTransactionRow.productProductId = productRevision.productId AND subTransactionRow.productRevision = productRevision.revision')
-            .innerJoin(SubTransaction, 'subTransaction', 'subTransaction.id = subTransactionRow.subTransactionId')
-        this.addSelectTotals(query);
+  public async getTotals(forId: number, fromDate: Date, tillDate: Date): Promise<{ totalExclVat: Dinero.Dinero, totalInclVat: Dinero.Dinero }> {
+    const query = this.manager.createQueryBuilder(ProductRevision, 'productRevision')
+      .innerJoin('productRevision.vat', 'vatGroup')
+      .innerJoin(SubTransactionRow, 'subTransactionRow', 'subTransactionRow.productProductId = productRevision.productId AND subTransactionRow.productRevision = productRevision.revision')
+      .innerJoin(SubTransaction, 'subTransaction', 'subTransaction.id = subTransactionRow.subTransactionId');
+    this.addSelectTotals(query);
 
-        const data = await this.addSubTransactionRowFilter(query, forId, fromDate, tillDate)
-            .getRawAndEntities();
+    const data = await this.addSubTransactionRowFilter(query, forId, fromDate, tillDate)
+      .getRawAndEntities();
 
-        const totalExclVat = asDinero(data.raw[0].total_excl_vat);
-        const totalInclVat = asDinero(data.raw[0].total_incl_vat);
-        return {
-            totalExclVat,
-            totalInclVat
-        };
-    }
+    const totalExclVat = asDinero(data.raw[0].total_excl_vat);
+    const totalInclVat = asDinero(data.raw[0].total_incl_vat);
+    return {
+      totalExclVat,
+      totalInclVat,
+    };
+  }
 
-    /**
+  /**
      * Gets the sales report for the given user
      * @param forId - The user ID to get the report for
      * @param fromDate - The from date to get the report for (inclusive)
      * @param tillDate - The till date to get the report for (exclusive)
      * @returns {Promise<SalesReport>} - The sales report
      */
-    public async getSalesReport(forId: number, fromDate: Date, tillDate: Date): Promise<SalesReport> {
-        console.error(forId, fromDate, tillDate);
+  public async getSalesReport(forId: number, fromDate: Date, tillDate: Date): Promise<SalesReport> {
+    console.error(forId, fromDate, tillDate);
 
-        const productEntries = await this.getProductEntries(forId, fromDate, tillDate);
-        const vatEntries = await this.getVatEntries(forId, fromDate, tillDate);
-        const categoryEntries = await this.getCategoryEntries(forId, fromDate, tillDate);
-        const totals = await this.getTotals(forId, fromDate, tillDate);
+    const productEntries = await this.getProductEntries(forId, fromDate, tillDate);
+    const vatEntries = await this.getVatEntries(forId, fromDate, tillDate);
+    const categoryEntries = await this.getCategoryEntries(forId, fromDate, tillDate);
+    const totals = await this.getTotals(forId, fromDate, tillDate);
 
-        return {
-            forId,
-            fromDate,
-            tillDate,
-            data: {
-                entries: productEntries,
-                categories: categoryEntries,
-                vat: vatEntries,
-            },
-            totalExclVat: totals.totalExclVat,
-            totalInclVat: totals.totalInclVat,
-        }
-    }
+    return {
+      forId,
+      fromDate,
+      tillDate,
+      data: {
+        entries: productEntries,
+        categories: categoryEntries,
+        vat: vatEntries,
+      },
+      totalExclVat: totals.totalExclVat,
+      totalInclVat: totals.totalInclVat,
+    };
+  }
 }

--- a/src/service/vat-group-service.ts
+++ b/src/service/vat-group-service.ts
@@ -24,7 +24,7 @@ import QueryFilter, { FilterMapping } from '../helpers/query-filter';
 import {
   PaginatedVatGroupResponse,
   VatDeclarationResponse,
-  VatDeclarationRow,
+  VatDeclarationRow, VatGroupResponse,
 } from '../controller/response/vat-group-response';
 import { UpdateVatGroupRequest, VatGroupRequest } from '../controller/request/vat-group-request';
 import { RequestWithToken } from '../middleware/token-middleware';
@@ -81,6 +81,14 @@ export function parseGetVatCalculationValuesParams(req: RequestWithToken): VatDe
 }
 
 export default class VatGroupService {
+  public static revisionToResponse(vatGroup: VatGroup): VatGroupResponse {
+    return {
+      ...vatGroup,
+      createdAt: vatGroup.createdAt.toISOString(),
+      updatedAt:vatGroup.updatedAt.toISOString(),
+    };
+  }
+
   /**
    * Returns all VAT groups with options.
    * @param filters - The filtering parameters.

--- a/test/helpers/transaction-factory.ts
+++ b/test/helpers/transaction-factory.ts
@@ -17,24 +17,24 @@
  */
 
 import dinero from 'dinero.js';
-import {expect} from 'chai';
-import {ProductResponse} from '../../src/controller/response/product-response';
-import {DineroObjectRequest} from '../../src/controller/request/dinero-request';
+import { expect } from 'chai';
+import { ProductResponse } from '../../src/controller/response/product-response';
+import { DineroObjectRequest } from '../../src/controller/request/dinero-request';
 import RevisionRequest from '../../src/controller/request/revision-request';
-import {ContainerWithProductsResponse} from '../../src/controller/response/container-response';
+import { ContainerWithProductsResponse } from '../../src/controller/response/container-response';
 import {
   SubTransactionRequest,
   SubTransactionRowRequest,
   TransactionRequest,
 } from '../../src/controller/request/transaction-request';
-import {PointOfSaleWithContainersResponse} from '../../src/controller/response/point-of-sale-response';
+import { PointOfSaleWithContainersResponse } from '../../src/controller/response/point-of-sale-response';
 import PointOfSaleRevision from '../../src/entity/point-of-sale/point-of-sale-revision';
 import PointOfSaleService from '../../src/service/point-of-sale-service';
-import TransactionService from "../../src/service/transaction-service";
+import TransactionService from '../../src/service/transaction-service';
 import Transaction from '../../src/entity/transactions/transaction';
-import {In, UpdateResult} from "typeorm";
-import {AppDataSource} from "../../src/database/database";
-import {toMySQLString} from "../../src/helpers/timestamps";
+import { In, UpdateResult } from 'typeorm';
+import { AppDataSource } from '../../src/database/database';
+import { toMySQLString } from '../../src/helpers/timestamps';
 
 function wrapGet<T>(array: T[], index: number): T {
   return array[index % array.length];
@@ -134,11 +134,11 @@ export async function createValidTransactionRequest(byId: number, toId: number) 
 }
 
 export async function createTransactionRequest(debtorId: number,
-                                               creditorId: number, transactionCount: number) {
+  creditorId: number, transactionCount: number) {
   const transactions: TransactionRequest[] = [];
   await Promise.all(Array(transactionCount).fill(0, 0).map(async () => {
     const t = await createValidTransactionRequest(
-        debtorId, creditorId,
+      debtorId, creditorId,
     );
     return transactions.push(t as TransactionRequest);
   }));
@@ -146,37 +146,47 @@ export async function createTransactionRequest(debtorId: number,
 }
 
 export async function requestToTransaction(
-    transactionRequests: TransactionRequest[],
+  transactionRequests: TransactionRequest[],
 ) {
   const transactions: Array<{ tId: number; amount: number }> = [];
   let total = 0;
   await Promise.all(
-      transactionRequests.map(async (t) => {
-        const transactionResponse = await new TransactionService().createTransaction(t);
-        transactions.push({
-          tId: transactionResponse.id,
-          amount: transactionResponse.totalPriceInclVat.amount,
-        });
-        total += transactionResponse.totalPriceInclVat.amount;
-      }),
+    transactionRequests.map(async (t) => {
+      const transactionResponse = await new TransactionService().createTransaction(t);
+      transactions.push({
+        tId: transactionResponse.id,
+        amount: transactionResponse.totalPriceInclVat.amount,
+      });
+      total += transactionResponse.totalPriceInclVat.amount;
+    }),
   );
-  return {transactions, total};
+  return { transactions, total };
 }
 
 export async function createTransactions(debtorId: number, creditorId: number, transactionCount: number, delta?: number) {
   const requests: TransactionRequest[] = await createTransactionRequest(
-      debtorId, creditorId, transactionCount,
+    debtorId, creditorId, transactionCount,
   );
 
   const transactions = await requestToTransaction(requests);
   if (delta) {
     const promises: Promise<any>[] = [];
     const ids = transactions.transactions.map((t) => t.tId);
-    await Transaction.find({ where: { id: In(ids) } }).then((transactions) => {
-      transactions.forEach((t) => {
-        const createdAt = new Date(t.createdAt.getTime() + delta);
-        const query = `UPDATE 'transaction' SET createdAt = '${toMySQLString(createdAt)}' WHERE id = ${t.id}`;
+    await Transaction.find({ where: { id: In(ids) }, relations: ['subTransactions', 'subTransactions.subTransactionRows'] }).then((tr) => {
+      tr.forEach((t) => {
+        let createdAt = new Date(t.createdAt.getTime() + delta);
+        let query = `UPDATE 'transaction' SET createdAt = '${toMySQLString(createdAt)}' WHERE id = ${t.id}`;
         promises.push(AppDataSource.query(query));
+        t.subTransactions.forEach((st) => {
+          createdAt = new Date(st.createdAt.getTime() + delta);
+          query = `UPDATE 'sub_transaction' SET createdAt = '${toMySQLString(createdAt)}' WHERE id = ${st.id}`;
+          promises.push(AppDataSource.query(query));
+          st.subTransactionRows.forEach((sr) => {
+            createdAt = new Date(sr.createdAt.getTime() + delta);
+            query = `UPDATE 'sub_transaction_row' SET createdAt = '${toMySQLString(createdAt)}' WHERE id = ${sr.id}`;
+            promises.push(AppDataSource.query(query));
+          });
+        });
       });
     });
     await Promise.all(promises);

--- a/test/helpers/transaction-factory.ts
+++ b/test/helpers/transaction-factory.ts
@@ -17,19 +17,24 @@
  */
 
 import dinero from 'dinero.js';
-import { expect } from 'chai';
-import { ProductResponse } from '../../src/controller/response/product-response';
-import { DineroObjectRequest } from '../../src/controller/request/dinero-request';
+import {expect} from 'chai';
+import {ProductResponse} from '../../src/controller/response/product-response';
+import {DineroObjectRequest} from '../../src/controller/request/dinero-request';
 import RevisionRequest from '../../src/controller/request/revision-request';
-import { ContainerWithProductsResponse } from '../../src/controller/response/container-response';
+import {ContainerWithProductsResponse} from '../../src/controller/response/container-response';
 import {
   SubTransactionRequest,
   SubTransactionRowRequest,
   TransactionRequest,
 } from '../../src/controller/request/transaction-request';
-import { PointOfSaleWithContainersResponse } from '../../src/controller/response/point-of-sale-response';
+import {PointOfSaleWithContainersResponse} from '../../src/controller/response/point-of-sale-response';
 import PointOfSaleRevision from '../../src/entity/point-of-sale/point-of-sale-revision';
 import PointOfSaleService from '../../src/service/point-of-sale-service';
+import TransactionService from "../../src/service/transaction-service";
+import Transaction from '../../src/entity/transactions/transaction';
+import {In, UpdateResult} from "typeorm";
+import {AppDataSource} from "../../src/database/database";
+import {toMySQLString} from "../../src/helpers/timestamps";
 
 function wrapGet<T>(array: T[], index: number): T {
   return array[index % array.length];
@@ -126,4 +131,57 @@ export async function createValidTransactionRequest(byId: number, toId: number) 
     byId, toId, 3, pos,
   ));
   return request;
+}
+
+export async function createTransactionRequest(debtorId: number,
+                                               creditorId: number, transactionCount: number) {
+  const transactions: TransactionRequest[] = [];
+  await Promise.all(Array(transactionCount).fill(0, 0).map(async () => {
+    const t = await createValidTransactionRequest(
+        debtorId, creditorId,
+    );
+    return transactions.push(t as TransactionRequest);
+  }));
+  return transactions;
+}
+
+export async function requestToTransaction(
+    transactionRequests: TransactionRequest[],
+) {
+  const transactions: Array<{ tId: number; amount: number }> = [];
+  let total = 0;
+  await Promise.all(
+      transactionRequests.map(async (t) => {
+        const transactionResponse = await new TransactionService().createTransaction(t);
+        transactions.push({
+          tId: transactionResponse.id,
+          amount: transactionResponse.totalPriceInclVat.amount,
+        });
+        total += transactionResponse.totalPriceInclVat.amount;
+      }),
+  );
+  return {transactions, total};
+}
+
+export async function createTransactions(debtorId: number, creditorId: number, transactionCount: number, delta?: number) {
+  const requests: TransactionRequest[] = await createTransactionRequest(
+      debtorId, creditorId, transactionCount,
+  );
+
+  const transactions = await requestToTransaction(requests);
+  if (delta) {
+    const promises: Promise<any>[] = [];
+    const ids = transactions.transactions.map((t) => t.tId);
+    await Transaction.find({ where: { id: In(ids) } }).then((transactions) => {
+      transactions.forEach((t) => {
+        const createdAt = new Date(t.createdAt.getTime() + delta);
+        const query = `UPDATE 'transaction' SET createdAt = '${toMySQLString(createdAt)}' WHERE id = ${t.id}`;
+        promises.push(AppDataSource.query(query));
+      });
+    });
+    await Promise.all(promises);
+  }
+
+
+  return transactions;
 }

--- a/test/helpers/transaction-factory.ts
+++ b/test/helpers/transaction-factory.ts
@@ -175,15 +175,15 @@ export async function createTransactions(debtorId: number, creditorId: number, t
     await Transaction.find({ where: { id: In(ids) }, relations: ['subTransactions', 'subTransactions.subTransactionRows'] }).then((tr) => {
       tr.forEach((t) => {
         let createdAt = new Date(t.createdAt.getTime() + delta);
-        let query = `UPDATE 'transaction' SET createdAt = '${toMySQLString(createdAt)}' WHERE id = ${t.id}`;
+        let query = `UPDATE \`transaction\` SET createdAt = '${toMySQLString(createdAt)}' WHERE id = ${t.id}`;
         promises.push(AppDataSource.query(query));
         t.subTransactions.forEach((st) => {
           createdAt = new Date(st.createdAt.getTime() + delta);
-          query = `UPDATE 'sub_transaction' SET createdAt = '${toMySQLString(createdAt)}' WHERE id = ${st.id}`;
+          query = `UPDATE \`sub_transaction\` SET createdAt = '${toMySQLString(createdAt)}' WHERE id = ${st.id}`;
           promises.push(AppDataSource.query(query));
           st.subTransactionRows.forEach((sr) => {
             createdAt = new Date(sr.createdAt.getTime() + delta);
-            query = `UPDATE 'sub_transaction_row' SET createdAt = '${toMySQLString(createdAt)}' WHERE id = ${sr.id}`;
+            query = `UPDATE \`sub_transaction_row\` SET createdAt = '${toMySQLString(createdAt)}' WHERE id = ${sr.id}`;
             promises.push(AppDataSource.query(query));
           });
         });

--- a/test/helpers/transaction-factory.ts
+++ b/test/helpers/transaction-factory.ts
@@ -32,7 +32,7 @@ import PointOfSaleRevision from '../../src/entity/point-of-sale/point-of-sale-re
 import PointOfSaleService from '../../src/service/point-of-sale-service';
 import TransactionService from '../../src/service/transaction-service';
 import Transaction from '../../src/entity/transactions/transaction';
-import { In, UpdateResult } from 'typeorm';
+import { In } from 'typeorm';
 import { AppDataSource } from '../../src/database/database';
 import { toMySQLString } from '../../src/helpers/timestamps';
 

--- a/test/unit/controller/invoice-controller.ts
+++ b/test/unit/controller/invoice-controller.ts
@@ -66,7 +66,7 @@ import sinon from 'sinon';
 import { truncateAllTables } from '../../setup';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { getToken, seedRoles } from '../../seed/rbac';
-import {createTransactionRequest, requestToTransaction} from "../../helpers/transaction-factory";
+import { createTransactionRequest, requestToTransaction } from '../../helpers/transaction-factory';
 
 describe('InvoiceController', async () => {
   let ctx: {

--- a/test/unit/controller/invoice-controller.ts
+++ b/test/unit/controller/invoice-controller.ts
@@ -56,7 +56,6 @@ import {
 import InvoiceEntryRequest from '../../../src/controller/request/invoice-entry-request';
 import { inUserContext, INVOICE_USER, ORGAN_USER, UserFactory } from '../../helpers/user-factory';
 import { TransactionRequest } from '../../../src/controller/request/transaction-request';
-import { createTransactionRequest, requestToTransaction } from '../service/invoice-service';
 import BalanceService from '../../../src/service/balance-service';
 import { InvoiceState } from '../../../src/entity/invoices/invoice-status';
 import InvoiceService from '../../../src/service/invoice-service';
@@ -67,6 +66,7 @@ import sinon from 'sinon';
 import { truncateAllTables } from '../../setup';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { getToken, seedRoles } from '../../seed/rbac';
+import {createTransactionRequest, requestToTransaction} from "../../helpers/transaction-factory";
 
 describe('InvoiceController', async () => {
   let ctx: {

--- a/test/unit/controller/user-controller.ts
+++ b/test/unit/controller/user-controller.ts
@@ -71,6 +71,7 @@ import { truncateAllTables } from '../../setup';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { getToken, SeededRole, seedRoles } from '../../seed/rbac';
 import { createTransactions } from '../../helpers/transaction-factory';
+import { ReportResponse } from '../../../src/controller/response/report-response';
 
 chai.use(deepEqualInAnyOrder);
 
@@ -2093,6 +2094,174 @@ describe('UserController', (): void => {
         .post(`/users/${user.id}/fines/waive`)
         .set('Authorization', `Bearer ${ctx.userToken}`);
       expect(res.status).to.equal(403);
+    });
+  });
+  describe('GET /users/{id}/transactions/sales/report', () => {
+    it('should return the correct model', async () => {
+      await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+        await createTransactions(debtor.id, creditor.id, 3);
+        const parameters = {
+          fromDate: new Date(2000, 0, 0),
+          tillDate: new Date(2050, 0, 0),
+        };
+
+        const res = await request(ctx.app)
+          .get(`/users/${creditor.id}/transactions/sales/report`)
+          .set('Authorization', `Bearer ${ctx.adminToken}`)
+          .query(parameters);
+        expect(res.status).to.equal(200);
+        const validation = ctx.specification.validateModel(
+          'ReportResponse',
+          res.body,
+          false,
+          false,
+        );
+        expect(validation.valid).to.be.true;
+      });
+    });
+    it('should create a transaction report', async () => {
+      await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+        const transactions = await createTransactions(debtor.id, creditor.id, 3);
+        const parameters = {
+          fromDate: new Date(2000, 0, 0),
+          tillDate: new Date(2050, 0, 0),
+        };
+
+        const res = await request(ctx.app)
+          .get(`/users/${creditor.id}/transactions/sales/report`)
+          .set('Authorization', `Bearer ${ctx.adminToken}`)
+          .query(parameters);
+        expect(res.status).to.equal(200);
+        const report = res.body as ReportResponse;
+
+        const productSum = report.data.products.reduce((sum, current) => {
+          return sum += current.totalInclVat.amount;
+        }, 0);
+        const catSum = report.data.categories.reduce((sum, current) => {
+          return sum += current.totalInclVat.amount;
+        }, 0);
+        const vatSum = report.data.vat.reduce((sum, current) => {
+          return sum += current.totalInclVat.amount;
+        }, 0);
+
+        expect(productSum).to.equal(report.totalInclVat.amount);
+        expect(catSum).to.equal(report.totalInclVat.amount);
+        expect(vatSum).to.equal(report.totalInclVat.amount);
+        expect(report.totalInclVat.amount).to.eq(transactions.total);
+      });
+    });
+    it('should validate transaction filters', async () => {
+      await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+        const parameters = {
+          fromDate: 'string' as unknown as Date,
+          tillDate: new Date(2050, 0, 0),
+        };
+
+        const res = await request(ctx.app)
+          .get(`/users/${creditor.id}/transactions/sales/report`)
+          .set('Authorization', `Bearer ${ctx.adminToken}`)
+          .query(parameters);
+        expect(res.status).to.equal(400);
+      });
+    });
+    it('should thrown an HTTP 404 if user is undefined', async () => {
+      const parameters = {
+        fromDate: new Date(2000, 0, 0),
+        tillDate: new Date(2050, 0, 0),
+      };
+      const count = await User.count();
+      const id = count + 1;
+      const user = await User.findOne({ where: { id } });
+      expect(user).to.be.null;
+      const res = await request(ctx.app)
+        .get(`/users/${id}/transactions/sales/report`)
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .query(parameters);
+      expect(res.status).to.equal(404);
+    });
+  });
+  describe('GET /users/{id}transactions/purchases/report', () => {
+    it('should return the correct model', async () => {
+      await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+        await createTransactions(debtor.id, creditor.id, 3);
+        const parameters = {
+          fromDate: new Date(2000, 0, 0),
+          tillDate: new Date(2050, 0, 0),
+        };
+
+        const res = await request(ctx.app)
+          .get(`/users/${creditor.id}/transactions/purchases/report`)
+          .set('Authorization', `Bearer ${ctx.adminToken}`)
+          .query(parameters);
+        expect(res.status).to.equal(200);
+        const validation = ctx.specification.validateModel(
+          'ReportResponse',
+          res.body,
+          false,
+          false,
+        );
+        expect(validation.valid).to.be.true;
+      });
+    });
+    it('should create a transaction report', async () => {
+      await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+        const transactions = await createTransactions(debtor.id, creditor.id, 3);
+        const parameters = {
+          fromDate: new Date(2000, 0, 0),
+          tillDate: new Date(2050, 0, 0),
+        };
+
+        const res = await request(ctx.app)
+          .get(`/users/${debtor.id}/transactions/purchases/report`)
+          .set('Authorization', `Bearer ${ctx.adminToken}`)
+          .query(parameters);
+        expect(res.status).to.equal(200);
+        const report = res.body as ReportResponse;
+
+        const productSum = report.data.products.reduce((sum, current) => {
+          return sum += current.totalInclVat.amount;
+        }, 0);
+        const catSum = report.data.categories.reduce((sum, current) => {
+          return sum += current.totalInclVat.amount;
+        }, 0);
+        const vatSum = report.data.vat.reduce((sum, current) => {
+          return sum += current.totalInclVat.amount;
+        }, 0);
+
+        expect(productSum).to.equal(report.totalInclVat.amount);
+        expect(catSum).to.equal(report.totalInclVat.amount);
+        expect(vatSum).to.equal(report.totalInclVat.amount);
+        expect(report.totalInclVat.amount).to.eq(transactions.total);
+      });
+    });
+    it('should validate transaction filters', async () => {
+      await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+        const parameters = {
+          fromDate: 'string' as unknown as Date,
+          tillDate: new Date(2050, 0, 0),
+        };
+
+        const res = await request(ctx.app)
+          .get(`/users/${creditor.id}/transactions/purchases/report`)
+          .set('Authorization', `Bearer ${ctx.adminToken}`)
+          .query(parameters);
+        expect(res.status).to.equal(400);
+      });
+    });
+    it('should thrown an HTTP 404 if user is undefined', async () => {
+      const parameters = {
+        fromDate: new Date(2000, 0, 0),
+        tillDate: new Date(2050, 0, 0),
+      };
+      const count = await User.count();
+      const id = count + 1;
+      const user = await User.findOne({ where: { id } });
+      expect(user).to.be.null;
+      const res = await request(ctx.app)
+        .get(`/users/${id}/transactions/purchases/report`)
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .query(parameters);
+      expect(res.status).to.equal(404);
     });
   });
 });

--- a/test/unit/controller/user-controller.ts
+++ b/test/unit/controller/user-controller.ts
@@ -65,12 +65,12 @@ import StripeDeposit from '../../../src/entity/stripe/stripe-deposit';
 import { StripeDepositResponse } from '../../../src/controller/response/stripe-response';
 import { TransactionReportResponse } from '../../../src/controller/response/transaction-report-response';
 import { TransactionFilterParameters } from '../../../src/service/transaction-service';
-import { createTransactions } from '../service/invoice-service';
 import UpdateNfcRequest from '../../../src/controller/request/update-nfc-request';
 import UserFineGroup from '../../../src/entity/fine/userFineGroup';
 import { truncateAllTables } from '../../setup';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { getToken, SeededRole, seedRoles } from '../../seed/rbac';
+import {createTransactions} from "../../helpers/transaction-factory";
 
 chai.use(deepEqualInAnyOrder);
 

--- a/test/unit/controller/user-controller.ts
+++ b/test/unit/controller/user-controller.ts
@@ -70,7 +70,7 @@ import UserFineGroup from '../../../src/entity/fine/userFineGroup';
 import { truncateAllTables } from '../../setup';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { getToken, SeededRole, seedRoles } from '../../seed/rbac';
-import {createTransactions} from "../../helpers/transaction-factory";
+import { createTransactions } from '../../helpers/transaction-factory';
 
 chai.use(deepEqualInAnyOrder);
 

--- a/test/unit/service/invoice-service.ts
+++ b/test/unit/service/invoice-service.ts
@@ -16,15 +16,15 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import {Connection, In} from 'typeorm';
-import express, {Application} from 'express';
-import {SwaggerSpecification} from 'swagger-model-validator';
-import {json} from 'body-parser';
-import chai, {expect} from 'chai';
+import { Connection, In } from 'typeorm';
+import express, { Application } from 'express';
+import { SwaggerSpecification } from 'swagger-model-validator';
+import { json } from 'body-parser';
+import chai, { expect } from 'chai';
 import deepEqualInAnyOrder from 'deep-equal-in-any-order';
-import User, {UserType} from '../../../src/entity/user/user';
+import User, { UserType } from '../../../src/entity/user/user';
 import Invoice from '../../../src/entity/invoices/invoice';
-import Database, {AppDataSource} from '../../../src/database/database';
+import Database, { AppDataSource } from '../../../src/database/database';
 import {
   seedContainers,
   seedInvoices,
@@ -43,19 +43,19 @@ import {
 } from '../../../src/controller/response/invoice-response';
 import InvoiceService from '../../../src/service/invoice-service';
 import InvoiceEntry from '../../../src/entity/invoices/invoice-entry';
-import {CreateInvoiceParams, UpdateInvoiceParams} from '../../../src/controller/request/invoice-request';
-import {TransferResponse} from '../../../src/controller/response/transfer-response';
+import { CreateInvoiceParams, UpdateInvoiceParams } from '../../../src/controller/request/invoice-request';
+import { TransferResponse } from '../../../src/controller/response/transfer-response';
 import TransactionService from '../../../src/service/transaction-service';
 import { BaseTransactionResponse, TransactionResponse } from '../../../src/controller/response/transaction-response';
 import BalanceService from '../../../src/service/balance-service';
-import {createTransactionRequest, createTransactions, requestToTransaction} from '../../helpers/transaction-factory';
-import {inUserContext, UserFactory} from '../../helpers/user-factory';
-import {TransactionRequest} from '../../../src/controller/request/transaction-request';
-import {InvoiceState} from '../../../src/entity/invoices/invoice-status';
+import { createTransactionRequest, createTransactions, requestToTransaction } from '../../helpers/transaction-factory';
+import { inUserContext, UserFactory } from '../../helpers/user-factory';
+import { TransactionRequest } from '../../../src/controller/request/transaction-request';
+import { InvoiceState } from '../../../src/entity/invoices/invoice-status';
 import Transaction from '../../../src/entity/transactions/transaction';
 import InvoiceUser from '../../../src/entity/user/invoice-user';
-import {truncateAllTables} from '../../setup';
-import {finishTestDB} from '../../helpers/test-helpers';
+import { truncateAllTables } from '../../setup';
+import { finishTestDB } from '../../helpers/test-helpers';
 
 chai.use(deepEqualInAnyOrder);
 

--- a/test/unit/service/report-service.ts
+++ b/test/unit/service/report-service.ts
@@ -19,7 +19,7 @@ import { defaultBefore, DefaultContext, finishTestDB } from '../../helpers/test-
 import { inUserContext, UserFactory } from '../../helpers/user-factory';
 import { createTransactions } from '../../helpers/transaction-factory';
 import User from '../../../src/entity/user/user';
-import { BuyerReportService, Report, ReportParameters, SalesReportService } from '../../../src/service/report-service';
+import { BuyerReportService, ReportParameters, SalesReportService } from '../../../src/service/report-service';
 import { expect } from 'chai';
 import {
   seedContainers,
@@ -30,6 +30,8 @@ import {
   seedVatGroups,
 } from '../../seed';
 import TransactionService from '../../../src/service/transaction-service';
+import { Report } from '../../../src/entity/report/report';
+
 describe('ReportService', () => {
   let ctx: any & DefaultContext;
 

--- a/test/unit/service/report-service.ts
+++ b/test/unit/service/report-service.ts
@@ -237,9 +237,9 @@ describe('ReportService', () => {
 
       it('should return the total income of a user with mixed transactions before and after the fromDate', async () => {
         await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
-          const fromDate = new Date(new Date().getTime() - 1500);
-          await createTransactions(debtor.id, creditor.id, 2, -2000);  // Before fromDate
-          const transactions = await createTransactions(debtor.id, creditor.id, 3, -1000); // After fromDate
+          await createTransactions(debtor.id, creditor.id, 2, -4000);  // Before fromDate
+          const fromDate = new Date(new Date().getTime() - 1000);
+          const transactions = await createTransactions(debtor.id, creditor.id, 3); // After fromDate
           await checkTransactionsSalesReport(transactions.transactions, {
             fromDate,
             tillDate: new Date(2050, 0, 0),

--- a/test/unit/service/report-service.ts
+++ b/test/unit/service/report-service.ts
@@ -1,0 +1,369 @@
+import { defaultBefore, DefaultContext, finishTestDB } from "../../helpers/test-helpers";
+import { inUserContext, UserFactory } from "../../helpers/user-factory";
+import { createTransactions } from "../../helpers/transaction-factory";
+import User from "../../../src/entity/user/user";
+import { BuyerReportService, Report, SalesReportService } from "../../../src/service/report-service";
+import { expect } from "chai";
+import {
+    seedContainers,
+    seedPointsOfSale,
+    seedProductCategories,
+    seedProducts, seedTransactions,
+    seedUsers,
+    seedVatGroups
+} from "../../seed";
+import TransactionService from "../../../src/service/transaction-service";
+import Transaction from "../../../src/entity/transactions/transaction";
+import {In} from "typeorm";
+
+
+const DAY = 86400000;
+describe('ReportService', () => {
+    let ctx: any & DefaultContext;
+
+    before(async () => {
+        ctx = {
+            ...(await defaultBefore()),
+        } as any;
+
+        const users = await seedUsers();
+        const vatGropus = await seedVatGroups();
+        const categories = await seedProductCategories();
+        const { productRevisions } = await seedProducts(users, categories, vatGropus);
+        const { containerRevisions } = await seedContainers(users, productRevisions);
+        const { pointOfSaleRevisions } = await seedPointsOfSale(users, containerRevisions);
+        const { transactions } = await seedTransactions(users, pointOfSaleRevisions);
+
+        ctx = {
+            ...ctx,
+            users,
+            transactions,
+        };
+    });
+
+    after(async () => {
+        await finishTestDB(ctx.connection);
+    });
+
+    function checkReport(report: Report) {
+        if (report.data.products) {
+            let sumExclVat = 0;
+            let sumInclVat = 0;
+            report.data.products.forEach((entry) => {
+                sumExclVat += entry.totalExclVat.getAmount();
+                sumInclVat += entry.totalInclVat.getAmount();
+                expect(entry.totalExclVat.getAmount()).to.eq(entry.count * Math.round(entry.product.priceInclVat.getAmount() / (1 + (entry.product.vat.percentage / 100))));
+                expect(entry.totalInclVat.getAmount()).to.equal(entry.product.priceInclVat.getAmount() * entry.count);
+            });
+            expect(sumExclVat).to.equal(report.totalExclVat.getAmount());
+            expect(sumInclVat).to.equal(report.totalInclVat.getAmount());
+        }
+        if (report.data.categories) {
+            let sumExclVat = 0;
+            let sumInclVat = 0;
+            report.data.categories.forEach((entry) => {
+                sumExclVat += entry.totalExclVat.getAmount();
+                sumInclVat += entry.totalInclVat.getAmount();
+            });
+            expect(sumExclVat).to.equal(report.totalExclVat.getAmount());
+            expect(sumInclVat).to.equal(report.totalInclVat.getAmount());
+        }
+        if (report.data.pos) {
+            let sumExclVat = 0;
+            let sumInclVat = 0;
+            report.data.pos.forEach((entry) => {
+                sumExclVat += entry.totalExclVat.getAmount();
+                sumInclVat += entry.totalInclVat.getAmount();
+            });
+            expect(sumExclVat).to.equal(report.totalExclVat.getAmount());
+            expect(sumInclVat).to.equal(report.totalInclVat.getAmount());
+        }
+        if (report.data.containers) {
+            let sumExclVat = 0;
+            let sumInclVat = 0;
+            report.data.containers.forEach((entry) => {
+                sumExclVat += entry.totalExclVat.getAmount();
+                sumInclVat += entry.totalInclVat.getAmount();
+            });
+            expect(sumExclVat).to.equal(report.totalExclVat.getAmount());
+            expect(sumInclVat).to.equal(report.totalInclVat.getAmount());
+        }
+        if (report.data.vat) {
+            let sumExclVat = 0;
+            let sumInclVat = 0;
+            report.data.vat.forEach((entry) => {
+                sumExclVat += entry.totalExclVat.getAmount();
+                sumInclVat += entry.totalInclVat.getAmount();
+            });
+            expect(sumExclVat).to.equal(report.totalExclVat.getAmount());
+            expect(sumInclVat).to.equal(report.totalInclVat.getAmount());
+        }
+    }
+
+    async function createMultipleBuyersSingleSeller(buyerCount: number = 3, tester: (users: User[], transactions: { tId: number, amount: number }[]) => Promise<void>) {
+        return inUserContext((await UserFactory()).clone(buyerCount + 1), async (...users: User[]) => {
+            const [seller, ...buyers] = users;
+            const transactions = [];
+            for (let buyer of buyers) {
+                transactions.push(...(await createTransactions(buyer.id, seller.id, 3)).transactions);
+            }
+            await tester([seller, ...buyers], transactions);
+        });
+    }
+
+    describe('BuyerReportService', () => {
+        it('should return the total income of a user', async () => {
+            await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+                const transaction = (await createTransactions(debtor.id, creditor.id, 1)).transactions[0];
+                const parameters = {
+                    fromDate: new Date(2000, 0, 0),
+                    tillDate: new Date(2050, 0, 0),
+                    forId: creditor.id,
+                };
+                const t = await new TransactionService().getSingleTransaction(transaction.tId);
+
+                const report = await new SalesReportService().getReport(parameters);
+                expect(report.totalInclVat.getAmount()).to.eq(t.totalPriceInclVat.amount);
+                checkReport(report);
+            });
+        });
+
+        it('should return the total income of a user with multiple transactions', async () => {
+            await inUserContext((await UserFactory()).clone(3), async (debtor: User, creditor: User) => {
+                const transactions = await createTransactions(debtor.id, creditor.id, 3);
+                const parameters = {
+                    fromDate: new Date(2000, 0, 0),
+                    tillDate: new Date(2050, 0, 0),
+                    forId: creditor.id,
+                };
+                const report = await new SalesReportService().getReport(parameters);
+                expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
+                checkReport(report);
+            });
+        });
+
+        it('should return an empty report when there are no transactions', async () => {
+            await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+                const parameters = {
+                    fromDate: new Date(2000, 0, 0),
+                    tillDate: new Date(2050, 0, 0),
+                    forId: creditor.id,
+                };
+                const report = await new SalesReportService().getReport(parameters);
+                expect(report.totalInclVat.getAmount()).to.eq(0);
+                checkReport(report);
+            });
+        });
+
+        it('should return the correct total income for multiple buyers buying from the same seller', async () => {
+            await createMultipleBuyersSingleSeller(3, async (users, transactions) => {
+                const [seller, buyer] = users;
+                const parameters = {
+                    fromDate: new Date(2000, 0, 0),
+                    tillDate: new Date(2050, 0, 0),
+                    forId: seller.id,
+                };
+                const report = await new SalesReportService().getReport(parameters);
+                const totalInclVat = transactions.reduce((sum, t) => sum + t.amount, 0);
+                expect(report.totalInclVat.getAmount()).to.eq(totalInclVat);
+                checkReport(report);
+            });
+        });
+
+        describe('fromDate filter', () => {
+            it('should return the total income of a user with a transactions in the past', async () => {
+                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+                    const transactions = await createTransactions(debtor.id, creditor.id, 3, -5000);
+                    const parameters = {
+                        fromDate: new Date(),
+                        tillDate: new Date(2050, 0, 0),
+                        forId: creditor.id,
+                    };
+                    const report = await new SalesReportService().getReport(parameters);
+                    expect(report.totalInclVat.getAmount()).to.eq(0);
+                    checkReport(report);
+                });
+            });
+
+            it('should return the total income of a user with transactions right before the fromDate', async () => {
+                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+                    const fromDate = new Date(new Date().getTime() - 1000);
+                    const transactions = await createTransactions(debtor.id, creditor.id, 3, -3000);
+
+                    const parameters = {
+                        fromDate,
+                        tillDate: new Date(2050, 0, 0),
+                        forId: creditor.id,
+                    };
+                    const report = await new SalesReportService().getReport(parameters);
+                    expect(report.totalInclVat.getAmount()).to.eq(0);
+                    checkReport(report);
+                });
+            });
+
+            it('should return the total income of a user with transactions right after the fromDate', async () => {
+                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+                    const fromDate = new Date(new Date().getTime() - 2000);
+                    const transactions = await createTransactions(debtor.id, creditor.id, 3, -1000);
+                    const parameters = {
+                        fromDate,
+                        tillDate: new Date(2050, 0, 0),
+                        forId: creditor.id,
+                    };
+                    const report = await new SalesReportService().getReport(parameters);
+                    expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
+                    checkReport(report);
+                });
+            });
+
+            it('should return the total income of a user with mixed transactions before and after the fromDate', async () => {
+                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+                    const fromDate = new Date(new Date().getTime() - 1500);
+                    await createTransactions(debtor.id, creditor.id, 2, -2000);  // Before fromDate
+                    const transactions = await createTransactions(debtor.id, creditor.id, 3, -1000); // After fromDate
+                    const parameters = {
+                        fromDate,
+                        tillDate: new Date(2050, 0, 0),
+                        forId: creditor.id,
+                    };
+                    const report = await new SalesReportService().getReport(parameters);
+                    expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
+                    checkReport(report);
+                });
+            });
+
+            it('should return the total income of a user from the exact fromDate', async () => {
+                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+                    const fromDate = new Date();
+                    const transactions = await createTransactions(debtor.id, creditor.id, 3);
+                    const parameters = {
+                        fromDate,
+                        tillDate: new Date(2050, 0, 0),
+                        forId: creditor.id,
+                    };
+                    const report = await new SalesReportService().getReport(parameters);
+                    expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
+                    checkReport(report);
+                });
+            });
+        });
+
+        describe('tillDate filter', () => {
+            it('should return the total income of a user with transactions before the tillDate', async () => {
+                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+                    const tillDate = new Date(new Date().getTime() + 1000);
+                    const transactions = await createTransactions(debtor.id, creditor.id, 3);
+                    const parameters = {
+                        fromDate: new Date(2000, 0, 0),
+                        tillDate,
+                        forId: creditor.id,
+                    };
+                    const report = await new SalesReportService().getReport(parameters);
+                    expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
+                    checkReport(report);
+                });
+            });
+
+            it('should return the total income of a user with transactions right after the tillDate', async () => {
+                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+                    const tillDate = new Date(new Date().getTime() + 1000);
+                    const transactions = await createTransactions(debtor.id, creditor.id, 3, 2000);
+                    const parameters = {
+                        fromDate: new Date(2000, 0, 0),
+                        tillDate,
+                        forId: creditor.id,
+                    };
+                    const report = await new SalesReportService().getReport(parameters);
+                    expect(report.totalInclVat.getAmount()).to.eq(0);
+                    checkReport(report);
+                });
+            });
+
+            it('should return the total income of a user with transactions right before the tillDate', async () => {
+                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+                    const tillDate = new Date(new Date().getTime() + 2000);
+                    const transactions = await createTransactions(debtor.id, creditor.id, 3, 1000);
+                    const parameters = {
+                        fromDate: new Date(2000, 0, 0),
+                        tillDate,
+                        forId: creditor.id,
+                    };
+                    const report = await new SalesReportService().getReport(parameters);
+                    expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
+                    checkReport(report);
+                });
+            });
+
+            it('should return the total income of a user with mixed transactions before and after the tillDate', async () => {
+                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+                    const tillDate = new Date(new Date().getTime() + 1500);
+                    await createTransactions(debtor.id, creditor.id, 2, 2000);  // After tillDate
+                    const transactions = await createTransactions(debtor.id, creditor.id, 3, 1000); // Before tillDate
+                    const parameters = {
+                        fromDate: new Date(2000, 0, 0),
+                        tillDate,
+                        forId: creditor.id,
+                    };
+                    const report = await new SalesReportService().getReport(parameters);
+                    expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
+                    checkReport(report);
+                });
+            });
+
+            it('should return the total income of a user till the exact tillDate', async () => {
+                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+                    const tillDate = new Date(new Date().getTime() + 1000);
+                    const transactions = await createTransactions(debtor.id, creditor.id, 3);
+                    const parameters = {
+                        fromDate: new Date(2000, 0, 0),
+                        tillDate,
+                        forId: creditor.id,
+                    };
+                    const report = await new SalesReportService().getReport(parameters);
+                    expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
+                    checkReport(report);
+                });
+            });
+        });
+
+        it('should adhere to both fromDate and tillDate filters', async () => {
+            await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+                const transactionsBefore = await createTransactions(debtor.id, creditor.id, 2, -40*DAY);
+                let ids = transactionsBefore.transactions.map((t) => t.tId);
+                let transactions = await Transaction.find({where: { id: In(ids)}});
+                console.error(transactions);
+                const fromDate = new Date(new Date().getTime() - DAY);
+                const transactionsWithin = await createTransactions(debtor.id, creditor.id, 3, -2*DAY);  // Within range
+                ids = transactionsWithin.transactions.map((t) => t.tId);
+                transactions = await Transaction.find({where: { id: In(ids)}});
+                console.error(transactions);
+                const tillDate = new Date(new Date().getTime());
+                // const transactionsAfter = await createTransactions(debtor.id, creditor.id, 2); // After tillDate
+                const parameters = {
+                    fromDate,
+                    tillDate,
+                    forId: creditor.id,
+                };
+                console.error('parameters', parameters);
+                const report = await new SalesReportService().getReport(parameters);
+                expect(report.totalInclVat.getAmount()).to.eq(transactionsWithin.total);
+                checkReport(report);
+            });
+        });
+
+        it('should correctly aggregate transactions from multiple buyers to the same seller', async () => {
+            await createMultipleBuyersSingleSeller(3, async (users, transactions) => {
+                const [seller, buyer] = users;
+                const parameters = {
+                    fromDate: new Date(2000, 0, 0),
+                    tillDate: new Date(2050, 0, 0),
+                    forId: seller.id,
+                };
+                const report = await new SalesReportService().getReport(parameters);
+                const totalInclVat = transactions.reduce((sum, t) => sum + t.amount, 0);
+                expect(report.totalInclVat.getAmount()).to.eq(totalInclVat);
+                checkReport(report);
+            });
+        });
+    });
+});

--- a/test/unit/service/report-service.ts
+++ b/test/unit/service/report-service.ts
@@ -1,369 +1,342 @@
-import { defaultBefore, DefaultContext, finishTestDB } from "../../helpers/test-helpers";
-import { inUserContext, UserFactory } from "../../helpers/user-factory";
-import { createTransactions } from "../../helpers/transaction-factory";
-import User from "../../../src/entity/user/user";
-import { BuyerReportService, Report, SalesReportService } from "../../../src/service/report-service";
-import { expect } from "chai";
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { defaultBefore, DefaultContext, finishTestDB } from '../../helpers/test-helpers';
+import { inUserContext, UserFactory } from '../../helpers/user-factory';
+import { createTransactions } from '../../helpers/transaction-factory';
+import User from '../../../src/entity/user/user';
+import { BuyerReportService, Report, ReportParameters, SalesReportService } from '../../../src/service/report-service';
+import { expect } from 'chai';
 import {
-    seedContainers,
-    seedPointsOfSale,
-    seedProductCategories,
-    seedProducts, seedTransactions,
-    seedUsers,
-    seedVatGroups
-} from "../../seed";
-import TransactionService from "../../../src/service/transaction-service";
-import Transaction from "../../../src/entity/transactions/transaction";
-import {In} from "typeorm";
-
-
-const DAY = 86400000;
+  seedContainers,
+  seedPointsOfSale,
+  seedProductCategories,
+  seedProducts, seedTransactions,
+  seedUsers,
+  seedVatGroups,
+} from '../../seed';
+import TransactionService from '../../../src/service/transaction-service';
 describe('ReportService', () => {
-    let ctx: any & DefaultContext;
+  let ctx: any & DefaultContext;
 
-    before(async () => {
-        ctx = {
-            ...(await defaultBefore()),
-        } as any;
+  before(async () => {
+    ctx = {
+      ...(await defaultBefore()),
+    } as any;
 
-        const users = await seedUsers();
-        const vatGropus = await seedVatGroups();
-        const categories = await seedProductCategories();
-        const { productRevisions } = await seedProducts(users, categories, vatGropus);
-        const { containerRevisions } = await seedContainers(users, productRevisions);
-        const { pointOfSaleRevisions } = await seedPointsOfSale(users, containerRevisions);
-        const { transactions } = await seedTransactions(users, pointOfSaleRevisions);
+    const users = await seedUsers();
+    const vatGropus = await seedVatGroups();
+    const categories = await seedProductCategories();
+    const { productRevisions } = await seedProducts(users, categories, vatGropus);
+    const { containerRevisions } = await seedContainers(users, productRevisions);
+    const { pointOfSaleRevisions } = await seedPointsOfSale(users, containerRevisions);
+    const { transactions } = await seedTransactions(users, pointOfSaleRevisions);
 
-        ctx = {
-            ...ctx,
-            users,
-            transactions,
+    ctx = {
+      ...ctx,
+      users,
+      transactions,
+    };
+  });
+
+  after(async () => {
+    await finishTestDB(ctx.connection);
+  });
+
+  /**
+   * Checks if the report agrees with itself.
+   * i.e. all the totals are the same across all categories.
+   */
+  function checkReport(report: Report) {
+    // Check products
+    if (report.data.products) {
+      let sumExclVat = 0;
+      let sumInclVat = 0;
+      report.data.products.forEach((entry) => {
+        sumExclVat += entry.totalExclVat.getAmount();
+        sumInclVat += entry.totalInclVat.getAmount();
+        expect(entry.totalExclVat.getAmount()).to.eq(entry.count * Math.round(entry.product.priceInclVat.getAmount() / (1 + (entry.product.vat.percentage / 100))));
+        expect(entry.totalInclVat.getAmount()).to.equal(entry.product.priceInclVat.getAmount() * entry.count);
+      });
+      expect(sumExclVat).to.equal(report.totalExclVat.getAmount());
+      expect(sumInclVat).to.equal(report.totalInclVat.getAmount());
+    }
+    // Check categories
+    if (report.data.categories) {
+      let sumExclVat = 0;
+      let sumInclVat = 0;
+      report.data.categories.forEach((entry) => {
+        sumExclVat += entry.totalExclVat.getAmount();
+        sumInclVat += entry.totalInclVat.getAmount();
+      });
+      expect(sumExclVat).to.equal(report.totalExclVat.getAmount());
+      expect(sumInclVat).to.equal(report.totalInclVat.getAmount());
+    }
+    // Check POS
+    if (report.data.pos) {
+      let sumExclVat = 0;
+      let sumInclVat = 0;
+      report.data.pos.forEach((entry) => {
+        sumExclVat += entry.totalExclVat.getAmount();
+        sumInclVat += entry.totalInclVat.getAmount();
+      });
+      expect(sumExclVat).to.equal(report.totalExclVat.getAmount());
+      expect(sumInclVat).to.equal(report.totalInclVat.getAmount());
+    }
+    // Check containers
+    if (report.data.containers) {
+      let sumExclVat = 0;
+      let sumInclVat = 0;
+      report.data.containers.forEach((entry) => {
+        sumExclVat += entry.totalExclVat.getAmount();
+        sumInclVat += entry.totalInclVat.getAmount();
+      });
+      expect(sumExclVat).to.equal(report.totalExclVat.getAmount());
+      expect(sumInclVat).to.equal(report.totalInclVat.getAmount());
+    }
+    // Check VAT
+    if (report.data.vat) {
+      let sumExclVat = 0;
+      let sumInclVat = 0;
+      report.data.vat.forEach((entry) => {
+        sumExclVat += entry.totalExclVat.getAmount();
+        sumInclVat += entry.totalInclVat.getAmount();
+      });
+      expect(sumExclVat).to.equal(report.totalExclVat.getAmount());
+      expect(sumInclVat).to.equal(report.totalInclVat.getAmount());
+    }
+  }
+
+  async function checkTransactionReport(transactions: { tId: number, amount: number }[], parameters: ReportParameters) {
+    const report = await new SalesReportService().getReport(parameters);
+    const totalInclVat = transactions.reduce((sum, t) => sum + t.amount, 0);
+    expect(report.totalInclVat.getAmount()).to.eq(totalInclVat);
+    checkReport(report);
+  }
+
+  async function createMultipleBuyersSingleSeller(buyerCount: number, tester: (users: User[], transactions: { tId: number, amount: number }[]) => Promise<void>) {
+    return inUserContext((await UserFactory()).clone(buyerCount + 1), async (...users: User[]) => {
+      const [seller, ...buyers] = users;
+      const transactions = [];
+      for (let buyer of buyers) {
+        transactions.push(...(await createTransactions(buyer.id, seller.id, 3)).transactions);
+      }
+      await tester([seller, ...buyers], transactions);
+    });
+  }
+
+  describe('BuyerReportService', () => {
+    it('should return the total income of a user', async () => {
+      await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+        const transaction = (await createTransactions(debtor.id, creditor.id, 1)).transactions[0];
+        const parameters = {
+          fromDate: new Date(2000, 0, 0),
+          tillDate: new Date(2050, 0, 0),
+          forId: creditor.id,
         };
+        const t = await new TransactionService().getSingleTransaction(transaction.tId);
+
+        const report = await new SalesReportService().getReport(parameters);
+        expect(report.totalInclVat.getAmount()).to.eq(t.totalPriceInclVat.amount);
+        checkReport(report);
+      });
     });
 
-    after(async () => {
-        await finishTestDB(ctx.connection);
+    it('should return the total income of a user with multiple transactions', async () => {
+      await inUserContext((await UserFactory()).clone(3), async (debtor: User, creditor: User) => {
+        const transactions = await createTransactions(debtor.id, creditor.id, 3);
+        await checkTransactionReport(transactions.transactions, {
+          fromDate: new Date(2000, 0, 0),
+          tillDate: new Date(2050, 0, 0),
+          forId: creditor.id,
+        });
+      });
     });
 
-    function checkReport(report: Report) {
-        if (report.data.products) {
-            let sumExclVat = 0;
-            let sumInclVat = 0;
-            report.data.products.forEach((entry) => {
-                sumExclVat += entry.totalExclVat.getAmount();
-                sumInclVat += entry.totalInclVat.getAmount();
-                expect(entry.totalExclVat.getAmount()).to.eq(entry.count * Math.round(entry.product.priceInclVat.getAmount() / (1 + (entry.product.vat.percentage / 100))));
-                expect(entry.totalInclVat.getAmount()).to.equal(entry.product.priceInclVat.getAmount() * entry.count);
-            });
-            expect(sumExclVat).to.equal(report.totalExclVat.getAmount());
-            expect(sumInclVat).to.equal(report.totalInclVat.getAmount());
-        }
-        if (report.data.categories) {
-            let sumExclVat = 0;
-            let sumInclVat = 0;
-            report.data.categories.forEach((entry) => {
-                sumExclVat += entry.totalExclVat.getAmount();
-                sumInclVat += entry.totalInclVat.getAmount();
-            });
-            expect(sumExclVat).to.equal(report.totalExclVat.getAmount());
-            expect(sumInclVat).to.equal(report.totalInclVat.getAmount());
-        }
-        if (report.data.pos) {
-            let sumExclVat = 0;
-            let sumInclVat = 0;
-            report.data.pos.forEach((entry) => {
-                sumExclVat += entry.totalExclVat.getAmount();
-                sumInclVat += entry.totalInclVat.getAmount();
-            });
-            expect(sumExclVat).to.equal(report.totalExclVat.getAmount());
-            expect(sumInclVat).to.equal(report.totalInclVat.getAmount());
-        }
-        if (report.data.containers) {
-            let sumExclVat = 0;
-            let sumInclVat = 0;
-            report.data.containers.forEach((entry) => {
-                sumExclVat += entry.totalExclVat.getAmount();
-                sumInclVat += entry.totalInclVat.getAmount();
-            });
-            expect(sumExclVat).to.equal(report.totalExclVat.getAmount());
-            expect(sumInclVat).to.equal(report.totalInclVat.getAmount());
-        }
-        if (report.data.vat) {
-            let sumExclVat = 0;
-            let sumInclVat = 0;
-            report.data.vat.forEach((entry) => {
-                sumExclVat += entry.totalExclVat.getAmount();
-                sumInclVat += entry.totalInclVat.getAmount();
-            });
-            expect(sumExclVat).to.equal(report.totalExclVat.getAmount());
-            expect(sumInclVat).to.equal(report.totalInclVat.getAmount());
-        }
-    }
-
-    async function createMultipleBuyersSingleSeller(buyerCount: number = 3, tester: (users: User[], transactions: { tId: number, amount: number }[]) => Promise<void>) {
-        return inUserContext((await UserFactory()).clone(buyerCount + 1), async (...users: User[]) => {
-            const [seller, ...buyers] = users;
-            const transactions = [];
-            for (let buyer of buyers) {
-                transactions.push(...(await createTransactions(buyer.id, seller.id, 3)).transactions);
-            }
-            await tester([seller, ...buyers], transactions);
+    it('should return an empty report when there are no transactions', async () => {
+      await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+        await checkTransactionReport([{ tId: 0, amount: 0 }], {
+          fromDate: new Date(2000, 0, 0),
+          tillDate: new Date(2050, 0, 0),
+          forId: creditor.id,
         });
-    }
-
-    describe('BuyerReportService', () => {
-        it('should return the total income of a user', async () => {
-            await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
-                const transaction = (await createTransactions(debtor.id, creditor.id, 1)).transactions[0];
-                const parameters = {
-                    fromDate: new Date(2000, 0, 0),
-                    tillDate: new Date(2050, 0, 0),
-                    forId: creditor.id,
-                };
-                const t = await new TransactionService().getSingleTransaction(transaction.tId);
-
-                const report = await new SalesReportService().getReport(parameters);
-                expect(report.totalInclVat.getAmount()).to.eq(t.totalPriceInclVat.amount);
-                checkReport(report);
-            });
-        });
-
-        it('should return the total income of a user with multiple transactions', async () => {
-            await inUserContext((await UserFactory()).clone(3), async (debtor: User, creditor: User) => {
-                const transactions = await createTransactions(debtor.id, creditor.id, 3);
-                const parameters = {
-                    fromDate: new Date(2000, 0, 0),
-                    tillDate: new Date(2050, 0, 0),
-                    forId: creditor.id,
-                };
-                const report = await new SalesReportService().getReport(parameters);
-                expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
-                checkReport(report);
-            });
-        });
-
-        it('should return an empty report when there are no transactions', async () => {
-            await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
-                const parameters = {
-                    fromDate: new Date(2000, 0, 0),
-                    tillDate: new Date(2050, 0, 0),
-                    forId: creditor.id,
-                };
-                const report = await new SalesReportService().getReport(parameters);
-                expect(report.totalInclVat.getAmount()).to.eq(0);
-                checkReport(report);
-            });
-        });
-
-        it('should return the correct total income for multiple buyers buying from the same seller', async () => {
-            await createMultipleBuyersSingleSeller(3, async (users, transactions) => {
-                const [seller, buyer] = users;
-                const parameters = {
-                    fromDate: new Date(2000, 0, 0),
-                    tillDate: new Date(2050, 0, 0),
-                    forId: seller.id,
-                };
-                const report = await new SalesReportService().getReport(parameters);
-                const totalInclVat = transactions.reduce((sum, t) => sum + t.amount, 0);
-                expect(report.totalInclVat.getAmount()).to.eq(totalInclVat);
-                checkReport(report);
-            });
-        });
-
-        describe('fromDate filter', () => {
-            it('should return the total income of a user with a transactions in the past', async () => {
-                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
-                    const transactions = await createTransactions(debtor.id, creditor.id, 3, -5000);
-                    const parameters = {
-                        fromDate: new Date(),
-                        tillDate: new Date(2050, 0, 0),
-                        forId: creditor.id,
-                    };
-                    const report = await new SalesReportService().getReport(parameters);
-                    expect(report.totalInclVat.getAmount()).to.eq(0);
-                    checkReport(report);
-                });
-            });
-
-            it('should return the total income of a user with transactions right before the fromDate', async () => {
-                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
-                    const fromDate = new Date(new Date().getTime() - 1000);
-                    const transactions = await createTransactions(debtor.id, creditor.id, 3, -3000);
-
-                    const parameters = {
-                        fromDate,
-                        tillDate: new Date(2050, 0, 0),
-                        forId: creditor.id,
-                    };
-                    const report = await new SalesReportService().getReport(parameters);
-                    expect(report.totalInclVat.getAmount()).to.eq(0);
-                    checkReport(report);
-                });
-            });
-
-            it('should return the total income of a user with transactions right after the fromDate', async () => {
-                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
-                    const fromDate = new Date(new Date().getTime() - 2000);
-                    const transactions = await createTransactions(debtor.id, creditor.id, 3, -1000);
-                    const parameters = {
-                        fromDate,
-                        tillDate: new Date(2050, 0, 0),
-                        forId: creditor.id,
-                    };
-                    const report = await new SalesReportService().getReport(parameters);
-                    expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
-                    checkReport(report);
-                });
-            });
-
-            it('should return the total income of a user with mixed transactions before and after the fromDate', async () => {
-                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
-                    const fromDate = new Date(new Date().getTime() - 1500);
-                    await createTransactions(debtor.id, creditor.id, 2, -2000);  // Before fromDate
-                    const transactions = await createTransactions(debtor.id, creditor.id, 3, -1000); // After fromDate
-                    const parameters = {
-                        fromDate,
-                        tillDate: new Date(2050, 0, 0),
-                        forId: creditor.id,
-                    };
-                    const report = await new SalesReportService().getReport(parameters);
-                    expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
-                    checkReport(report);
-                });
-            });
-
-            it('should return the total income of a user from the exact fromDate', async () => {
-                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
-                    const fromDate = new Date();
-                    const transactions = await createTransactions(debtor.id, creditor.id, 3);
-                    const parameters = {
-                        fromDate,
-                        tillDate: new Date(2050, 0, 0),
-                        forId: creditor.id,
-                    };
-                    const report = await new SalesReportService().getReport(parameters);
-                    expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
-                    checkReport(report);
-                });
-            });
-        });
-
-        describe('tillDate filter', () => {
-            it('should return the total income of a user with transactions before the tillDate', async () => {
-                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
-                    const tillDate = new Date(new Date().getTime() + 1000);
-                    const transactions = await createTransactions(debtor.id, creditor.id, 3);
-                    const parameters = {
-                        fromDate: new Date(2000, 0, 0),
-                        tillDate,
-                        forId: creditor.id,
-                    };
-                    const report = await new SalesReportService().getReport(parameters);
-                    expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
-                    checkReport(report);
-                });
-            });
-
-            it('should return the total income of a user with transactions right after the tillDate', async () => {
-                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
-                    const tillDate = new Date(new Date().getTime() + 1000);
-                    const transactions = await createTransactions(debtor.id, creditor.id, 3, 2000);
-                    const parameters = {
-                        fromDate: new Date(2000, 0, 0),
-                        tillDate,
-                        forId: creditor.id,
-                    };
-                    const report = await new SalesReportService().getReport(parameters);
-                    expect(report.totalInclVat.getAmount()).to.eq(0);
-                    checkReport(report);
-                });
-            });
-
-            it('should return the total income of a user with transactions right before the tillDate', async () => {
-                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
-                    const tillDate = new Date(new Date().getTime() + 2000);
-                    const transactions = await createTransactions(debtor.id, creditor.id, 3, 1000);
-                    const parameters = {
-                        fromDate: new Date(2000, 0, 0),
-                        tillDate,
-                        forId: creditor.id,
-                    };
-                    const report = await new SalesReportService().getReport(parameters);
-                    expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
-                    checkReport(report);
-                });
-            });
-
-            it('should return the total income of a user with mixed transactions before and after the tillDate', async () => {
-                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
-                    const tillDate = new Date(new Date().getTime() + 1500);
-                    await createTransactions(debtor.id, creditor.id, 2, 2000);  // After tillDate
-                    const transactions = await createTransactions(debtor.id, creditor.id, 3, 1000); // Before tillDate
-                    const parameters = {
-                        fromDate: new Date(2000, 0, 0),
-                        tillDate,
-                        forId: creditor.id,
-                    };
-                    const report = await new SalesReportService().getReport(parameters);
-                    expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
-                    checkReport(report);
-                });
-            });
-
-            it('should return the total income of a user till the exact tillDate', async () => {
-                await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
-                    const tillDate = new Date(new Date().getTime() + 1000);
-                    const transactions = await createTransactions(debtor.id, creditor.id, 3);
-                    const parameters = {
-                        fromDate: new Date(2000, 0, 0),
-                        tillDate,
-                        forId: creditor.id,
-                    };
-                    const report = await new SalesReportService().getReport(parameters);
-                    expect(report.totalInclVat.getAmount()).to.eq(transactions.total);
-                    checkReport(report);
-                });
-            });
-        });
-
-        it('should adhere to both fromDate and tillDate filters', async () => {
-            await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
-                const transactionsBefore = await createTransactions(debtor.id, creditor.id, 2, -40*DAY);
-                let ids = transactionsBefore.transactions.map((t) => t.tId);
-                let transactions = await Transaction.find({where: { id: In(ids)}});
-                console.error(transactions);
-                const fromDate = new Date(new Date().getTime() - DAY);
-                const transactionsWithin = await createTransactions(debtor.id, creditor.id, 3, -2*DAY);  // Within range
-                ids = transactionsWithin.transactions.map((t) => t.tId);
-                transactions = await Transaction.find({where: { id: In(ids)}});
-                console.error(transactions);
-                const tillDate = new Date(new Date().getTime());
-                // const transactionsAfter = await createTransactions(debtor.id, creditor.id, 2); // After tillDate
-                const parameters = {
-                    fromDate,
-                    tillDate,
-                    forId: creditor.id,
-                };
-                console.error('parameters', parameters);
-                const report = await new SalesReportService().getReport(parameters);
-                expect(report.totalInclVat.getAmount()).to.eq(transactionsWithin.total);
-                checkReport(report);
-            });
-        });
-
-        it('should correctly aggregate transactions from multiple buyers to the same seller', async () => {
-            await createMultipleBuyersSingleSeller(3, async (users, transactions) => {
-                const [seller, buyer] = users;
-                const parameters = {
-                    fromDate: new Date(2000, 0, 0),
-                    tillDate: new Date(2050, 0, 0),
-                    forId: seller.id,
-                };
-                const report = await new SalesReportService().getReport(parameters);
-                const totalInclVat = transactions.reduce((sum, t) => sum + t.amount, 0);
-                expect(report.totalInclVat.getAmount()).to.eq(totalInclVat);
-                checkReport(report);
-            });
-        });
+      });
     });
+
+    it('should return the correct total income for multiple buyers buying from the same seller', async () => {
+      await createMultipleBuyersSingleSeller(3, async (users, transactions) => {
+        const [seller] = users;
+        await checkTransactionReport(transactions, {
+          fromDate: new Date(2000, 0, 0),
+          tillDate: new Date(2050, 0, 0),
+          forId: seller.id,
+        });
+      });
+    });
+
+    describe('fromDate filter', () => {
+      it('should return the total income of a user with a transactions in the past', async () => {
+        await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+          const transactions = await createTransactions(debtor.id, creditor.id, 3, -5000);
+          await checkTransactionReport(transactions.transactions, {
+            fromDate: new Date(2000, 0, 0),
+            tillDate: new Date(2050, 0, 0),
+            forId: creditor.id,
+          });
+        });
+      });
+
+      it('should return the total income of a user with transactions right before the fromDate', async () => {
+        await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+          const fromDate = new Date(new Date().getTime() - 1000);
+          await createTransactions(debtor.id, creditor.id, 3, -3000);
+          await checkTransactionReport([{ tId: 0, amount: 0 }], {
+            fromDate,
+            tillDate: new Date(2050, 0, 0),
+            forId: creditor.id,
+          });
+        });
+      });
+
+      it('should return the total income of a user with transactions right after the fromDate', async () => {
+        await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+          const fromDate = new Date(new Date().getTime() - 2000);
+          const transactions = await createTransactions(debtor.id, creditor.id, 3, -1000);
+          await checkTransactionReport(transactions.transactions, {
+            fromDate,
+            tillDate: new Date(2050, 0, 0),
+            forId: creditor.id,
+          });
+        });
+      });
+
+      it('should return the total income of a user with mixed transactions before and after the fromDate', async () => {
+        await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+          const fromDate = new Date(new Date().getTime() - 1500);
+          await createTransactions(debtor.id, creditor.id, 2, -2000);  // Before fromDate
+          const transactions = await createTransactions(debtor.id, creditor.id, 3, -1000); // After fromDate
+          await checkTransactionReport(transactions.transactions, {
+            fromDate,
+            tillDate: new Date(2050, 0, 0),
+            forId: creditor.id,
+          });
+        });
+      });
+      it('should return the total income of a user from the exact fromDate', async () => {
+        await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+          const fromDate = new Date(new Date().getTime() - 1000);
+          const transactions = await createTransactions(debtor.id, creditor.id, 3);
+          await checkTransactionReport(transactions.transactions, {
+            fromDate,
+            tillDate: new Date(2050, 0, 0),
+            forId: creditor.id,
+          });
+        });
+      });
+    });
+
+    describe('tillDate filter', () => {
+      it('should return the total income of a user with transactions before the tillDate', async () => {
+        await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+          const tillDate = new Date(new Date().getTime() + 1000);
+          const transactions = await createTransactions(debtor.id, creditor.id, 3);
+          await checkTransactionReport(transactions.transactions, {
+            fromDate: new Date(2000, 0, 0),
+            tillDate,
+            forId: creditor.id,
+          });
+        });
+      });
+
+      it('should return the total income of a user with transactions right after the tillDate', async () => {
+        await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+          const tillDate = new Date(new Date().getTime() + 1000);
+          await createTransactions(debtor.id, creditor.id, 3, 2000);
+          await checkTransactionReport([{ tId: 0, amount: 0 }], {
+            fromDate: new Date(2000, 0, 0),
+            tillDate,
+            forId: creditor.id,
+          });
+        });
+      });
+
+      it('should return the total income of a user with transactions right before the tillDate', async () => {
+        await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+          const tillDate = new Date(new Date().getTime() + 2000);
+          const transactions = await createTransactions(debtor.id, creditor.id, 3, 1000);
+          await checkTransactionReport(transactions.transactions, {
+            fromDate: new Date(2000, 0, 0),
+            tillDate,
+            forId: creditor.id,
+          });
+        });
+      });
+
+      it('should return the total income of a user with mixed transactions before and after the tillDate', async () => {
+        await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+          const tillDate = new Date(new Date().getTime() + 1500);
+          await createTransactions(debtor.id, creditor.id, 2, 2000);  // After tillDate
+          const transactions = await createTransactions(debtor.id, creditor.id, 3, 1000); // Before tillDate
+          await checkTransactionReport(transactions.transactions, {
+            fromDate: new Date(2000, 0, 0),
+            tillDate,
+            forId: creditor.id,
+          });
+        });
+      });
+
+      it('should return the total income of a user till the exact tillDate', async () => {
+        await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+          const tillDate = new Date(new Date().getTime() + 1000);
+          const transactions = await createTransactions(debtor.id, creditor.id, 3);
+          await checkTransactionReport(transactions.transactions, {
+            fromDate: new Date(2000, 0, 0),
+            tillDate,
+            forId: creditor.id,
+          });
+        });
+      });
+    });
+
+    it('should adhere to both fromDate and tillDate filters', async () => {
+      await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
+        await createTransactions(debtor.id, creditor.id, 2, -5000);
+        const fromDate = new Date(new Date().getTime() - 4000);
+        const transactionsWithin = await createTransactions(debtor.id, creditor.id, 3, -3000);  // Within range
+        const tillDate = new Date(new Date().getTime() - 1000);
+        await createTransactions(debtor.id, creditor.id, 2); // After tillDate
+
+        await checkTransactionReport(transactionsWithin.transactions, {
+          fromDate,
+          tillDate,
+          forId: creditor.id,
+        });
+      });
+    });
+
+    it('should correctly aggregate transactions from multiple buyers to the same seller', async () => {
+      await createMultipleBuyersSingleSeller(3, async (users, transactions) => {
+        const [seller, buyer] = users;
+        await checkTransactionReport(transactions, {
+          fromDate: new Date(2000, 0, 0),
+          tillDate: new Date(2050, 0, 0),
+          forId: seller.id,
+        });
+      });
+    });
+  });
 });

--- a/test/unit/service/report-service.ts
+++ b/test/unit/service/report-service.ts
@@ -301,7 +301,7 @@ describe('ReportService', () => {
         await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
           const transactions = await createTransactions(debtor.id, creditor.id, 3); // Before tillDate
           const tillDate = new Date(new Date().getTime() + 2000);
-          await createTransactions(debtor.id, creditor.id, 2, 3000);  // After tillDate
+          await createTransactions(debtor.id, creditor.id, 2, 4000);  // After tillDate
           await checkTransactionsSalesReport(transactions.transactions, {
             fromDate: new Date(2000, 0, 0),
             tillDate,
@@ -490,9 +490,9 @@ describe('ReportService', () => {
 
       it('should return the total expenditure of a user with mixed transactions before and after the tillDate', async () => {
         await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
-          const tillDate = new Date(new Date().getTime() + 1500); // Set tillDate to 1.5 seconds after current time
-          await createTransactions(debtor.id, creditor.id, 2, 2000);  // Transactions 2 seconds in the future (after tillDate)
-          const transactions = await createTransactions(debtor.id, creditor.id, 3, 1000); // Transactions 1 second in the future (before tillDate)
+          const transactions = await createTransactions(debtor.id, creditor.id, 3);
+          const tillDate = new Date();
+          await createTransactions(debtor.id, creditor.id, 2, 2000);
           await checkTransactionsBuyerReport(transactions.transactions, {
             fromDate: new Date(2000, 0, 0),
             tillDate,

--- a/test/unit/service/report-service.ts
+++ b/test/unit/service/report-service.ts
@@ -139,7 +139,7 @@ describe('ReportService', () => {
     });
   }
 
-  describe('BuyerReportService', () => {
+  describe('SalesReportService', () => {
     it('should return the total income of a user', async () => {
       await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
         const transaction = (await createTransactions(debtor.id, creditor.id, 1)).transactions[0];
@@ -330,7 +330,7 @@ describe('ReportService', () => {
 
     it('should correctly aggregate transactions from multiple buyers to the same seller', async () => {
       await createMultipleBuyersSingleSeller(3, async (users, transactions) => {
-        const [seller, buyer] = users;
+        const [seller] = users;
         await checkTransactionReport(transactions, {
           fromDate: new Date(2000, 0, 0),
           tillDate: new Date(2050, 0, 0),

--- a/test/unit/service/transaction-service.ts
+++ b/test/unit/service/transaction-service.ts
@@ -55,6 +55,7 @@ import { createInvoiceWithTransfers, createTransactions } from './invoice-servic
 import { truncateAllTables } from '../../setup';
 import ProductRevision from '../../../src/entity/product/product-revision';
 import { calculateBalance } from '../../helpers/balance';
+import SalesReportService from "../../../src/service/sales-report-service";
 
 chai.use(deepEqualInAnyOrder);
 
@@ -887,11 +888,15 @@ describe('TransactionService', (): void => {
     it('should create a transaction report response', async () => {
       await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
         const transactions = await createTransactions(debtor.id, creditor.id, 3);
+        // TODO: Remove, this is TEMP.
+        await createTransactions(debtor.id, creditor.id, 3);
+        await createTransactions(debtor.id, creditor.id, 3);
         const parameters: TransactionFilterParameters = {
           fromDate: new Date(2000, 0, 0),
           tillDate: new Date(2050, 0, 0),
           toId: creditor.id,
         };
+        console.error(await new SalesReportService().getSalesReport(creditor.id, new Date(2000, 0, 0), new Date(2050, 0, 0)));
         const report = await new TransactionService().getTransactionReportResponse(parameters);
         expect(report.totalInclVat.amount).to.eq(transactions.total);
       });

--- a/test/unit/service/transaction-service.ts
+++ b/test/unit/service/transaction-service.ts
@@ -46,12 +46,12 @@ import {
 import SubTransaction from '../../../src/entity/transactions/sub-transaction';
 import SubTransactionRow from '../../../src/entity/transactions/sub-transaction-row';
 import User, { TermsOfServiceStatus, UserType } from '../../../src/entity/user/user';
-import { createValidTransactionRequest } from '../../helpers/transaction-factory';
+import {createTransactions, createValidTransactionRequest} from '../../helpers/transaction-factory';
 import PointOfSaleRevision from '../../../src/entity/point-of-sale/point-of-sale-revision';
 import ContainerRevision from '../../../src/entity/container/container-revision';
 import generateBalance, { finishTestDB } from '../../helpers/test-helpers';
 import { inUserContext, UserFactory } from '../../helpers/user-factory';
-import { createInvoiceWithTransfers, createTransactions } from './invoice-service';
+import { createInvoiceWithTransfers } from './invoice-service';
 import { truncateAllTables } from '../../setup';
 import ProductRevision from '../../../src/entity/product/product-revision';
 import { calculateBalance } from '../../helpers/balance';
@@ -888,16 +888,13 @@ describe('TransactionService', (): void => {
     it('should create a transaction report response', async () => {
       await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
         const transactions = await createTransactions(debtor.id, creditor.id, 3);
-        // TODO: Remove, this is TEMP.
-        await createTransactions(debtor.id, creditor.id, 3);
-        await createTransactions(debtor.id, creditor.id, 3);
+
         const parameters: TransactionFilterParameters = {
           fromDate: new Date(2000, 0, 0),
           tillDate: new Date(2050, 0, 0),
           toId: creditor.id,
         };
-        await new SalesReportService().getReport(creditor.id, new Date(2000, 0, 0), new Date(2050, 0, 0));
-        await new BuyerReportService().getReport(debtor.id, new Date(2000, 0, 0), new Date(2050, 0, 0));
+
         const report = await new TransactionService().getTransactionReportResponse(parameters);
         expect(report.totalInclVat.amount).to.eq(transactions.total);
       });

--- a/test/unit/service/transaction-service.ts
+++ b/test/unit/service/transaction-service.ts
@@ -55,7 +55,7 @@ import { createInvoiceWithTransfers, createTransactions } from './invoice-servic
 import { truncateAllTables } from '../../setup';
 import ProductRevision from '../../../src/entity/product/product-revision';
 import { calculateBalance } from '../../helpers/balance';
-import SalesReportService from "../../../src/service/sales-report-service";
+import SalesReportService from '../../../src/service/sales-report-service';
 
 chai.use(deepEqualInAnyOrder);
 

--- a/test/unit/service/transaction-service.ts
+++ b/test/unit/service/transaction-service.ts
@@ -46,7 +46,7 @@ import {
 import SubTransaction from '../../../src/entity/transactions/sub-transaction';
 import SubTransactionRow from '../../../src/entity/transactions/sub-transaction-row';
 import User, { TermsOfServiceStatus, UserType } from '../../../src/entity/user/user';
-import {createTransactions, createValidTransactionRequest} from '../../helpers/transaction-factory';
+import { createTransactions, createValidTransactionRequest } from '../../helpers/transaction-factory';
 import PointOfSaleRevision from '../../../src/entity/point-of-sale/point-of-sale-revision';
 import ContainerRevision from '../../../src/entity/container/container-revision';
 import generateBalance, { finishTestDB } from '../../helpers/test-helpers';
@@ -55,7 +55,6 @@ import { createInvoiceWithTransfers } from './invoice-service';
 import { truncateAllTables } from '../../setup';
 import ProductRevision from '../../../src/entity/product/product-revision';
 import { calculateBalance } from '../../helpers/balance';
-import { BuyerReportService, SalesReportService } from '../../../src/service/report-service';
 
 chai.use(deepEqualInAnyOrder);
 

--- a/test/unit/service/transaction-service.ts
+++ b/test/unit/service/transaction-service.ts
@@ -55,7 +55,7 @@ import { createInvoiceWithTransfers, createTransactions } from './invoice-servic
 import { truncateAllTables } from '../../setup';
 import ProductRevision from '../../../src/entity/product/product-revision';
 import { calculateBalance } from '../../helpers/balance';
-import SalesReportService from '../../../src/service/sales-report-service';
+import ReportService, {BuyerReportService, SalesReportService} from '../../../src/service/report-service';
 
 chai.use(deepEqualInAnyOrder);
 
@@ -896,7 +896,8 @@ describe('TransactionService', (): void => {
           tillDate: new Date(2050, 0, 0),
           toId: creditor.id,
         };
-        console.error(await new SalesReportService().getSalesReport(creditor.id, new Date(2000, 0, 0), new Date(2050, 0, 0)));
+        await new SalesReportService().getReport(creditor.id, new Date(2000, 0, 0), new Date(2050, 0, 0));
+        await new BuyerReportService().getReport(debtor.id, new Date(2000, 0, 0), new Date(2050, 0, 0));
         const report = await new TransactionService().getTransactionReportResponse(parameters);
         expect(report.totalInclVat.amount).to.eq(transactions.total);
       });

--- a/test/unit/service/transaction-service.ts
+++ b/test/unit/service/transaction-service.ts
@@ -55,7 +55,7 @@ import { createInvoiceWithTransfers, createTransactions } from './invoice-servic
 import { truncateAllTables } from '../../setup';
 import ProductRevision from '../../../src/entity/product/product-revision';
 import { calculateBalance } from '../../helpers/balance';
-import ReportService, {BuyerReportService, SalesReportService} from '../../../src/service/report-service';
+import { BuyerReportService, SalesReportService } from '../../../src/service/report-service';
 
 chai.use(deepEqualInAnyOrder);
 


### PR DESCRIPTION
# Description
Implements a new Sales Reporting function, as described in https://github.com/GEWIS/sudosos-backend/issues/260 and marked as a TODO here https://github.com/GEWIS/sudosos-backend/pull/259.

This is *SO* much faster. It is not even funny, aggregating the whole database is instant. This is because the new service writes queries instead of fetching data and computing the statistics itself. This is how it should always have but the previous reporting function got some scope creep to try and make it more versatile.

This leaves the old reporting untouched, for backwards compatability.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
- New feature _(non-breaking change which adds functionality)_
