### PR TITLE
fix: add ordering by user ID in descending order

### DIFF
--- a/src/service/user-service.ts
+++ b/src/service/user-service.ts
@@ -167,6 +167,8 @@ export default class UserService {
       }
     }
 
+    builder.orderBy('user.id', 'DESC');
+
     const users = await builder.limit(take).offset(skip).getRawMany();
     const count = await builder.getCount();
 

--- a/test/unit/controller/user-controller.ts
+++ b/test/unit/controller/user-controller.ts
@@ -350,7 +350,7 @@ describe('UserController', (): void => {
       const searchQuery = 'Firstname1 Last';
       const res = await request(ctx.app)
         .get('/users')
-        .query({ search: searchQuery })
+        .query({ search: searchQuery, take: 100, skip: 0 })
         .set('Authorization', `Bearer ${ctx.adminToken}`);
       expect(res.status).to.equal(200);
 
@@ -370,7 +370,7 @@ describe('UserController', (): void => {
         expect(ids).to.includes(u.id);
       });
 
-      expect(pagination.take).to.equal(defaultPagination());
+      expect(pagination.take).to.equal(100);
       expect(pagination.skip).to.equal(0);
 
     });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
`GET /users/` returns users ordered by `id` descending.

## Related issues/external references
#273 

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
