### PR TITLE
fix: Stripe webhook success event never creating a transfer

### DIFF
--- a/src/service/stripe-service.ts
+++ b/src/service/stripe-service.ts
@@ -191,7 +191,7 @@ export default class StripeService {
     paymentIntentId: number, state: StripePaymentIntentState,
   ): Promise<StripePaymentIntentStatus> {
     const paymentIntent = await this.manager.getRepository(StripePaymentIntent)
-      .findOne({ where: { id: paymentIntentId } });
+      .findOne({ where: { id: paymentIntentId }, relations: { deposit: true } });
 
     const states = paymentIntent.paymentIntentStatuses?.map((status) => status.state) ?? [];
     if (states.includes(state)) throw new Error(`Status ${state} already exists.`);

--- a/test/unit/service/stripe-service.ts
+++ b/test/unit/service/stripe-service.ts
@@ -115,7 +115,7 @@ describe('StripeService', async (): Promise<void> => {
     });
   });
 
-  describe('createNewDepositStatus', () => {
+  describe('createNewPaymentIntentStatus', () => {
     const testStatusCreation = async (id: number, state: StripePaymentIntentState) => {
       const beforeStripeDeposit = await StripeService.getStripeDeposit(id);
 
@@ -146,13 +146,15 @@ describe('StripeService', async (): Promise<void> => {
       await testStatusCreation(id, StripePaymentIntentState.PROCESSING);
     });
     it('should correctly create only one success status', async () => {
-      const { id } = (ctx.stripeDeposits.filter((d) => d.stripePaymentIntent.paymentIntentStatuses.length === 2))[0];
-      let deposit = await StripeService.getStripeDeposit(id);
-      expect(deposit.transfer).to.be.undefined;
+      const { id } = (ctx.stripeDeposits.filter((d) => d.stripePaymentIntent.paymentIntentStatuses.length === 2 && !d.transfer))[0];
+      let deposit = await StripeService.getStripeDeposit(id, ['transfer', 'transfer.to', 'to']);
+      expect(deposit.transfer).to.be.null;
 
       await testStatusCreation(id, StripePaymentIntentState.SUCCEEDED);
 
       deposit = await StripeService.getStripeDeposit(id, ['transfer', 'transfer.to', 'to']);
+      // Correct transfer should have been created
+      expect(deposit.transfer).to.not.be.null;
       expect(ctx.dineroTransformer.to(deposit.transfer.amountInclVat))
         .to.equal(ctx.dineroTransformer.to(deposit.stripePaymentIntent.amount));
       expect(deposit.transfer.to.id).to.equal(deposit.to.id);

--- a/test/unit/service/stripe-service.ts
+++ b/test/unit/service/stripe-service.ts
@@ -160,7 +160,7 @@ describe('StripeService', async (): Promise<void> => {
       expect(deposit.transfer.to.id).to.equal(deposit.to.id);
     });
     it('should correctly create only one failed status', async () => {
-      const { id } = (ctx.stripeDeposits.filter((d) => d.stripePaymentIntent.paymentIntentStatuses.length === 2))[1];
+      const { id } = (ctx.stripeDeposits.filter((d) => d.stripePaymentIntent.paymentIntentStatuses.length === 1))[1];
       await testStatusCreation(id, StripePaymentIntentState.FAILED);
     });
     it('should not create duplicate created status', async () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
It seems I made a stupid mistake while working on the `stripe-service` that remained undiscovered due to a faulty test. This is now fixed. However, the Stripe events were indeed all handled correctly, so there are two options to fix these issues:
1. For all these topups, we remove the "success" state and send all the webhook events again. We therefore act as if we have never processed these topups up to now (my preference).
2. We manually create transfers for all "success" deposits that have no transfers attached to them.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Actual fix for https://github.com/GEWIS/sudosos-backend/pull/281.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_