### PR TITLE
feat: add maintenance mode to restrict access to SudoSOS during upgrades

### DIFF
--- a/src/authentication/json-web-token.ts
+++ b/src/authentication/json-web-token.ts
@@ -38,6 +38,12 @@ export default class JsonWebToken {
   public lesser: boolean;
 
   /**
+   * Whether this token should still be able to access
+   * all endpoints in maintenance mode
+   */
+  public overrideMaintenance?: boolean;
+
+  /**
    * All the organs that the user is a part of.
    */
   public organs?: User[];

--- a/src/controller/authentication-controller.ts
+++ b/src/controller/authentication-controller.ts
@@ -118,6 +118,7 @@ export default class AuthenticationController extends BaseController {
           body: { modelName: 'AuthenticationLocalRequest' },
           policy: async () => true,
           handler: this.LocalLogin.bind(this),
+          restrictions: { availableDuringMaintenance: true },
         },
         PUT: {
           body: { modelName: 'AuthenticationResetTokenRequest' },

--- a/src/controller/authentication-controller.ts
+++ b/src/controller/authentication-controller.ts
@@ -150,7 +150,7 @@ export default class AuthenticationController extends BaseController {
     const body = req.body as AuthenticationMockRequest;
 
     // Only allow in development setups
-    if (process.env.NODE_ENV !== 'development') return false;
+    if (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test') return false;
 
     // Check the existence of the user
     const user = await User.findOne({ where: { id: body.userId } });

--- a/src/controller/authentication-secure-controller.ts
+++ b/src/controller/authentication-secure-controller.ts
@@ -28,6 +28,7 @@ import User from '../entity/user/user';
 import PointOfSaleController from './point-of-sale-controller';
 import PointOfSale from '../entity/point-of-sale/point-of-sale';
 import ServerSettingsStore from '../server-settings/server-settings-store';
+import { ISettings } from '../entity/server-setting';
 
 export default class AuthenticationSecureController extends BaseController {
   private logger: Logger = log4js.getLogger('AuthenticationController');
@@ -115,7 +116,7 @@ export default class AuthenticationSecureController extends BaseController {
         return;
       }
 
-      const expiry = ServerSettingsStore.getInstance().getSetting('jwtExpiryPointOfSale');
+      const expiry = ServerSettingsStore.getInstance().getSetting('jwtExpiryPointOfSale') as ISettings['jwtExpiryPointOfSale'];
       const token = await AuthenticationService.getSaltedToken(pointOfSale.user, {
         roleManager: this.roleManager,
         tokenHandler: this.tokenHandler,

--- a/src/controller/response/server-status-response.ts
+++ b/src/controller/response/server-status-response.ts
@@ -1,0 +1,25 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @typedef {object} ServerStatusResponse
+ * @property {boolean} maintenanceMode.required - Whether the server is in maintenance mode
+ */
+export interface ServerStatusResponse {
+  maintenanceMode: boolean;
+}

--- a/src/controller/root-controller.ts
+++ b/src/controller/root-controller.ts
@@ -23,14 +23,7 @@ import Policy from './policy';
 import { parseRequestPagination } from '../helpers/pagination';
 import BannerService from '../service/banner-service';
 import ServerSettingsStore from '../server-settings/server-settings-store';
-
-/**
- * @typedef {object} ServerStatusReponse
- * @property {boolean} maintenanceMode.required - Whether the server is in maintenance mode
- */
-interface ServerStatusResponse {
-  maintenanceMode: boolean;
-}
+import { ServerStatusResponse } from './response/server-status-response';
 
 export default class RootController extends BaseController {
   /**

--- a/src/controller/root-controller.ts
+++ b/src/controller/root-controller.ts
@@ -48,6 +48,7 @@ export default class RootController extends BaseController {
         GET: {
           policy: async () => Promise.resolve(true),
           handler: this.ping.bind(this),
+          restrictions: { availableDuringMaintenance: true },
         },
       },
       '/open/banners': {

--- a/src/controller/root-controller.ts
+++ b/src/controller/root-controller.ts
@@ -118,7 +118,7 @@ export default class RootController extends BaseController {
       const maintenanceMode = await store.getSettingFromDatabase('maintenanceMode');
       res.status(200).json({
         maintenanceMode,
-      });
+      } as ServerStatusResponse);
     } catch (e) {
       res.status(500).json('Internal server error.');
     }

--- a/src/controller/server-settings-controller.ts
+++ b/src/controller/server-settings-controller.ts
@@ -1,0 +1,79 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import BaseController, { BaseControllerOptions } from './base-controller';
+import { Response } from 'express';
+import log4js, { Logger } from 'log4js';
+import Policy from './policy';
+import { RequestWithToken } from '../middleware/token-middleware';
+import ServerSettingsStore from '../server-settings/server-settings-store';
+
+/**
+ * @typedef {object} UpdateMaintenanceModeRequest
+ * @property {boolean} enabled.required - Whether maintenance mode should be enabled or disabled
+ */
+interface UpdateMaintenanceModeRequest {
+  enabled: boolean;
+}
+
+export default class ServerSettingsController extends BaseController {
+  private logger: Logger = log4js.getLogger('ServerSettingsController');
+
+  public constructor(options: BaseControllerOptions) {
+    super(options);
+    this.logger.level = process.env.LOG_LEVEL;
+  }
+
+  public getPolicy(): Policy {
+    return {
+      '/maintenance-mode': {
+        PUT: {
+          policy: async (req) => this.roleManager.can(req.token.roles, 'update', 'all', 'Maintenance', ['*']),
+          handler: this.setMaintenanceMode.bind(this),
+          body: { modelName: 'UpdateMaintenanceModeRequest' },
+          restrictions: { availableDuringMaintenance: true },
+        },
+      },
+    };
+  }
+
+  /**
+   * PUT /server-settings/maintenance-mode
+   * @summary Enable/disable maintenance mode
+   * @operationId setMaintenanceMode
+   * @tags serverSettings - Operations of the server settings controller
+   * @security JWT
+   * @param {UpdateMaintenanceModeRequest} request.body.required
+   * @return {string} 204 - Success.
+   * @return {string} 500 - Internal server error.
+   */
+  public async setMaintenanceMode(req: RequestWithToken, res: Response): Promise<void> {
+    this.logger.trace('Set maintenance mode by', req.token.user);
+
+    try {
+      const body = req.body as UpdateMaintenanceModeRequest;
+
+      const store = ServerSettingsStore.getInstance();
+      await store.setSetting('maintenanceMode', body.enabled);
+
+      res.status(204).send();
+    } catch (error) {
+      this.logger.error('Could not update maintenance mode:', error);
+      res.status(500).json('Internal server error.');
+    }
+  }
+}

--- a/src/entity/server-setting.ts
+++ b/src/entity/server-setting.ts
@@ -22,6 +22,7 @@ export interface ISettings {
   highVatGroupId: number;
   jwtExpiryDefault: number;
   jwtExpiryPointOfSale: number;
+  maintenanceMode: boolean;
 }
 
 /**

--- a/src/gewis/controller/gewis-authentication-controller.ts
+++ b/src/gewis/controller/gewis-authentication-controller.ts
@@ -102,6 +102,7 @@ export default class GewisAuthenticationController extends BaseController {
           body: { modelName: 'AuthenticationLDAPRequest' },
           policy: async () => true,
           handler: this.ldapLogin.bind(this),
+          restrictions: { availableDuringMaintenance: true },
         },
       },
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ import WriteOffController from './controller/write-off-controller';
 import ServerSettingsStore from './server-settings/server-settings-store';
 import SellerPayoutController from './controller/seller-payout-controller';
 import { ISettings } from './entity/server-setting';
+import ServerSettingsController from './controller/server-settings-controller';
 
 export class Application {
   app: express.Express;
@@ -242,6 +243,7 @@ export default async function createApp(): Promise<Application> {
   application.app.use('/v1/containers', new ContainerController(options).getRouter());
   application.app.use('/v1/writeoffs', new WriteOffController(options).getRouter());
   application.app.use('/v1/seller-payouts', new SellerPayoutController(options).getRouter());
+  application.app.use('/v1/server-settings', new ServerSettingsController(options).getRouter());
   if (process.env.NODE_ENV === 'development') {
     application.app.use('/v1/files', new SimpleFileController(options).getRouter());
     application.app.use('/v1/test', new TestController(options).getRouter());

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ import EventShiftController from './controller/event-shift-controller';
 import WriteOffController from './controller/write-off-controller';
 import ServerSettingsStore from './server-settings/server-settings-store';
 import SellerPayoutController from './controller/seller-payout-controller';
+import { ISettings } from './entity/server-setting';
 
 export class Application {
   app: express.Express;
@@ -107,7 +108,7 @@ async function createTokenHandler(): Promise<TokenHandler> {
     algorithm: 'RS512',
     publicKey: jwtPublic.export({ type: 'spki', format: 'pem' }),
     privateKey: jwtPrivate.export({ type: 'pkcs8', format: 'pem' }),
-    expiry: ServerSettingsStore.getInstance().getSetting('jwtExpiryDefault'),
+    expiry: ServerSettingsStore.getInstance().getSetting('jwtExpiryDefault') as ISettings['jwtExpiryDefault'],
   });
 }
 

--- a/src/middleware/restriction-middleware.ts
+++ b/src/middleware/restriction-middleware.ts
@@ -32,6 +32,11 @@ export interface TokenRestrictions {
    * Whether the TOS should be accepted to access this endpoint. True by default.
    */
   acceptedTOS: boolean;
+
+  /**
+   * Whether this endpoint should remain accessible when maintenance mode is enabled.
+   */
+  availableDuringMaintenance: boolean;
 }
 
 export default class RestrictionMiddleware {
@@ -51,10 +56,10 @@ export default class RestrictionMiddleware {
    * @param next - the express next function to continue processing of the request.
    */
   public async handle(req: RequestWithToken, res: Response, next: Function): Promise<void> {
-    const { lesser, acceptedTOS } = this.restrictionsImpl();
+    const { lesser, acceptedTOS, availableDuringMaintenance } = this.restrictionsImpl();
 
     const maintenance = await ServerSettingsStore.getInstance().getSettingFromDatabase('maintenanceMode') as ISettings['maintenanceMode'];
-    if (maintenance) {
+    if (maintenance && !availableDuringMaintenance) {
       res.status(503).end('Service is in maintenance mode. Please try again later.');
       return;
     }

--- a/src/rbac/default-roles.ts
+++ b/src/rbac/default-roles.ts
@@ -187,6 +187,9 @@ export default class DefaultRoles {
       name: 'Super admin',
       userTypes: [UserType.LOCAL_ADMIN],
       permissions: {
+        Maintenance: {
+          override: { all: star },
+        },
         Authenticator: admin,
         Balance: admin,
         Banner: admin,

--- a/src/server-settings/setting-defaults.ts
+++ b/src/server-settings/setting-defaults.ts
@@ -21,6 +21,7 @@ const SettingsDefaults: ISettings = {
   highVatGroupId: -1,
   jwtExpiryDefault: 3600,
   jwtExpiryPointOfSale: 60 * 60 * 24 * 14,
+  maintenanceMode: false,
 };
 
 export default SettingsDefaults;

--- a/src/service/write-off-service.ts
+++ b/src/service/write-off-service.ts
@@ -42,6 +42,7 @@ import VatGroup from '../entity/vat-group';
 import ServerSettingsStore from '../server-settings/server-settings-store';
 import { AppDataSource } from '../database/database';
 import Transfer from '../entity/transactions/transfer';
+import { ISettings } from '../entity/server-setting';
 
 export interface WriteOffFilterParameters {
   /**
@@ -116,7 +117,7 @@ export default class WriteOffService {
   }
 
   private static async getHighVATGroup(): Promise<VatGroup> {
-    const id = ServerSettingsStore.getInstance().getSetting('highVatGroupId');
+    const id = ServerSettingsStore.getInstance().getSetting('highVatGroupId') as ISettings['highVatGroupId'];
     const vatGroup = await VatGroup.findOne({ where: { id } });
     if (vatGroup) return vatGroup;
     else throw new Error('High vat group not found');

--- a/test/unit/controller/server-settings-controller.ts
+++ b/test/unit/controller/server-settings-controller.ts
@@ -96,6 +96,13 @@ describe('ServerSettingsController', () => {
       // Cleanup
       await store.setSetting('maintenanceMode', enabled);
     });
+    it('should return 400 if invalid request', async () => {
+      const res = await request(ctx.app)
+        .put('/server-settings/maintenance-mode')
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .send({ enabled: 'Ploperdeplop' });
+      expect(res.status).to.equal(400);
+    });
     it('should return 403 if not admin', async () => {
       const res = await request(ctx.app)
         .put('/server-settings/maintenance-mode')

--- a/test/unit/controller/server-settings-controller.ts
+++ b/test/unit/controller/server-settings-controller.ts
@@ -1,0 +1,126 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { defaultContext, DefaultContext, finishTestDB } from '../../helpers/test-helpers';
+import { seedUsers } from '../../seed';
+import { getToken, seedRoles } from '../../seed/rbac';
+import User, { UserType } from '../../../src/entity/user/user';
+import TokenMiddleware from '../../../src/middleware/token-middleware';
+import { json } from 'body-parser';
+import ServerSettingsController from '../../../src/controller/server-settings-controller';
+import ServerSettingsStore from '../../../src/server-settings/server-settings-store';
+import { expect, request } from 'chai';
+import sinon from 'sinon';
+
+describe('ServerSettingsController', () => {
+  let ctx: DefaultContext & {
+    admin: User,
+    user: User,
+    adminToken: string,
+    userToken: string,
+  };
+
+  before(async () => {
+    const c = { ...await defaultContext() };
+
+    const users = await seedUsers();
+
+    const all = { all: new Set<string>(['*']) };
+    const adminRole = await seedRoles([{
+      name: 'Admin',
+      permissions: {
+        Maintenance: {
+          update: all,
+        },
+      },
+      assignmentCheck: async (user: User) => user.type === UserType.LOCAL_ADMIN,
+    }]);
+
+    const admin = users.find((u) => u.type === UserType.LOCAL_ADMIN);
+    const user = users.find((u) => u.type === UserType.LOCAL_USER);
+    const adminToken = await c.tokenHandler.signToken(await getToken(admin, adminRole), 'nonce admin');
+    const userToken = await c.tokenHandler.signToken(await getToken(user, adminRole), 'nonce');
+
+    const tokenMiddleware = new TokenMiddleware({ tokenHandler: c.tokenHandler, refreshFactor: 0.5 }).getMiddleware();
+    c.app.use(json());
+    c.app.use(tokenMiddleware);
+    const controller = new ServerSettingsController({ specification: c.specification, roleManager: c.roleManager });
+    c.app.use('/server-settings', controller.getRouter());
+
+    ServerSettingsStore.deleteInstance();
+    await ServerSettingsStore.getInstance().initialize();
+
+    ctx = {
+      ...c,
+      admin,
+      user,
+      adminToken,
+      userToken,
+    };
+  });
+
+  after(async () => {
+    await finishTestDB(ctx.connection);
+    ServerSettingsStore.deleteInstance();
+  });
+
+  describe('PUT /server-settings/maintenance-mode', () => {
+    it('should return 204 and correctly set maintenance mode', async () => {
+      const store = ServerSettingsStore.getInstance();
+      const enabled = await store.getSettingFromDatabase('maintenanceMode');
+
+      const res = await request(ctx.app)
+        .put('/server-settings/maintenance-mode')
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .send({ enabled: !enabled });
+      expect(res.status).to.equal(204);
+      expect(res.body).to.be.empty;
+
+      expect(store.getSetting('maintenanceMode')).to.equal(!enabled);
+      await expect(store.getSettingFromDatabase('maintenanceMode')).to.eventually.equal(!enabled);
+
+      // Cleanup
+      await store.setSetting('maintenanceMode', enabled);
+    });
+    it('should return 403 if not admin', async () => {
+      const res = await request(ctx.app)
+        .put('/server-settings/maintenance-mode')
+        .set('Authorization', `Bearer ${ctx.userToken}`)
+        .send({ enabled: true });
+      expect(res.status).to.equal(403);
+      expect(res.body).to.be.empty;
+    });
+    it('should return 500 if database error', async () => {
+      const store = ServerSettingsStore.getInstance();
+      const enabled = await store.getSettingFromDatabase('maintenanceMode');
+
+      const stub = sinon.stub(ServerSettingsStore.prototype, 'setSetting')
+        .throws(new Error('Mock database error'));
+
+      const res = await request(ctx.app)
+        .put('/server-settings/maintenance-mode')
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .send({ enabled: !enabled });
+      expect(res.status).to.equal(500);
+      expect(res.body).to.equal('Internal server error.');
+
+      stub.restore();
+      expect(store.getSetting('maintenanceMode')).to.equal(enabled);
+      await expect(store.getSettingFromDatabase('maintenanceMode')).to.eventually.equal(enabled);
+    });
+  });
+});

--- a/test/unit/server-settings/server-settings-store.ts
+++ b/test/unit/server-settings/server-settings-store.ts
@@ -86,6 +86,25 @@ describe('ServerSettingsStore', () => {
       await expect(store.initialize()).to.eventually.be.rejectedWith('ServerSettingsStore already initialized!');
     });
   });
+  describe('.getSettingFromDatabase (static)', () => {
+    it('should correctly return value if key exists in the database', async () => {
+      await ServerSettingsStore.getInstance().initialize();
+
+      const key: keyof ISettings = 'highVatGroupId';
+      const value = await ServerSettingsStore.getSettingFromDatabase(key);
+      expect(value).to.equal(settingDefaults[key]);
+    });
+    it('should return null if key does not exist', async () => {
+      const key: keyof ISettings = 'highVatGroupId';
+
+      // Sanity check
+      const record = await ServerSetting.findOne({ where: { key } });
+      expect(record).to.be.null;
+
+      const value = await ServerSettingsStore.getSettingFromDatabase(key);
+      expect(value).to.be.null;
+    });
+  });
   describe('#getSetting', () => {
     it('should correctly get a setting from store', async () => {
       const store = await new ServerSettingsStore().initialize();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds maintenance mode to the `restriction-middleware`. The following rules apply:
- Maintenance mode is added as a server setting
- All endpoints (except LDAP login, local login and `/ping`) will return a 503 once maintenance mode is enabled.
- All users that have the permission `Maintenance override` can always access all endpoints, even during maintenance.
- Maintenance mode can be enabled/disabled using a new endpoint.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Fixes https://github.com/GEWIS/sudosos-backend/issues/280.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_