### PR TITLE
fix: wrong query param type for `userType` in Swagger

### DIFF
--- a/src/controller/debtor-controller.ts
+++ b/src/controller/debtor-controller.ts
@@ -188,7 +188,7 @@ export default class DebtorController extends BaseController {
    * @tags debtors - Operations of the debtor controller
    * @operationId calculateFines
    * @security JWT
-   * @param {Array<integer>} userTypes.query - List of all user types fines should be calculated for 1 (MEMBER), 2 (ORGAN), 3 (VOUCHER), 4 (LOCAL_USER), 5 (LOCAL_ADMIN), 6 (INVOICE), 7 (AUTOMATIC_INVOICE).
+   * @param {Array<string>} userTypes.query - List of all user types fines should be calculated for (MEMBER, ORGAN, VOUCHER, LOCAL_USER, LOCAL_ADMIN, INVOICE, AUTOMATIC_INVOICE).
    * @param {Array<string>} referenceDates.query.required - Dates to base the fines on. Every returned user has at
    *    least five euros debt on every reference date. The height of the fine is based on the first date in the array.
    * @return {Array<UserToFineResponse>} 200 - List of eligible fines


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Did a little oopsie and forgot to change this parameter type.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
- Breaking change _(fix or feature that would cause existing functionality to change)_