### PR TITLE
feat: add description and metadata to Stripe PaymentIntents

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,4 +1,5 @@
 NODE_ENV = development
+NAME = sudosos-dev
 API_HOST = localhost:3000
 API_BASEPATH = /v1
 HTTP_PORT = 3000

--- a/src/authentication/token-handler.ts
+++ b/src/authentication/token-handler.ts
@@ -20,7 +20,6 @@ import assert from 'assert';
 import * as util from 'util';
 import * as jwt from 'jsonwebtoken';
 import JsonWebToken from './json-web-token';
-import User from '../entity/user/user';
 
 /**
  * The configuration options for the token handler.

--- a/src/authentication/token-handler.ts
+++ b/src/authentication/token-handler.ts
@@ -20,6 +20,7 @@ import assert from 'assert';
 import * as util from 'util';
 import * as jwt from 'jsonwebtoken';
 import JsonWebToken from './json-web-token';
+import User from '../entity/user/user';
 
 /**
  * The configuration options for the token handler.

--- a/src/entity/user/user.ts
+++ b/src/entity/user/user.ts
@@ -146,9 +146,19 @@ export default class User extends BaseEntity {
   public directAssignedRoles: AssignedRole[];
 
   public fullName(): string {
-    let name = this.firstName;
-    if (this.nickname) name += ` "${this.nickname}"`;
-    if (this.lastName) name += ` ${this.lastName}`;
+    return User.fullName(this);
+  }
+
+  /**
+   * Get the full name of the given user.
+   * Separate static method, as user objects taken from tokens
+   * do not have any class methods.
+   * @param user
+   */
+  public static fullName(user: User): string {
+    let name = user.firstName;
+    if (user.nickname) name += ` "${user.nickname}"`;
+    if (user.lastName) name += ` ${user.lastName}`;
     return name;
   }
 

--- a/src/service/stripe-service.ts
+++ b/src/service/stripe-service.ts
@@ -151,6 +151,11 @@ export default class StripeService {
       amount: DineroTransformer.Instance.to(amount),
       currency: amount.getCurrency(),
       automatic_payment_methods: { enabled: true },
+      description: `SudoSOS deposit of ${amount.getCurrency()} ${(amount.getAmount() / 100).toFixed(2)} for ${User.fullName(user)}.`,
+      metadata: {
+        'service': process.env.NAME ?? 'sudosos-unknown',
+        'userId': user.id,
+      },
     });
 
     const stripePaymentIntent = await this.manager.getRepository(StripePaymentIntent).save({

--- a/test/unit/controller/stripe-webhook-controller.ts
+++ b/test/unit/controller/stripe-webhook-controller.ts
@@ -36,6 +36,7 @@ import { seedStripeDeposits, seedUsers } from '../../seed';
 
 describe('StripeWebhookController', async (): Promise<void> => {
   let shouldSkip: boolean;
+  let originalName: string;
 
   let ctx: {
     connection: DataSource,
@@ -62,6 +63,10 @@ describe('StripeWebhookController', async (): Promise<void> => {
       || process.env.STRIPE_PRIVATE_KEY === '' || process.env.STRIPE_PRIVATE_KEY === undefined);
     if (shouldSkip) this.skip();
 
+    originalName = process.env.NAME;
+    const serviceName = 'sudosos-stripe-webhook-test-suite';
+    process.env.NAME = serviceName;
+
     const connection = await Database.initialize();
     await truncateAllTables(connection);
 
@@ -87,6 +92,10 @@ describe('StripeWebhookController', async (): Promise<void> => {
       data: {
         object: {
           id: stripeDeposits[0].stripePaymentIntent.stripeId,
+          metadata: {
+            service: serviceName,
+            user_id: stripeDeposits[0].to.id,
+          } as any,
         } as Stripe.PaymentIntent,
       },
       type: 'payment_intent.succeeded',
@@ -105,6 +114,8 @@ describe('StripeWebhookController', async (): Promise<void> => {
 
   after(async () => {
     if (shouldSkip) return;
+
+    process.env.NAME = originalName;
     await finishTestDB(ctx.connection);
   });
 
@@ -154,7 +165,7 @@ describe('StripeWebhookController', async (): Promise<void> => {
 
       expect(res.status).to.equal(400);
     });
-    it('should return 200 when sending correct request', async () => {
+    it('should return 204 when sending correct request', async () => {
       const handleWebhookEventStub = sinon.stub(StripeService.prototype, 'handleWebhookEvent').resolves();
       stubs.push(handleWebhookEventStub);
 
@@ -162,14 +173,14 @@ describe('StripeWebhookController', async (): Promise<void> => {
         .post('/stripe/webhook')
         .set('stripe-signature', getSignatureHeader(ctx.payload))
         .send(ctx.payload);
-      expect(res.status).to.equal(200);
+      expect(res.status).to.equal(204);
 
       // Race condition (by design), because the webhook event is and should be handled asynchronously
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       expect(handleWebhookEventStub).to.have.been.calledOnce;
     });
-    it('should return 404 when using unknown payment intent', async () => {
+    it('should return 400 when using unknown payment intent', async () => {
       const payload = {
         ...ctx.payload,
         data: {
@@ -183,10 +194,60 @@ describe('StripeWebhookController', async (): Promise<void> => {
         .post('/stripe/webhook')
         .set('stripe-signature', getSignatureHeader(payload))
         .send(payload);
-      expect(res.status).to.equal(404);
+      expect(res.status).to.equal(400);
       expect(res.body).to.equal('PaymentIntent with ID "Yeeeee" not found.');
     });
-    it('should return 200 if not listening for event', async () => {
+    it('should return 204 if not for SudoSOS service', async () => {
+      const handleWebhookEventStub = sinon.stub(StripeService.prototype, 'handleWebhookEvent').resolves();
+      stubs.push(handleWebhookEventStub);
+
+      const payload = {
+        ...ctx.payload,
+        data: {
+          object: {
+            ...ctx.payload.data.object,
+            metadata: {
+              service: 'definitely-not-sudosos',
+            },
+          },
+        },
+      };
+      const res = await request(ctx.app)
+        .post('/stripe/webhook')
+        .set('stripe-signature', getSignatureHeader(payload))
+        .send(payload);
+      expect(res.status).to.equal(204);
+
+      // Race condition (by design), because the webhook event is and should be handled asynchronously
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(handleWebhookEventStub).to.not.have.been.called;
+    });
+    it('should return 204 if no service given', async () => {
+      const handleWebhookEventStub = sinon.stub(StripeService.prototype, 'handleWebhookEvent').resolves();
+      stubs.push(handleWebhookEventStub);
+
+      const payload = {
+        ...ctx.payload,
+        data: {
+          object: {
+            ...ctx.payload.data.object,
+            metadata: {},
+          },
+        },
+      };
+      const res = await request(ctx.app)
+        .post('/stripe/webhook')
+        .set('stripe-signature', getSignatureHeader(payload))
+        .send(payload);
+      expect(res.status).to.equal(204);
+
+      // Race condition (by design), because the webhook event is and should be handled asynchronously
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(handleWebhookEventStub).to.not.have.been.called;
+    });
+    it('should return 204 if not listening for event', async () => {
       const handleWebhookEventStub = sinon.stub(StripeService.prototype, 'handleWebhookEvent').resolves();
       stubs.push(handleWebhookEventStub);
 
@@ -198,7 +259,7 @@ describe('StripeWebhookController', async (): Promise<void> => {
         .post('/stripe/webhook')
         .set('stripe-signature', getSignatureHeader(payload))
         .send(payload);
-      expect(res.status).to.equal(200);
+      expect(res.status).to.equal(204);
 
       // Race condition (by design), because the webhook event is and should be handled asynchronously
       await new Promise((resolve) => setTimeout(resolve, 100));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds a description and metadata to Stripe PaymentIntents. The metadata contains a `service` key, which includes the new `NAME` environment variable. This variable should contain the name of the service, for example `sudosos-prod` or `sudosos-test`. When receiving Stripe webhook events, SudoSOS checks whether this service name matches. If so, it will actually process the webhook event. **If not, it will still return a 204 to Stripe, but not process the event any further.** It is therefore important that we add these environment variables when deploying.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Fixes https://github.com/GEWIS/sudosos-backend/issues/288.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_