### PR TITLE
fix: mistake in user-type-enums migration

### DIFF
--- a/src/migrations/1725196803203-user-type-enums.ts
+++ b/src/migrations/1725196803203-user-type-enums.ts
@@ -17,14 +17,14 @@
  */
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
 
-const UserTypeMapping: Record<string, number> = {
-  MEMBER: 1,
-  ORGAN: 2,
-  VOUCHER: 3,
-  LOCAL_USER: 4,
-  LOCAL_ADMIN: 5,
-  INVOICE: 6,
-  POINT_OF_SALE: 7,
+const UserTypeMapping: Record<string, string> = {
+  MEMBER: '1',
+  ORGAN: '2',
+  VOUCHER: '3',
+  LOCAL_USER: '4',
+  LOCAL_ADMIN: '5',
+  INVOICE: '6',
+  POINT_OF_SALE: '7',
 };
 
 export class UserTypeEnums1725196803203 implements MigrationInterface {
@@ -50,13 +50,12 @@ export class UserTypeEnums1725196803203 implements MigrationInterface {
       await queryRunner.query('ALTER TABLE role_user_type MODIFY userType varchar(64) NOT NULL');
     }
 
-    const promises: Promise<void>[] = [];
-    Object.entries(UserTypeMapping).forEach(([key, value]) => {
-      promises.push(queryRunner.query('UPDATE user SET type = ? WHERE type = ?', [key, value]));
-      promises.push(queryRunner.query('UPDATE role_user_type SET userType = ? WHERE userType = ?', [key, value]));
-    });
-
-    await Promise.all(promises);
+    for (let userTypeMappingKey in UserTypeMapping) {
+      console.warn(`Updating user type ${userTypeMappingKey} to ${UserTypeMapping[userTypeMappingKey]}`);
+      console.warn('UPDATE user SET type = ? WHERE type = ?', [userTypeMappingKey, UserTypeMapping[userTypeMappingKey]]);
+      await queryRunner.query('UPDATE user SET type = ? WHERE type = ?', [userTypeMappingKey, UserTypeMapping[userTypeMappingKey]]);
+      await queryRunner.query('UPDATE role_user_type SET userType = ? WHERE userType = ?', [userTypeMappingKey, UserTypeMapping[userTypeMappingKey]]);
+    }
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
MariaDB failed on migration because of changing the column causing the 1 to become a string 1

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
