### PR TITLE
chore: remove TypeORM deprecated function usage

### DIFF
--- a/src/controller/authentication-secure-controller.ts
+++ b/src/controller/authentication-secure-controller.ts
@@ -84,7 +84,7 @@ export default class AuthenticationSecureController extends BaseController {
 
     try {
       const user = await User.findOne({ where: { id: req.token.user.id } });
-      const token = await AuthenticationService.getSaltedToken(user, {
+      const token = await new AuthenticationService().getSaltedToken(user, {
         roleManager: this.roleManager,
         tokenHandler: this.tokenHandler,
       }, req.token.lesser);
@@ -118,7 +118,7 @@ export default class AuthenticationSecureController extends BaseController {
       }
 
       const expiry = ServerSettingsStore.getInstance().getSetting('jwtExpiryPointOfSale') as ISettings['jwtExpiryPointOfSale'];
-      const token = await AuthenticationService.getSaltedToken(pointOfSale.user, {
+      const token = await new AuthenticationService().getSaltedToken(pointOfSale.user, {
         roleManager: this.roleManager,
         tokenHandler: this.tokenHandler,
       }, false, undefined, expiry);

--- a/src/controller/user-controller.ts
+++ b/src/controller/user-controller.ts
@@ -459,7 +459,7 @@ export default class UserController extends BaseController {
         return;
       }
 
-      await AuthenticationService.setUserAuthenticationHash(user,
+      await new AuthenticationService().setUserAuthenticationHash(user,
         updatePinRequest.pin.toString(), PinAuthenticator);
       res.status(204).json();
     } catch (error) {
@@ -501,7 +501,7 @@ export default class UserController extends BaseController {
         return;
       }
 
-      await AuthenticationService.setUserAuthenticationNfc(user,
+      await new AuthenticationService().setUserAuthenticationNfc(user,
         updateNfcRequest.nfcCode.toString(), NfcAuthenticator);
       res.status(204).json();
     } catch (error) {
@@ -574,7 +574,7 @@ export default class UserController extends BaseController {
       }
 
       const generatedKey = randomBytes(128).toString('hex');
-      await AuthenticationService.setUserAuthenticationHash(user,
+      await new AuthenticationService().setUserAuthenticationHash(user,
         generatedKey, KeyAuthenticator);
       const response = { key: generatedKey } as UpdateKeyResponse;
       res.status(200).json(response);
@@ -651,7 +651,7 @@ export default class UserController extends BaseController {
         return;
       }
 
-      await AuthenticationService.setUserAuthenticationHash(user,
+      await new AuthenticationService().setUserAuthenticationHash(user,
         updateLocalRequest.password, LocalAuthenticator);
       res.status(204).json();
     } catch (error) {
@@ -1384,7 +1384,7 @@ export default class UserController extends BaseController {
         tokenHandler: this.tokenHandler,
       };
 
-      const token = await AuthenticationService.getSaltedToken(authenticateAs, context, false);
+      const token = await new AuthenticationService().getSaltedToken(authenticateAs, context, false);
       res.status(200).json(token);
     } catch (error) {
       this.logger.error('Could not authenticate as user:', error);

--- a/src/controller/user-controller.ts
+++ b/src/controller/user-controller.ts
@@ -1157,6 +1157,7 @@ export default class UserController extends BaseController {
    * @returns {string} 200 - The requested report - application/pdf
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
+   * @return {string} 502 - PDF generation failed
    */
   public async getUsersSalesReportPdf(req: RequestWithToken, res: Response): Promise<void> {
     const { id } = req.params;
@@ -1206,6 +1207,7 @@ export default class UserController extends BaseController {
    * @returns {string} 200 - The requested report - application/pdf
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
+   * @return {string} 502 - PDF generation failed
    */
   public async getUsersPurchaseReportPdf(req: RequestWithToken, res: Response): Promise<void> {
     const { id } = req.params;

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -21,7 +21,7 @@
 import log4js, { Logger } from 'log4js';
 import Database from './database/database';
 import dinero, { Currency } from 'dinero.js';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import cron from 'node-cron';
 import BalanceService from './service/balance-service';
 import ADService from './service/ad-service';
@@ -34,7 +34,7 @@ import DefaultRoles from './rbac/default-roles';
 class CronApplication {
   logger: Logger;
 
-  connection: Connection;
+  connection: DataSource;
 
   tasks: cron.ScheduledTask[];
 

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -96,14 +96,15 @@ async function createCronTasks(): Promise<void> {
   Gewis.overwriteBindings();
 
   if (process.env.ENABLE_LDAP === 'true') {
-    await ADService.syncUsers();
-    await ADService.syncSharedAccounts().then(
-      () => ADService.syncUserRoles(application.roleManager),
+    const adService = new ADService();
+    await adService.syncUsers();
+    await adService.syncSharedAccounts().then(
+      () => adService.syncUserRoles(application.roleManager),
     );
     const syncADGroups = cron.schedule('*/10 * * * *', async () => {
       logger.debug('Syncing AD.');
-      await ADService.syncSharedAccounts().then(
-        () => ADService.syncUserRoles(application.roleManager),
+      await adService.syncSharedAccounts().then(
+        () => adService.syncUserRoles(application.roleManager),
       );
       logger.debug('Synced AD');
     });

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -44,7 +44,7 @@ export default async function createApp() {
   try {
     await application.connection.synchronize();
     application.logger.info('Schema synchronized successfully');
-    await application.connection.close();
+    await application.connection.destroy();
   } catch (e) {
     application.logger.error('Error synchronizing schema', e);
   }

--- a/src/gewis/controller/gewis-authentication-controller.ts
+++ b/src/gewis/controller/gewis-authentication-controller.ts
@@ -33,8 +33,6 @@ import GEWISAuthenticationPinRequest from './request/gewis-authentication-pin-re
 import AuthenticationLDAPRequest from '../../controller/request/authentication-ldap-request';
 import AuthenticationController from '../../controller/authentication-controller';
 import Gewis from '../gewis';
-import User from '../../entity/user/user';
-import wrapInManager from '../../helpers/database';
 import UserService from '../../service/user-service';
 import { webResponseToUpdate } from '../helpers/gewis-helper';
 
@@ -161,7 +159,7 @@ export default class GewisAuthenticationController extends BaseController {
       });
       if (!gewisUser) {
         // If
-        gewisUser = await wrapInManager<GewisUser>(Gewis.createUserFromWeb)(gewisweb);
+        gewisUser = await new Gewis().createUserFromWeb(gewisweb);
       } else {
         //
         const update = webResponseToUpdate(gewisweb);
@@ -197,7 +195,8 @@ export default class GewisAuthenticationController extends BaseController {
     this.logger.trace('GEWIS LDAP authentication for user', body.accountName);
 
     try {
-      await AuthenticationController.LDAPLoginConstructor(this.roleManager, this.tokenHandler, Gewis.findOrCreateGEWISUserAndBind.bind(Gewis))(req, res);
+      const gewisService = new Gewis();
+      await AuthenticationController.LDAPLoginConstructor(this.roleManager, this.tokenHandler, gewisService.findOrCreateGEWISUserAndBind.bind(gewisService))(req, res);
     } catch (error) {
       this.logger.error('Could not authenticate using LDAP:', error);
       res.status(500).json('Internal server error.');

--- a/src/gewis/controller/gewis-authentication-controller.ts
+++ b/src/gewis/controller/gewis-authentication-controller.ts
@@ -168,7 +168,7 @@ export default class GewisAuthenticationController extends BaseController {
         await UserService.updateUser(gewisUser.user.id, update);
       }
 
-      const response = await AuthenticationService.getSaltedToken(
+      const response = await new AuthenticationService().getSaltedToken(
         gewisUser.user,
         { roleManager: this.roleManager, tokenHandler: this.tokenHandler },
         false,
@@ -197,8 +197,7 @@ export default class GewisAuthenticationController extends BaseController {
     this.logger.trace('GEWIS LDAP authentication for user', body.accountName);
 
     try {
-      await AuthenticationController.LDAPLoginConstructor(this.roleManager, this.tokenHandler,
-        wrapInManager<User>(Gewis.findOrCreateGEWISUserAndBind))(req, res);
+      await AuthenticationController.LDAPLoginConstructor(this.roleManager, this.tokenHandler, Gewis.findOrCreateGEWISUserAndBind.bind(Gewis))(req, res);
     } catch (error) {
       this.logger.error('Could not authenticate using LDAP:', error);
       res.status(500).json('Internal server error.');

--- a/src/gewis/gewis.ts
+++ b/src/gewis/gewis.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { createQueryBuilder, EntityManager } from 'typeorm';
+import { EntityManager } from 'typeorm';
 import User, { UserType } from '../entity/user/user';
 import GewisUser from './entity/gewis-user';
 import AuthenticationService from '../service/authentication-service';
@@ -104,7 +104,7 @@ export default class Gewis {
   }
 
   public static getUserBuilder() {
-    return createQueryBuilder()
+    return AppDataSource.createQueryBuilder()
       .from(User, 'user')
       .leftJoin(GewisUser, 'gewis_user', 'userId = id')
       .orderBy('userId', 'ASC');

--- a/src/gewis/gewis.ts
+++ b/src/gewis/gewis.ts
@@ -18,7 +18,6 @@
  *  @license
  */
 
-import { EntityManager } from 'typeorm';
 import User, { UserType } from '../entity/user/user';
 import GewisUser from './entity/gewis-user';
 import AuthenticationService from '../service/authentication-service';
@@ -29,6 +28,7 @@ import { parseRawUserToResponse, RawUser } from '../helpers/revision-to-response
 import Bindings from '../helpers/bindings';
 import { GewisUserResponse } from './controller/response/gewis-user-response';
 import { AppDataSource } from '../database/database';
+import WithManager from '../database/with-manager';
 
 export interface RawGewisUser extends RawUser {
   gewisId: number
@@ -37,15 +37,12 @@ export interface RawGewisUser extends RawUser {
 /**
  * The GEWIS-specific module with definitions and helper functions.
  */
-export default class Gewis {
+export default class Gewis extends WithManager {
   /**
    * This function creates a new user if needed and binds it to a GEWIS number and AD account.
-   * @param manager - Reference to the EntityManager needed for the transaction.
    * @param ADUser
    */
-  public static async findOrCreateGEWISUserAndBind(ADUser: LDAPUser): Promise<User> {
-    const manager = AppDataSource.manager;
-
+  public async findOrCreateGEWISUserAndBind(ADUser: LDAPUser): Promise<User> {
     // The employeeNumber is the leading truth for m-number.
     if (!ADUser.mNumber) return undefined;
     let gewisUser;
@@ -56,12 +53,11 @@ export default class Gewis {
       gewisUser = await GewisUser.findOne({ where: { gewisId }, relations: ['user'] });
       if (gewisUser) {
         // If user exists we only have to bind the AD user
-        await bindUser(manager, ADUser, gewisUser.user);
+        await bindUser(this.manager, ADUser, gewisUser.user);
       } else {
         // If m-account does not exist we create an account and bind it.
-        gewisUser = await new AuthenticationService(manager)
-          .createUserAndBind(ADUser).then(async (u) => (
-            (Promise.resolve(await Gewis.createGEWISUser(manager, u, gewisId)))));
+        const u = await new AuthenticationService(this.manager).createUserAndBind(ADUser);
+        gewisUser = await this.createGEWISUser(u, gewisId);
       }
     } catch (error) {
       return undefined;
@@ -72,11 +68,9 @@ export default class Gewis {
 
   /**
    * Function that creates a SudoSOS user based on the payload provided by the GEWIS Web token.
-   * @param manager
    * @param token
    */
-  public static async createUserFromWeb(manager: EntityManager, token: GewiswebToken):
-  Promise<GewisUser> {
+  public async createUserFromWeb(token: GewiswebToken): Promise<GewisUser> {
     const user = Object.assign(new User(), {
       firstName: token.given_name,
       lastName: (token.middle_name.length > 0 ? `${token.middle_name} ` : '') + token.family_name,
@@ -86,7 +80,8 @@ export default class Gewis {
       ofAge: token.is_18_plus,
       canGoIntoDebt: true,
     } as User) as User;
-    return manager.save(user).then((u) => Gewis.createGEWISUser(manager, u, token.lidnr));
+    const u = await this.manager.save(user);
+    return this.createGEWISUser(u, token.lidnr);
   }
 
   /**
@@ -112,18 +107,16 @@ export default class Gewis {
 
   /**
    * Function that turns a local User into a GEWIS User.
-   * @param manager - Reference to the EntityManager needed for the transaction.
    * @param user - The local user
    * @param gewisId - GEWIS member ID of the user
    */
-  public static async createGEWISUser(manager: EntityManager, user: User, gewisId: number)
-    : Promise<GewisUser> {
+  public async createGEWISUser(user: User, gewisId: number): Promise<GewisUser> {
     const gewisUser = Object.assign(new GewisUser(), {
       user,
       gewisId,
     });
 
-    await manager.save(gewisUser);
+    await this.manager.save(gewisUser);
     // 09-08-2022 (Roy): code block below (temporarily) disabled, because the huge amount of queries
     // in this chain makes the request too slow for the test suite
     //
@@ -137,7 +130,10 @@ export default class Gewis {
 
   // eslint-disable-next-line class-methods-use-this
   static overwriteBindings() {
-    Bindings.ldapUserCreation = () => Gewis.findOrCreateGEWISUserAndBind.bind(Gewis);
+    Bindings.ldapUserCreation = () => {
+      const service = new Gewis();
+      return service.findOrCreateGEWISUserAndBind.bind(service);
+    };
     Bindings.Users = {
       parseToResponse: Gewis.parseRawUserToGewisResponse,
       getBuilder: Gewis.getUserBuilder,

--- a/src/helpers/bindings.ts
+++ b/src/helpers/bindings.ts
@@ -18,12 +18,13 @@
  *  @license
  */
 
-import { createQueryBuilder, SelectQueryBuilder } from 'typeorm';
+import { SelectQueryBuilder } from 'typeorm';
 import User from '../entity/user/user';
 import AuthenticationService from '../service/authentication-service';
 import { LDAPUser } from './ad';
 import { parseRawUserToResponse, parseUserToResponse, RawUser } from './revision-to-response';
 import { UserResponse } from '../controller/response/user-response';
+import { AppDataSource } from '../database/database';
 
 /**
  * Class used for setting default functions or bindings.
@@ -51,6 +52,6 @@ export default class Bindings {
     getBuilder: () => SelectQueryBuilder<User>
   } = {
       parseToResponse: parseRawUserToResponse,
-      getBuilder: () => createQueryBuilder().from(User, 'user').orderBy({ 'user.id': 'ASC' }),
+      getBuilder: () => AppDataSource.createQueryBuilder().from(User, 'user').orderBy({ 'user.id': 'ASC' }),
     };
 }

--- a/src/helpers/bindings.ts
+++ b/src/helpers/bindings.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { createQueryBuilder, EntityManager, SelectQueryBuilder } from 'typeorm';
+import { createQueryBuilder, SelectQueryBuilder } from 'typeorm';
 import User from '../entity/user/user';
 import AuthenticationService from '../service/authentication-service';
 import { LDAPUser } from './ad';
@@ -34,8 +34,10 @@ export default class Bindings {
   /**
    * Function called when an unbound User is found and created.
    */
-  public static ldapUserCreation: (manager: EntityManager,
-    ADUser: LDAPUser) => Promise<User> = AuthenticationService.createUserAndBind;
+  public static ldapUserCreation: () => (ADUser: LDAPUser) => Promise<User> = () => {
+    const service = new AuthenticationService();
+    return service.createUserAndBind.bind(service);
+  };
 
   /**
    * Function called when mapping db user entities to responses.

--- a/src/helpers/database.ts
+++ b/src/helpers/database.ts
@@ -18,20 +18,4 @@
  *  @license
  */
 
-import { EntityManager } from 'typeorm';
-import { AppDataSource } from '../database/database';
-
-/**
- * Takes a function with an EntityManager as first param and wraps it in a manager.
- * This ensures that if any of the DB transactions fail of the given transaction
- * function everything will be rolled back.
- * @param transactionFunction
- */
-export default function wrapInManager<T>(transactionFunction:
-(manager: EntityManager, ...arg: any[]) => Promise<T>): (...arg: any[]) => Promise<T> {
-  return async (...arg: any[]) => Promise.resolve(AppDataSource.manager.transaction(
-    async (manager) => Promise.resolve(transactionFunction(manager, ...arg)),
-  ));
-}
-
 export const PERSISTENT_TEST_DATABASES = new Set(['mysql', 'mariadb']);

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ export class Application {
     this.logger.info('Stopping application instance...');
     await util.promisify(this.server.close).bind(this.server)();
     this.tasks.forEach((task) => task.stop());
-    await this.connection.close();
+    await this.connection.destroy();
     this.logger.info('Application stopped.');
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import dinero, { Currency } from 'dinero.js';
 import { config } from 'dotenv';
 import express from 'express';
 import log4js, { Logger } from 'log4js';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import cron from 'node-cron';
 import fileUpload from 'express-fileupload';
 import Database from './database/database';
@@ -81,7 +81,7 @@ export class Application {
 
   server: http.Server;
 
-  connection: Connection;
+  connection: DataSource;
 
   logger: Logger;
 

--- a/src/service/authentication-service.ts
+++ b/src/service/authentication-service.ts
@@ -22,7 +22,7 @@ import bcrypt from 'bcrypt';
 // @ts-ignore
 import { filter } from 'ldap-escape';
 import log4js, { Logger } from 'log4js';
-import { EntityManager, FindOptionsWhere, getRepository, In } from 'typeorm';
+import { FindOptionsWhere, In } from 'typeorm';
 import { randomBytes } from 'crypto';
 import User, { LocalUserTypes, UserType } from '../entity/user/user';
 import JsonWebToken from '../authentication/json-web-token';
@@ -42,6 +42,7 @@ import AuthenticationResetTokenRequest from '../controller/request/authenticatio
 import NfcAuthenticator from '../entity/authenticator/nfc-authenticator';
 import RBACService from './rbac-service';
 import Role from '../entity/rbac/role';
+import WithManager from '../database/with-manager';
 
 export interface AuthenticationContext {
   tokenHandler: TokenHandler,
@@ -53,7 +54,7 @@ export interface ResetTokenInfo {
   password: string,
 }
 
-export default class AuthenticationService {
+export default class AuthenticationService extends WithManager {
   /**
    * Amount of salt rounds to use.
    */
@@ -62,7 +63,7 @@ export default class AuthenticationService {
   /**
    * ResetToken expiry time in seconds
    */
-  private static RESET_TOKEN_EXPIRES: () => number =
+  private RESET_TOKEN_EXPIRES: () => number =
     () => {
       const env = parseInt(process.env.RESET_TOKEN_EXPIRES, 10);
       return Number.isNaN(env) ? 3600 : env;
@@ -72,7 +73,7 @@ export default class AuthenticationService {
    * Helper function hashes the given string with salt.
    * @param password - password to hash
    */
-  public static async hashPassword(password: string): Promise<string> {
+  public async hashPassword(password: string): Promise<string> {
     const salt = await bcrypt.genSalt(AuthenticationService.BCRYPT_ROUNDS);
     return Promise.resolve(bcrypt.hash(password, salt));
   }
@@ -86,7 +87,7 @@ export default class AuthenticationService {
    * @param overrideMaintenance - If the token should be able to access all endpoints
    * in maintenance mode
    */
-  public static async makeJsonWebToken(
+  public async makeJsonWebToken(
     user: User, roles: Role[], organs: User[], lesser: boolean, overrideMaintenance: boolean,
   ): Promise<JsonWebToken> {
 
@@ -103,7 +104,7 @@ export default class AuthenticationService {
    * Function that checks if the provided request corresponds to a valid reset token in the DB.
    * @param request
    */
-  public static async isResetTokenRequestValid(request: AuthenticationResetTokenRequest):
+  public async isResetTokenRequestValid(request: AuthenticationResetTokenRequest):
   Promise<ResetToken | undefined> {
     const user = await User.findOne({
       where: { email: request.accountMail, deleted: false, type: In(LocalUserTypes) },
@@ -151,10 +152,9 @@ export default class AuthenticationService {
   /**
    * Creates a new User and binds it to the ObjectGUID of the provided LDAPUser.
    * Function is ran in a single DB transaction in the context of an EntityManager
-   * @param manager - The EntityManager context to use.
    * @param ADUser - The user for which to create a new account.
    */
-  public static async createUserAndBind(manager: EntityManager, ADUser: LDAPUser): Promise<User> {
+  public async createUserAndBind(ADUser: LDAPUser): Promise<User> {
     let account = Object.assign(new User(), {
       firstName: ADUser.givenName,
       lastName: ADUser.sn,
@@ -164,8 +164,8 @@ export default class AuthenticationService {
       ofAge: false,
     } as User) as User;
 
-    account = await manager.save(account);
-    const auth = await bindUser(manager, ADUser, account);
+    account = await this.manager.save(User, account);
+    const auth = await bindUser(this.manager, ADUser, account);
     return auth.user;
   }
 
@@ -176,9 +176,9 @@ export default class AuthenticationService {
    * @param pass - Code to set
    * @param Type
    */
-  public static async setUserAuthenticationHash<T extends HashBasedAuthenticationMethod>(user: User,
+  public async setUserAuthenticationHash<T extends HashBasedAuthenticationMethod>(user: User,
     pass: string, Type: new () => T): Promise<T> {
-    const repo = getRepository(Type);
+    const repo = this.manager.getRepository(Type);
     let authenticator = await repo.findOne({ where: { user: { id: user.id } } as FindOptionsWhere<T>, relations: ['user'] });
     const hash = await this.hashPassword(pass);
 
@@ -198,9 +198,9 @@ export default class AuthenticationService {
     return authenticator;
   }
 
-  public static async setUserAuthenticationNfc<T extends NfcAuthenticator>(user: User,
+  public async setUserAuthenticationNfc<T extends NfcAuthenticator>(user: User,
     nfcCode: string, Type: new () => T): Promise<T> {
-    const repo = getRepository(Type);
+    const repo = this.manager.getRepository(Type);
     let authenticator = await repo.findOne({ where: { user: { id: user.id } } as FindOptionsWhere<T>, relations: ['user'] });
 
     if (authenticator) {
@@ -229,7 +229,7 @@ export default class AuthenticationService {
    * @param lesser
    * @constructor
    */
-  public static async HashAuthentication<T extends HashBasedAuthenticationMethod>(pass: string,
+  public async HashAuthentication<T extends HashBasedAuthenticationMethod>(pass: string,
     authenticator: T, context: AuthenticationContext, lesser = true)
     : Promise<AuthenticationResponse | undefined> {
     const valid = await this.compareHash(pass, authenticator.hash);
@@ -245,7 +245,7 @@ export default class AuthenticationService {
    * @param onNewUser - Callback function when user does not exist in local system.
    * @constructor
    */
-  public static async LDAPAuthentication(uid:string, password: string,
+  public async LDAPAuthentication(uid:string, password: string,
     onNewUser: (ADUser: LDAPUser) => Promise<User>): Promise<User | undefined> {
     const logger: Logger = log4js.getLogger('LDAP');
     logger.level = process.env.LOG_LEVEL;
@@ -298,7 +298,7 @@ export default class AuthenticationService {
     }
 
     // At this point the user is authenticated.
-    const authenticator = await LDAPAuthenticator.findOne({ where: { UUID: ADUser.objectGUID }, relations: ['user'] });
+    const authenticator = await this.manager.findOne(LDAPAuthenticator, { where: { UUID: ADUser.objectGUID }, relations: ['user'] });
 
     // If there is no user associated with the GUID we create the user and bind it.
     return Promise.resolve(authenticator
@@ -309,8 +309,8 @@ export default class AuthenticationService {
    * Get a list of all users this user can authenticate as, including itself.
    * @param user
    */
-  public static async getMemberAuthenticators(user: User): Promise<User[]> {
-    const users = (await MemberAuthenticator.find({ where: { user: { id: user.id } }, relations: ['authenticateAs'] }))
+  public async getMemberAuthenticators(user: User): Promise<User[]> {
+    const users = (await this.manager.find(MemberAuthenticator, { where: { user: { id: user.id } }, relations: ['authenticateAs'] }))
       .map((auth) => auth.authenticateAs);
 
     users.push(user);
@@ -325,15 +325,14 @@ export default class AuthenticationService {
    * @param users - The users that gain access.
    * @param authenticateAs - The account that needs to be accessed.
    */
-  public static async setMemberAuthenticator(manager: EntityManager, users: User[],
-    authenticateAs: User) {
+  public async setMemberAuthenticator(users: User[], authenticateAs: User) {
     // First drop all rows containing authenticateAs
     // We check if there is anything to drop or else type orm will complain.
-    const toRemove: MemberAuthenticator[] = await MemberAuthenticator
-      .find({ where: { authenticateAs: { id: authenticateAs.id } } });
+    const toRemove: MemberAuthenticator[] = await this.manager
+      .find(MemberAuthenticator, { where: { authenticateAs: { id: authenticateAs.id } } });
 
     if (toRemove.length !== 0) {
-      await manager.delete(MemberAuthenticator, { authenticateAs });
+      await this.manager.delete(MemberAuthenticator, { authenticateAs });
     }
 
     const promises: Promise<MemberAuthenticator>[] = [];
@@ -344,7 +343,7 @@ export default class AuthenticationService {
         userId: user.id,
         authenticateAsId: authenticateAs.id,
       });
-      promises.push(manager.save(authenticator));
+      promises.push(this.manager.save(MemberAuthenticator, authenticator));
     });
 
     await Promise.all(promises);
@@ -356,12 +355,12 @@ export default class AuthenticationService {
    * @param token - Passcode of the reset token
    * @param newPassword - New password to set for the authentication
    */
-  public static async resetLocalUsingToken(resetToken: ResetToken,
+  public async resetLocalUsingToken(resetToken: ResetToken,
     token: string, newPassword: string): Promise<LocalAuthenticator | undefined> {
     const auth = await this.setUserAuthenticationHash(
       resetToken.user, newPassword, LocalAuthenticator,
     );
-    await ResetToken.delete(resetToken.userId);
+    await this.manager.delete(ResetToken, resetToken.userId);
     return auth;
   }
 
@@ -369,7 +368,7 @@ export default class AuthenticationService {
    * Creates a ResetToken for the given user.
    * @param user
    */
-  public static async createResetToken(user: User): Promise<ResetTokenInfo> {
+  public async createResetToken(user: User): Promise<ResetTokenInfo> {
     const password = randomBytes(32).toString('hex');
     const resetToken = await this.setUserAuthenticationHash(user, password, ResetToken);
 
@@ -392,7 +391,7 @@ export default class AuthenticationService {
    * @param expiry Custom expiry time (in seconds). If not set,
    * the default tokenHandler expiry will be used
    */
-  public static async getSaltedToken(
+  public async getSaltedToken(
     user: User, context: AuthenticationContext, lesser = true, salt?: string, expiry?: number,
   ): Promise<AuthenticationResponse> {
     const [roles, organs] = await Promise.all([
@@ -405,10 +404,10 @@ export default class AuthenticationService {
     if (!salt) salt = await bcrypt.genSalt(AuthenticationService.BCRYPT_ROUNDS);
     const token = await context.tokenHandler.signToken(contents, salt, expiry);
 
-    return this.asAuthenticationResponse(contents.user, roles, contents.organs, token);
+    return AuthenticationService.asAuthenticationResponse(contents.user, roles, contents.organs, token);
   }
 
-  public static async compareHash(password: string, hash: string): Promise<boolean> {
+  public async compareHash(password: string, hash: string): Promise<boolean> {
     return bcrypt.compare(password, hash);
   }
 }

--- a/src/service/authentication-service.ts
+++ b/src/service/authentication-service.ts
@@ -301,8 +301,8 @@ export default class AuthenticationService extends WithManager {
     const authenticator = await this.manager.findOne(LDAPAuthenticator, { where: { UUID: ADUser.objectGUID }, relations: ['user'] });
 
     // If there is no user associated with the GUID we create the user and bind it.
-    return Promise.resolve(authenticator
-      ? authenticator.user : await onNewUser(ADUser));
+    if (authenticator) return authenticator.user;
+    return onNewUser(ADUser);
   }
 
   /**

--- a/src/service/container-service.ts
+++ b/src/service/container-service.ts
@@ -325,7 +325,7 @@ export default class ContainerService {
 
     let owner: FindOptionsWhere<User> = {};
     if (user) {
-      const organIds = (await AuthenticationService.getMemberAuthenticators(user)).map((u) => u.id);
+      const organIds = (await new AuthenticationService().getMemberAuthenticators(user)).map((u) => u.id);
       owner = { id: In(organIds) };
     } else if (params.ownerId) {
       owner = { id: params.ownerId };

--- a/src/service/debtor-service.ts
+++ b/src/service/debtor-service.ts
@@ -36,13 +36,13 @@ import { DineroObjectRequest } from '../controller/request/dinero-request';
 import UserFineGroup from '../entity/fine/userFineGroup';
 import { PaginationParameters } from '../helpers/pagination';
 import { parseUserToBaseResponse } from '../helpers/revision-to-response';
-import { getConnection } from 'typeorm';
 import Transfer from '../entity/transactions/transfer';
 import Mailer from '../mailer';
 import UserGotFined from '../mailer/messages/user-got-fined';
 import MailMessage from '../mailer/mail-message';
 import UserWillGetFined from '../mailer/messages/user-will-get-fined';
 import { FineReport } from '../entity/report/fine-report';
+import { AppDataSource } from '../database/database';
 
 export interface CalculateFinesParams {
   userTypes?: UserType[];
@@ -202,7 +202,7 @@ export default class DebtorService {
     });
 
     // NOTE: executed in single transaction
-    const { fines: fines1, fineHandoutEvent: fineHandoutEvent1, emails: emails1 } = await getConnection().transaction(async (manager) => {
+    const { fines: fines1, fineHandoutEvent: fineHandoutEvent1, emails: emails1 } = await AppDataSource.transaction(async (manager) => {
       // Create a new fine group to "connect" all these fines
       const fineHandoutEvent = Object.assign(new FineHandoutEvent(), {
         referenceDate,

--- a/src/service/event-service.ts
+++ b/src/service/event-service.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Between, createQueryBuilder, FindManyOptions, In, IsNull, LessThanOrEqual, MoreThanOrEqual } from 'typeorm';
+import { Between, FindManyOptions, In, IsNull, LessThanOrEqual, MoreThanOrEqual } from 'typeorm';
 import {
   BaseEventAnswerResponse,
   BaseEventResponse,
@@ -48,6 +48,7 @@ import Mailer from '../mailer';
 import ForgotEventPlanning from '../mailer/messages/forgot-event-planning';
 import { Language } from '../mailer/mail-message';
 import Role from '../entity/rbac/role';
+import { AppDataSource } from '../database/database';
 
 export interface EventFilterParameters {
   name?: string;
@@ -492,7 +493,7 @@ export default class EventService {
   public static async getShiftSelectedCount(
     shiftId: number, { eventType, afterDate, beforeDate }: ShiftSelectedCountParams = {},
   ): Promise<EventPlanningSelectedCount[]> {
-    let query = createQueryBuilder()
+    let query = AppDataSource.createQueryBuilder()
       .select('user.id', 'id')
       .addSelect('count(event.id)', 'count')
       .addSelect('max(user.firstName)', 'firstName')

--- a/src/service/file-service.ts
+++ b/src/service/file-service.ts
@@ -29,8 +29,8 @@ import ProductImage from '../entity/file/product-image';
 import Banner from '../entity/banner';
 import BannerImage from '../entity/file/banner-image';
 import Pdf from '../entity/file/pdf-file';
-import { getRepository } from 'typeorm';
 import { IPdfAble } from '../entity/file/pdf-able';
+import { AppDataSource } from '../database/database';
 
 /**
  *  Possible storage methods that can be used
@@ -153,8 +153,8 @@ export default class FileService {
   public async uploadPdf<T extends IPdfAble<S>, S extends Pdf>(entity: T, PdfType: new () => S, fileData: Buffer, createdBy: User): Promise<S> {
     let pdf = entity.pdf;
 
-    const entityRepo = getRepository(entity.constructor as new () => T);
-    const entityPdf = getRepository(PdfType);
+    const entityRepo = AppDataSource.getRepository(entity.constructor as new () => T);
+    const entityPdf = AppDataSource.getRepository(PdfType);
 
     const hash = await entity.getPdfParamHash();
     if (pdf == null) {

--- a/src/service/point-of-sale-service.ts
+++ b/src/service/point-of-sale-service.ts
@@ -268,7 +268,7 @@ export default class PointOfSaleService {
 
     let owner: FindOptionsWhere<User> = {};
     if (user) {
-      const organIds = (await AuthenticationService.getMemberAuthenticators(user)).map((u) => u.id);
+      const organIds = (await new AuthenticationService().getMemberAuthenticators(user)).map((u) => u.id);
       owner = { id: In(organIds) };
     } else if (params.ownerId) {
       owner = { id: params.ownerId };

--- a/src/service/product-service.ts
+++ b/src/service/product-service.ts
@@ -385,7 +385,7 @@ export default class ProductService {
 
     let owner: FindOptionsWhere<User> = {};
     if (user) {
-      const organIds = (await AuthenticationService.getMemberAuthenticators(user)).map((u) => u.id);
+      const organIds = (await new AuthenticationService().getMemberAuthenticators(user)).map((u) => u.id);
       owner = { id: In(organIds) };
     } else if (params.ownerId) {
       owner = { id: params.ownerId };

--- a/src/service/user-service.ts
+++ b/src/service/user-service.ts
@@ -214,7 +214,7 @@ export default class UserService {
 
     // Local users will receive a reset link.
     if (LocalUserTypes.includes(user.type)) {
-      const resetTokenInfo = await AuthenticationService.createResetToken(user);
+      const resetTokenInfo = await new AuthenticationService().createResetToken(user);
       Mailer.getInstance().send(user, new WelcomeWithReset({ email: user.email, resetTokenInfo })).then().catch((e) => {
         throw e;
       });

--- a/src/service/vat-group-service.ts
+++ b/src/service/vat-group-service.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { createQueryBuilder, FindManyOptions } from 'typeorm';
+import { FindManyOptions } from 'typeorm';
 import { DineroObject } from 'dinero.js';
 import { PaginationParameters } from '../helpers/pagination';
 import VatGroup, { VatDeclarationPeriod } from '../entity/vat-group';
@@ -36,6 +36,7 @@ import SubTransactionRow from '../entity/transactions/sub-transaction-row';
 import ProductRevision from '../entity/product/product-revision';
 import DineroTransformer from '../entity/transformer/dinero-transformer';
 import ProductService from './product-service';
+import { AppDataSource } from '../database/database';
 
 interface VatGroupFilterParameters {
   vatGroupId?: number;
@@ -200,7 +201,7 @@ export default class VatGroupService {
 
     const vatGroups = await VatGroup.find({ where: { deleted: false } });
 
-    const builder = createQueryBuilder(SubTransactionRow, 'str')
+    const builder = AppDataSource.createQueryBuilder(SubTransactionRow, 'str')
       .select([
         'vatgroup.id as id',
         'MAX(vatgroup.name) as name',

--- a/test/helpers/test-helpers.ts
+++ b/test/helpers/test-helpers.ts
@@ -71,10 +71,8 @@ export async function finishTestDB(connection: DataSource) {
   // Only drop in sqlite. If really wanted otherwise, do the call directly on the connection.
   if (process.env.TYPEORM_CONNECTION === 'sqlite') {
     await connection.dropDatabase();
-    await connection.close();
-  } else {
-    await connection.destroy();
   }
+  await connection.destroy();
 }
 
 // Cleans up the database accordingly

--- a/test/helpers/test-helpers.ts
+++ b/test/helpers/test-helpers.ts
@@ -21,7 +21,7 @@
 import dinero from 'dinero.js';
 import express, { Express } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
-import { Connection, DataSource } from 'typeorm';
+import { DataSource } from 'typeorm';
 import TransferRequest from '../../src/controller/request/transfer-request';
 import TransferService from '../../src/service/transfer-service';
 import Swagger from '../../src/start/swagger';
@@ -37,7 +37,7 @@ export interface DefaultContext {
   app: Express,
   specification: SwaggerSpecification,
   roleManager: RoleManager,
-  connection: Connection,
+  connection: DataSource,
   tokenHandler: TokenHandler,
 }
 

--- a/test/integration/propagation.ts
+++ b/test/integration/propagation.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import express, { Application } from 'express';
 import ProductController from '../../src/controller/product-controller';
 import ContainerController from '../../src/controller/container-controller';
@@ -48,7 +48,7 @@ import { ProductCategorySeeder, RbacSeeder, VatGroupSeeder } from '../seed';
 
 describe('Propagation between products, containers, POSs', () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     productController: ProductController,
     containerController: ContainerController,

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -33,6 +33,7 @@ import sinonChai from 'sinon-chai';
 import { config } from 'dotenv';
 import { DataSource } from 'typeorm';
 import { PERSISTENT_TEST_DATABASES } from '../src/helpers/database';
+import '../src/database/database';
 
 use(chaiAsPromised);
 use(chaiHttp);

--- a/test/unit/controller/authentication-controller.ts
+++ b/test/unit/controller/authentication-controller.ts
@@ -499,7 +499,7 @@ describe('AuthenticationController', async (): Promise<void> => {
         // eslint-disable-next-line no-param-reassign
         user.type = UserType.LOCAL_USER;
         await User.save(user);
-        const resetToken = await AuthenticationService.createResetToken(user);
+        const resetToken = await new AuthenticationService().createResetToken(user);
         const password = 'Password2';
         const req: AuthenticationResetTokenRequest = {
           accountMail: user.email,
@@ -528,7 +528,7 @@ describe('AuthenticationController', async (): Promise<void> => {
         // eslint-disable-next-line no-param-reassign
         user.type = UserType.LOCAL_USER;
         await User.save(user);
-        const resetToken = await AuthenticationService.createResetToken(user);
+        const resetToken = await new AuthenticationService().createResetToken(user);
         const password = 'Password2';
         const req: AuthenticationResetTokenRequest = {
           accountMail: 'wrong@sudosos.nl',
@@ -569,7 +569,7 @@ describe('AuthenticationController', async (): Promise<void> => {
         // eslint-disable-next-line no-param-reassign
         user.type = UserType.LOCAL_USER;
         await User.save(user);
-        const resetToken = await AuthenticationService.createResetToken(user);
+        const resetToken = await new AuthenticationService().createResetToken(user);
         const password = 'Password2';
         const req: AuthenticationResetTokenRequest = {
           accountMail: user.email,
@@ -592,7 +592,7 @@ describe('AuthenticationController', async (): Promise<void> => {
         // eslint-disable-next-line no-param-reassign
         user.type = UserType.LOCAL_USER;
         await User.save(user);
-        await AuthenticationService.createResetToken(user);
+        await new AuthenticationService().createResetToken(user);
         const password = 'Password2';
         const req: AuthenticationResetTokenRequest = {
           accountMail: user.email,

--- a/test/unit/controller/authentication-secure-controller.ts
+++ b/test/unit/controller/authentication-secure-controller.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import { json } from 'body-parser';
@@ -42,7 +42,7 @@ import { PointOfSaleSeeder, RbacSeeder, UserSeeder } from '../../seed';
 
 describe('AuthenticationSecureController', () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     tokenHandler: TokenHandler,
     specification: SwaggerSpecification,

--- a/test/unit/controller/balance-controller.ts
+++ b/test/unit/controller/balance-controller.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import express, { Application } from 'express';
 import { expect, request } from 'chai';
 import { SwaggerSpecification } from 'swagger-model-validator';
@@ -45,7 +45,7 @@ import { FineSeeder, RbacSeeder, TransactionSeeder, TransferSeeder, UserSeeder }
 
 describe('BalanceController', (): void => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     controller: BalanceController,

--- a/test/unit/controller/banner-controller.ts
+++ b/test/unit/controller/banner-controller.ts
@@ -22,7 +22,7 @@ import { json } from 'body-parser';
 import { expect, request } from 'chai';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import sinon from 'sinon';
 import fs from 'fs';
 import path from 'path';
@@ -69,7 +69,7 @@ export function bannerEq(a: Banner, b: BannerResponse): Boolean {
 
 describe('BannerController', async (): Promise<void> => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     controller: BannerController,

--- a/test/unit/controller/base-controller.ts
+++ b/test/unit/controller/base-controller.ts
@@ -22,7 +22,7 @@ import express, { Application, Request } from 'express';
 import { expect, request } from 'chai';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import { json } from 'body-parser';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import BaseController from '../../../src/controller/base-controller';
 import Policy from '../../../src/controller/policy';
 import { getSpecification } from '../entity/transformer/test-model';
@@ -92,7 +92,7 @@ class TestController extends BaseController {
 
 describe('BaseController', (): void => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     controller: BaseController,

--- a/test/unit/controller/borrelkaart-group-controller.ts
+++ b/test/unit/controller/borrelkaart-group-controller.ts
@@ -22,7 +22,7 @@ import { json } from 'body-parser';
 import { expect, request } from 'chai';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import TokenHandler from '../../../src/authentication/token-handler';
 import VoucherGroupController from '../../../src/controller/voucher-group-controller';
 import { VoucherGroupRequest } from '../../../src/controller/request/voucher-group-request';
@@ -73,7 +73,7 @@ async function saveBKG(
 
 describe('VoucherGroupController', async (): Promise<void> => {
   let ctx: {
-    connection: Connection;
+    connection: DataSource;
     clock: Sinon.SinonFakeTimers,
     app: Application;
     specification: SwaggerSpecification;

--- a/test/unit/controller/container-controller.ts
+++ b/test/unit/controller/container-controller.ts
@@ -19,7 +19,7 @@
  */
 
 import {
-  Connection, IsNull, Not,
+  DataSource, IsNull, Not,
 } from 'typeorm';
 import express, { Application } from 'express';
 import chai, { request, expect } from 'chai';
@@ -75,7 +75,7 @@ function containerProductsEq(source: CreateContainerRequest,
 
 describe('ContainerController', async (): Promise<void> => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     controller: ContainerController,

--- a/test/unit/controller/debtor-controller.ts
+++ b/test/unit/controller/debtor-controller.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import DebtorController from '../../../src/controller/debtor-controller';
@@ -54,7 +54,7 @@ import { FineSeeder, RbacSeeder, TransactionSeeder, TransferSeeder, UserSeeder }
 
 describe('DebtorController', () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     controller: DebtorController,

--- a/test/unit/controller/event-controller.ts
+++ b/test/unit/controller/event-controller.ts
@@ -19,7 +19,7 @@
  */
 
 import express, { Application } from 'express';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import EventController from '../../../src/controller/event-controller';
 import User, { TermsOfServiceStatus, UserType } from '../../../src/entity/user/user';
@@ -48,7 +48,7 @@ import { EventSeeder, RbacSeeder, UserSeeder } from '../../seed';
 
 describe('EventController', () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application
     specification: SwaggerSpecification,
     controller: EventController,

--- a/test/unit/controller/event-shift-controller.ts
+++ b/test/unit/controller/event-shift-controller.ts
@@ -19,7 +19,7 @@
  */
 
 import express, { Application } from 'express';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import User, { TermsOfServiceStatus, UserType } from '../../../src/entity/user/user';
 import EventShift from '../../../src/entity/event/event-shift';
@@ -49,7 +49,7 @@ import { EventSeeder, RbacSeeder, UserSeeder } from '../../seed';
 
 describe('EventShiftController', () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application
     specification: SwaggerSpecification,
     controller: EventShiftController,

--- a/test/unit/controller/invoice-controller.ts
+++ b/test/unit/controller/invoice-controller.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection, In, Not } from 'typeorm';
+import { DataSource, In, Not } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import { json } from 'body-parser';
@@ -62,7 +62,7 @@ import { InvoiceSeeder, RbacSeeder, TransactionSeeder, UserSeeder } from '../../
 
 describe('InvoiceController', async () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     controller: InvoiceController,

--- a/test/unit/controller/payout-request-controller.ts
+++ b/test/unit/controller/payout-request-controller.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import { json } from 'body-parser';
@@ -46,7 +46,7 @@ import { PayoutRequestSeeder, RbacSeeder, UserSeeder } from '../../seed';
 
 describe('PayoutRequestController', () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     controller: PayoutRequestController,

--- a/test/unit/controller/point-of-sale-controller.ts
+++ b/test/unit/controller/point-of-sale-controller.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection, IsNull, Not } from 'typeorm';
+import { DataSource, IsNull, Not } from 'typeorm';
 import { json } from 'body-parser';
 import chai, { expect, request } from 'chai';
 import PointOfSaleController from '../../../src/controller/point-of-sale-controller';
@@ -82,7 +82,7 @@ function updatePointOfSaleEq(source: UpdatePointOfSaleRequest, response: PointOf
 
 describe('PointOfSaleController', async () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Express,
     specification: SwaggerSpecification,
     roleManager: RoleManager,

--- a/test/unit/controller/product-category-controller.ts
+++ b/test/unit/controller/product-category-controller.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import { json } from 'body-parser';
@@ -47,7 +47,7 @@ import { ProductCategorySeeder, RbacSeeder } from '../../seed';
 
 describe('ProductCategoryController', async (): Promise<void> => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     controller: ProductCategoryController,

--- a/test/unit/controller/product-controller.ts
+++ b/test/unit/controller/product-controller.ts
@@ -19,7 +19,7 @@
  */
 
 import {
-  Connection, IsNull, Not,
+  DataSource, IsNull, Not,
 } from 'typeorm';
 import express, { Application } from 'express';
 import { request, expect } from 'chai';
@@ -72,7 +72,7 @@ function productEq(source: CreateProductRequest | UpdateProductRequest, response
 
 describe('ProductController', async (): Promise<void> => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     controller: ProductController,

--- a/test/unit/controller/stripe-controller.ts
+++ b/test/unit/controller/stripe-controller.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import { json } from 'body-parser';
@@ -45,7 +45,7 @@ describe('StripeController', async (): Promise<void> => {
   let originalName: string;
 
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     controller: StripeController,

--- a/test/unit/controller/transaction-controller.ts
+++ b/test/unit/controller/transaction-controller.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import express, { Application } from 'express';
 import { expect, request } from 'chai';
 import { SwaggerSpecification } from 'swagger-model-validator';
@@ -46,7 +46,7 @@ import { RbacSeeder } from '../../seed';
 
 describe('TransactionController', (): void => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     controller: TransactionController,

--- a/test/unit/controller/transfer-controller.ts
+++ b/test/unit/controller/transfer-controller.ts
@@ -21,7 +21,7 @@
 import { expect, request } from 'chai';
 import dinero from 'dinero.js';
 import express, { Application, json } from 'express';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import TokenHandler from '../../../src/authentication/token-handler';
 import TransferRequest from '../../../src/controller/request/transfer-request';
@@ -38,7 +38,7 @@ import { finishTestDB } from '../../helpers/test-helpers';
 import { RbacSeeder, TransferSeeder, UserSeeder } from '../../seed';
 
 describe('TransferController', async (): Promise<void> => {
-  let connection: Connection;
+  let connection: DataSource;
   let app: Application;
 
   let adminAccountDeposit: Transfer;

--- a/test/unit/controller/user-controller.ts
+++ b/test/unit/controller/user-controller.ts
@@ -21,7 +21,7 @@
 import express, { Application } from 'express';
 import chai, { expect, request } from 'chai';
 import { SwaggerSpecification } from 'swagger-model-validator';
-import { DataSource, createQueryBuilder } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { json } from 'body-parser';
 import deepEqualInAnyOrder from 'deep-equal-in-any-order';
 import { describe } from 'mocha';
@@ -30,7 +30,7 @@ import User, { TermsOfServiceStatus, UserType } from '../../../src/entity/user/u
 import Product from '../../../src/entity/product/product';
 import Transaction from '../../../src/entity/transactions/transaction';
 import TokenHandler from '../../../src/authentication/token-handler';
-import Database from '../../../src/database/database';
+import Database, { AppDataSource } from '../../../src/database/database';
 import Swagger from '../../../src/start/swagger';
 import TokenMiddleware, { RequestWithToken } from '../../../src/middleware/token-middleware';
 import ProductCategory from '../../../src/entity/product/product-category';
@@ -1147,7 +1147,7 @@ describe('UserController', (): void => {
 
       const transactions = res.body.records as TransactionResponse[];
 
-      const actualTransactions = await createQueryBuilder(Transaction, 'transaction')
+      const actualTransactions = await ctx.connection.createQueryBuilder(Transaction, 'transaction')
         .leftJoinAndSelect('transaction.from', 'from')
         .leftJoinAndSelect('transaction.createdBy', 'createdBy')
         .leftJoinAndSelect('transaction.pointOfSale', 'pointOfSaleRev')
@@ -1178,7 +1178,7 @@ describe('UserController', (): void => {
 
       const transactions = res.body.records as TransactionResponse[];
 
-      const actualTransactions = await createQueryBuilder(Transaction, 'transaction')
+      const actualTransactions = await ctx.connection.createQueryBuilder(Transaction, 'transaction')
         .leftJoinAndSelect('transaction.from', 'from')
         .leftJoinAndSelect('transaction.createdBy', 'createdBy')
         .leftJoinAndSelect('transaction.pointOfSale', 'pointOfSaleRev')

--- a/test/unit/controller/user-controller.ts
+++ b/test/unit/controller/user-controller.ts
@@ -21,7 +21,7 @@
 import express, { Application } from 'express';
 import chai, { expect, request } from 'chai';
 import { SwaggerSpecification } from 'swagger-model-validator';
-import { Connection, createQueryBuilder } from 'typeorm';
+import { DataSource, createQueryBuilder } from 'typeorm';
 import { json } from 'body-parser';
 import deepEqualInAnyOrder from 'deep-equal-in-any-order';
 import { describe } from 'mocha';
@@ -83,7 +83,7 @@ chai.use(deepEqualInAnyOrder);
 
 describe('UserController', (): void => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     controller: UserController,
@@ -352,7 +352,7 @@ describe('UserController', (): void => {
       const searchQuery = 'Firstname1 Last';
       const res = await request(ctx.app)
         .get('/users')
-        .query({ search: searchQuery, take: 100, skip: 0 })
+        .query({ search: searchQuery })
         .set('Authorization', `Bearer ${ctx.adminToken}`);
       expect(res.status).to.equal(200);
 
@@ -372,7 +372,7 @@ describe('UserController', (): void => {
         expect(ids).to.includes(u.id);
       });
 
-      expect(pagination.take).to.equal(100);
+      expect(pagination.take).to.equal(defaultPagination());
       expect(pagination.skip).to.equal(0);
 
     });
@@ -2302,7 +2302,7 @@ describe('UserController', (): void => {
           .query(parameters);
         expect(res.status).to.equal(200);
       });
-      it('should return 502 if pdf generation fails', async () => {
+      it('should return 500 if pdf generation fails', async () => {
         clientStub.generateUserReport.rejects(new Error('Failed to generate PDF'));
         const id = 1;
         const parameters = { fromDate: '2021-01-01', tillDate: '2021-12-31' };
@@ -2312,7 +2312,7 @@ describe('UserController', (): void => {
           .get(`/users/${id}/transactions/sales/report/pdf`)
           .set('Authorization', `Bearer ${ctx.adminToken}`)
           .query(parameters);
-        expect(res.status).to.equal(502);
+        expect(res.status).to.equal(500);
       });
       it('should return 403 if not admin', async () => {
         const id = 2;
@@ -2395,7 +2395,7 @@ describe('UserController', (): void => {
           .query(parameters);
         expect(res.status).to.equal(200);
       });
-      it('should return 502 if pdf generation fails', async () => {
+      it('should return 500 if pdf generation fails', async () => {
         clientStub.generateUserReport.rejects(new Error('Failed to generate PDF'));
         const id = 1;
         const parameters = { fromDate: '2021-01-01', tillDate: '2021-12-31' };
@@ -2405,7 +2405,7 @@ describe('UserController', (): void => {
           .get(`/users/${id}/transactions/purchases/report/pdf`)
           .set('Authorization', `Bearer ${ctx.adminToken}`)
           .query(parameters);
-        expect(res.status).to.equal(502);
+        expect(res.status).to.equal(500);
       });
       it('should return 403 if not admin', async () => {
         const id = 2;

--- a/test/unit/controller/user-controller.ts
+++ b/test/unit/controller/user-controller.ts
@@ -30,7 +30,7 @@ import User, { TermsOfServiceStatus, UserType } from '../../../src/entity/user/u
 import Product from '../../../src/entity/product/product';
 import Transaction from '../../../src/entity/transactions/transaction';
 import TokenHandler from '../../../src/authentication/token-handler';
-import Database, { AppDataSource } from '../../../src/database/database';
+import Database from '../../../src/database/database';
 import Swagger from '../../../src/start/swagger';
 import TokenMiddleware, { RequestWithToken } from '../../../src/middleware/token-middleware';
 import ProductCategory from '../../../src/entity/product/product-category';

--- a/test/unit/controller/user-controller.ts
+++ b/test/unit/controller/user-controller.ts
@@ -350,9 +350,10 @@ describe('UserController', (): void => {
     });
     it('should return correct user using search', async () => {
       const searchQuery = 'Firstname1 Last';
+      const take = 50;
       const res = await request(ctx.app)
         .get('/users')
-        .query({ search: searchQuery })
+        .query({ search: searchQuery, take })
         .set('Authorization', `Bearer ${ctx.adminToken}`);
       expect(res.status).to.equal(200);
 
@@ -372,7 +373,7 @@ describe('UserController', (): void => {
         expect(ids).to.includes(u.id);
       });
 
-      expect(pagination.take).to.equal(defaultPagination());
+      expect(pagination.take).to.equal(take);
       expect(pagination.skip).to.equal(0);
 
     });

--- a/test/unit/controller/user-controller.ts
+++ b/test/unit/controller/user-controller.ts
@@ -2303,7 +2303,7 @@ describe('UserController', (): void => {
           .query(parameters);
         expect(res.status).to.equal(200);
       });
-      it('should return 500 if pdf generation fails', async () => {
+      it('should return 502 if pdf generation fails', async () => {
         clientStub.generateUserReport.rejects(new Error('Failed to generate PDF'));
         const id = 1;
         const parameters = { fromDate: '2021-01-01', tillDate: '2021-12-31' };
@@ -2313,7 +2313,7 @@ describe('UserController', (): void => {
           .get(`/users/${id}/transactions/sales/report/pdf`)
           .set('Authorization', `Bearer ${ctx.adminToken}`)
           .query(parameters);
-        expect(res.status).to.equal(500);
+        expect(res.status).to.equal(502);
       });
       it('should return 403 if not admin', async () => {
         const id = 2;
@@ -2396,7 +2396,7 @@ describe('UserController', (): void => {
           .query(parameters);
         expect(res.status).to.equal(200);
       });
-      it('should return 500 if pdf generation fails', async () => {
+      it('should return 502 if pdf generation fails', async () => {
         clientStub.generateUserReport.rejects(new Error('Failed to generate PDF'));
         const id = 1;
         const parameters = { fromDate: '2021-01-01', tillDate: '2021-12-31' };
@@ -2406,7 +2406,7 @@ describe('UserController', (): void => {
           .get(`/users/${id}/transactions/purchases/report/pdf`)
           .set('Authorization', `Bearer ${ctx.adminToken}`)
           .query(parameters);
-        expect(res.status).to.equal(500);
+        expect(res.status).to.equal(502);
       });
       it('should return 403 if not admin', async () => {
         const id = 2;

--- a/test/unit/controller/vat-group-controller.ts
+++ b/test/unit/controller/vat-group-controller.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import { json } from 'body-parser';
@@ -49,7 +49,7 @@ import {
 
 describe('VatGroupController', () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     controller: VatGroupController,

--- a/test/unit/database.ts
+++ b/test/unit/database.ts
@@ -19,7 +19,7 @@
  */
 
 import Database from '../../src/database/database';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { expect } from 'chai';
 import { finishTestDB } from '../helpers/test-helpers';
 describe('Database', async (): Promise<void> => {
@@ -32,7 +32,7 @@ describe('Database', async (): Promise<void> => {
     });
   });
   describe('#generate', async () => {
-    let dataSource: Connection;
+    let dataSource: DataSource;
 
     before(async function () {
       dataSource = await Database.initialize();

--- a/test/unit/database.ts
+++ b/test/unit/database.ts
@@ -28,7 +28,7 @@ describe('Database', async (): Promise<void> => {
       if (process.env.TYPEORM_CONNECTION !== 'sqlite') this.skip();
       const connection = await Database.initialize();
       await connection.synchronize();
-      await connection.close();
+      await connection.destroy();
     });
   });
   describe('#generate', async () => {

--- a/test/unit/files/storage/disk-storage.ts
+++ b/test/unit/files/storage/disk-storage.ts
@@ -21,7 +21,7 @@
 import sinon from 'sinon';
 import { expect, assert } from 'chai';
 import path from 'path';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { DiskStorage } from '../../../../src/files/storage';
 import BaseFile from '../../../../src/entity/file/base-file';
 import User from '../../../../src/entity/user/user';
@@ -34,7 +34,7 @@ const workdir = './imaginary/directory';
 
 describe('Disk Storage', async () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     files: BaseFile[],
     users: User[],
     diskStorage: DiskStorage,

--- a/test/unit/gewis/controller/gewis-authentication-controller.ts
+++ b/test/unit/gewis/controller/gewis-authentication-controller.ts
@@ -21,7 +21,7 @@
 import express, { Application } from 'express';
 import { expect, request } from 'chai';
 import { SwaggerSpecification } from 'swagger-model-validator';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { json } from 'body-parser';
 import * as jwt from 'jsonwebtoken';
 import log4js from 'log4js';
@@ -47,7 +47,7 @@ import { RbacSeeder } from '../../../seed';
 
 describe('GewisAuthenticationController', async (): Promise<void> => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     tokenHandler: TokenHandler,
     roleManager: RoleManager,

--- a/test/unit/gewis/controller/gewis-authentication-controller.ts
+++ b/test/unit/gewis/controller/gewis-authentication-controller.ts
@@ -99,7 +99,7 @@ describe('GewisAuthenticationController', async (): Promise<void> => {
       secret: '42',
     };
 
-    await AuthenticationService.setUserAuthenticationHash(await User.findOne({ where: { id: 1 } }), '1000', PinAuthenticator);
+    await new AuthenticationService().setUserAuthenticationHash(await User.findOne({ where: { id: 1 } }), '1000', PinAuthenticator);
 
     const roles = await new RbacSeeder().seed([{
       name: 'Role',

--- a/test/unit/gewis/gewis.ts
+++ b/test/unit/gewis/gewis.ts
@@ -191,7 +191,8 @@ describe('GEWIS Helper functions', async (): Promise<void> => {
         let authUser: User;
         await ctx.connection.transaction(async (manager) => {
           const service = new AuthenticationService(manager);
-          authUser = await service.LDAPAuthentication(`m${user.id}`, 'This Is Correct', (u: LDAPUser) => Gewis.findOrCreateGEWISUserAndBind(u));
+          const gewisService = new Gewis(manager);
+          authUser = await service.LDAPAuthentication(`m${user.id}`, 'This Is Correct', (u: LDAPUser) => gewisService.findOrCreateGEWISUserAndBind(u));
         });
 
         expect(authUser.id).to.be.equal(user.id);
@@ -223,7 +224,8 @@ describe('GEWIS Helper functions', async (): Promise<void> => {
         let authUser: User;
         await ctx.connection.transaction(async (manager) => {
           const service = new AuthenticationService(manager);
-          authUser = await service.LDAPAuthentication(`m${user.id}`, 'This Is Correct', (u: LDAPUser) => Gewis.findOrCreateGEWISUserAndBind(u));
+          const gewisService = new Gewis(manager);
+          authUser = await service.LDAPAuthentication(`m${user.id}`, 'This Is Correct', (u: LDAPUser) => gewisService.findOrCreateGEWISUserAndBind(u));
         });
 
         DBUser = await User.findOne(

--- a/test/unit/gewis/gewis.ts
+++ b/test/unit/gewis/gewis.ts
@@ -21,7 +21,7 @@
 import { expect, request } from 'chai';
 import sinon from 'sinon';
 import { Client } from 'ldapts';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import { json } from 'body-parser';
@@ -48,7 +48,7 @@ import { RbacSeeder } from '../../seed';
 
 describe('GEWIS Helper functions', async (): Promise<void> => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     users: User[],
     spec: SwaggerSpecification,

--- a/test/unit/mailer/mailer.ts
+++ b/test/unit/mailer/mailer.ts
@@ -21,7 +21,7 @@
 import { expect } from 'chai';
 import sinon, { SinonSandbox, SinonStub } from 'sinon';
 import nodemailer, { Transporter } from 'nodemailer';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import Mailer from '../../../src/mailer';
 import User, { UserType } from '../../../src/entity/user/user';
 import Database from '../../../src/database/database';
@@ -34,7 +34,7 @@ import { templateFieldDefault } from '../../../src/mailer/mail-body-generator';
 
 describe('Mailer', () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     mailer?: Mailer,
     user: User,
     htmlMailTemplate: string,

--- a/test/unit/middleware/restriction-middleware.ts
+++ b/test/unit/middleware/restriction-middleware.ts
@@ -19,7 +19,7 @@
  */
 
 import express, { Application, Response } from 'express';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { expect, request } from 'chai';
 import RestrictionMiddleware from '../../../src/middleware/restriction-middleware';
 import Database from '../../../src/database/database';
@@ -34,7 +34,7 @@ import sinon from 'sinon';
 
 describe('RestrictionMiddleware', (): void => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     middleware: RestrictionMiddleware,
     tokenHandler: TokenHandler,

--- a/test/unit/service/ad-service.ts
+++ b/test/unit/service/ad-service.ts
@@ -152,7 +152,7 @@ describe('AD Service', (): void => {
       stubs.push(clientSearchStub);
 
       const organCount = await User.count({ where: { type: UserType.ORGAN } });
-      await ADService.syncSharedAccounts();
+      await new ADService().syncSharedAccounts();
 
       expect(await User.count({ where: { type: UserType.ORGAN } })).to.be.equal(organCount + 1);
       const newOrgan = (await LDAPAuthenticator.findOne({ where: { UUID: newADSharedAccount.objectGUID }, relations: ['user'] })).user;
@@ -208,7 +208,7 @@ describe('AD Service', (): void => {
       stubs.push(clientBindStub);
       stubs.push(clientSearchStub);
 
-      await ADService.syncSharedAccounts();
+      await new ADService().syncSharedAccounts();
 
       const newOrgan = (await LDAPAuthenticator.findOne({ where: { UUID: newADSharedAccount.objectGUID }, relations: ['user'] })).user;
 
@@ -264,7 +264,7 @@ describe('AD Service', (): void => {
       stubs.push(clientBindStub);
       stubs.push(clientSearchStub);
 
-      await ADService.syncSharedAccounts();
+      await new ADService().syncSharedAccounts();
 
       // Should contain the first users
       const newOrgan = (await LDAPAuthenticator.findOne({ where: { UUID: newADSharedAccount.objectGUID }, relations: ['user'] })).user;
@@ -299,7 +299,7 @@ describe('AD Service', (): void => {
       stubs.push(clientBindStub2);
       stubs.push(clientSearchStub2);
 
-      await ADService.syncSharedAccounts();
+      await new ADService().syncSharedAccounts();
 
       canAuthenticateAsIDs = (await MemberAuthenticator.find(
         { where: { authenticateAs: { id: newOrgan.id } }, relations: ['user'] },
@@ -318,7 +318,7 @@ describe('AD Service', (): void => {
       )).to.be.null;
 
       const userCount = await User.count();
-      await ADService.createAccountIfNew([adUser]);
+      await new ADService().createAccountIfNew([adUser]);
 
       expect(await User.count()).to.be.equal(userCount + 1);
       const auth = (await LDAPAuthenticator.findOne(
@@ -336,7 +336,7 @@ describe('AD Service', (): void => {
       const newUser = { ...(ctx.validADUser(await User.count() + 2)) };
       const existingUser = { ...(ctx.validADUser(await User.count() + 3)) };
 
-      await ADService.createAccountIfNew([existingUser]);
+      await new ADService().createAccountIfNew([existingUser]);
       // precondition.
       expect(await LDAPAuthenticator.findOne(
         { where: { UUID: newUser.objectGUID } },
@@ -377,7 +377,7 @@ describe('AD Service', (): void => {
 
       const roleManager = await new RoleManager().initialize();
 
-      await ADService.syncUserRoles(roleManager);
+      await new ADService().syncUserRoles(roleManager);
       const auth = (await LDAPAuthenticator.findOne(
         { where: { UUID: newUser.objectGUID }, relations: ['user'] },
       ));
@@ -385,7 +385,7 @@ describe('AD Service', (): void => {
       const { user } = auth;
       userIsAsExpected(user, newUser);
 
-      const users = await ADService.getUsers([newUser as LDAPUser, existingUser as LDAPUser]);
+      const users = await new ADService().getUsers([newUser as LDAPUser, existingUser as LDAPUser]);
       expect(await AssignedRole.findOne({ where: { role: { name: 'SudoSOS - Test' }, user: { id: users[0].id } } })).to.exist;
       expect(await AssignedRole.findOne({ where: { role: { name: 'SudoSOS - Test' }, user: { id: users[1].id } } })).to.exist;
     });
@@ -406,7 +406,7 @@ describe('AD Service', (): void => {
       stubs.push(clientBindStub);
       stubs.push(clientSearchStub);
 
-      await ADService.syncUsers();
+      await new ADService().syncUsers();
       const auth = (await LDAPAuthenticator.findOne(
         { where: { UUID: newUser.objectGUID }, relations: ['user'] },
       ));

--- a/test/unit/service/ad-service.ts
+++ b/test/unit/service/ad-service.ts
@@ -31,7 +31,6 @@ import Swagger from '../../../src/start/swagger';
 import ADService from '../../../src/service/ad-service';
 import LDAPAuthenticator from '../../../src/entity/authenticator/ldap-authenticator';
 import AuthenticationService from '../../../src/service/authentication-service';
-import wrapInManager from '../../../src/helpers/database';
 import MemberAuthenticator from '../../../src/entity/authenticator/member-authenticator';
 import { LDAPGroup, LDAPUser } from '../../../src/helpers/ad';
 import userIsAsExpected from './authentication-service';
@@ -127,7 +126,11 @@ describe('AD Service', (): void => {
         return users;
       }
 
-      return Promise.resolve(wrapInManager(createAccounts)(accounts));
+      let result: any[];
+      await ctx.connection.transaction(async (manager) => {
+        result = await createAccounts(manager, accounts);
+      });
+      return result;
     }
     it('should create an account for new shared accounts', async () => {
       const newADSharedAccount = {

--- a/test/unit/service/ad-service.ts
+++ b/test/unit/service/ad-service.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection, EntityManager } from 'typeorm';
+import { DataSource, EntityManager } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import sinon from 'sinon';
@@ -45,7 +45,7 @@ chai.use(deepEqualInAnyOrder);
 
 describe('AD Service', (): void => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     users: User[],
     spec: SwaggerSpecification,

--- a/test/unit/service/authentication-service.ts
+++ b/test/unit/service/authentication-service.ts
@@ -26,7 +26,7 @@ import sinon from 'sinon';
 import { Client } from 'ldapts';
 import User, { UserType } from '../../../src/entity/user/user';
 import Database from '../../../src/database/database';
-import seedDatabase from '../../seed';
+import seedDatabase from '../../seed/all';
 import Swagger from '../../../src/start/swagger';
 import AuthenticationService from '../../../src/service/authentication-service';
 import { inUserContext, UserFactory } from '../../helpers/user-factory';

--- a/test/unit/service/authentication-service.ts
+++ b/test/unit/service/authentication-service.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import { expect } from 'chai';
@@ -51,7 +51,7 @@ export default function userIsAsExpected(user: User | UserResponse, ADResponse: 
 
 describe('AuthenticationService', (): void => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     users: User[],
     spec: SwaggerSpecification,

--- a/test/unit/service/balance-service.ts
+++ b/test/unit/service/balance-service.ts
@@ -19,7 +19,7 @@
  */
 
 import { expect } from 'chai';
-import { Connection, DeepPartial } from 'typeorm';
+import { DataSource, DeepPartial } from 'typeorm';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import Transaction from '../../../src/entity/transactions/transaction';
 import Transfer from '../../../src/entity/transactions/transfer';
@@ -45,7 +45,7 @@ import { FineSeeder, PointOfSaleSeeder, TransactionSeeder, TransferSeeder, UserS
 
 describe('BalanceService', (): void => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     users: User[],
     pointOfSaleRevisions: PointOfSaleRevision[],
     transactions: Transaction[],

--- a/test/unit/service/container-service.ts
+++ b/test/unit/service/container-service.ts
@@ -19,7 +19,7 @@
  */
 
 import {
-  Connection, getManager, IsNull, Not,
+  DataSource, getManager, IsNull, Not,
 } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
@@ -95,7 +95,7 @@ chai.use(deepEqualInAnyOrder);
 
 describe('ContainerService', async (): Promise<void> => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     users: User[],

--- a/test/unit/service/container-service.ts
+++ b/test/unit/service/container-service.ts
@@ -19,7 +19,7 @@
  */
 
 import {
-  DataSource, getManager, IsNull, Not,
+  DataSource, IsNull, Not,
 } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
@@ -255,9 +255,7 @@ describe('ContainerService', async (): Promise<void> => {
         expect(cont.owner.id).to.equal(owner2.id);
       });
 
-      await AuthenticationService.setMemberAuthenticator(
-        getManager(), [owner1], owner2,
-      );
+      await new AuthenticationService().setMemberAuthenticator([owner1], owner2);
 
       const ownerIds = [owner1, owner2].map((o) => o.id);
       containers = await ContainerService.getContainers({}, {}, owner1);

--- a/test/unit/service/debtor-service.ts
+++ b/test/unit/service/debtor-service.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import User, { TermsOfServiceStatus, UserType } from '../../../src/entity/user/user';
 import Database from '../../../src/database/database';
 import Transaction from '../../../src/entity/transactions/transaction';
@@ -44,7 +44,7 @@ import { FineSeeder, TransactionSeeder, TransferSeeder, UserSeeder } from '../..
 
 describe('DebtorService', (): void => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     users: User[],
     transactions: Transaction[],
     subTransactions: SubTransaction[],

--- a/test/unit/service/event-service.ts
+++ b/test/unit/service/event-service.ts
@@ -19,7 +19,7 @@
  */
 
 import { describe } from 'mocha';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import User from '../../../src/entity/user/user';
 import Event, { EventType } from '../../../src/entity/event/event';
 import EventShift from '../../../src/entity/event/event-shift';
@@ -39,7 +39,7 @@ import { EventSeeder, UserSeeder } from '../../seed';
 
 describe('eventService', () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     users: User[],
     events: Event[],
     eventShifts: EventShift[],

--- a/test/unit/service/file-service.ts
+++ b/test/unit/service/file-service.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { expect, assert } from 'chai';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
@@ -41,7 +41,7 @@ import { ProductSeeder, UserSeeder } from '../../seed';
 
 describe('FileService', async (): Promise<void> => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     users: User[],

--- a/test/unit/service/invoice-pdf-service.ts
+++ b/test/unit/service/invoice-pdf-service.ts
@@ -24,7 +24,7 @@ import sinon, { SinonStub } from 'sinon';
 import Invoice from '../../../src/entity/invoices/invoice';
 import chai, { expect } from 'chai';
 import InvoicePdf from '../../../src/entity/file/invoice-pdf';
-import { Connection, IsNull } from 'typeorm';
+import { DataSource, IsNull } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import User from '../../../src/entity/user/user';
@@ -47,7 +47,7 @@ chai.use(deepEqualInAnyOrder);
 
 describe('InvoicePdfService', async (): Promise<void> => {
   let ctx: {
-    connection: Connection;
+    connection: DataSource;
     app: Application;
     specification: SwaggerSpecification;
     users: User[];

--- a/test/unit/service/invoice-service.ts
+++ b/test/unit/service/invoice-service.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection, In } from 'typeorm';
+import { DataSource, In } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import { json } from 'body-parser';
@@ -100,7 +100,7 @@ createInvoiceWithTransfers(debtorId: number, creditorId: number,
 
 describe('InvoiceService', () => {
   let ctx: {
-    connection: Connection;
+    connection: DataSource;
     app: Application;
     specification: SwaggerSpecification;
     users: User[];

--- a/test/unit/service/payout-request-pdf-service.ts
+++ b/test/unit/service/payout-request-pdf-service.ts
@@ -21,7 +21,7 @@
 import { Client } from 'pdf-generator-client';
 import sinon, { SinonStub } from 'sinon';
 import chai, { expect } from 'chai';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import User from '../../../src/entity/user/user';
@@ -41,7 +41,7 @@ import { PayoutRequestSeeder, UserSeeder } from '../../seed';
 chai.use(deepEqualInAnyOrder);
 describe('PayoutRequestPdfService', async () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     users: User[],

--- a/test/unit/service/payout-request-service.ts
+++ b/test/unit/service/payout-request-service.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { expect } from 'chai';
 import User from '../../../src/entity/user/user';
 import PayoutRequest from '../../../src/entity/transactions/payout/payout-request';
@@ -34,7 +34,7 @@ import { PayoutRequestSeeder, UserSeeder } from '../../seed';
 
 describe('PayoutRequestService', () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     users: User[],
     payoutRequests: PayoutRequest[],
     dineroTransformer: DineroTransformer,

--- a/test/unit/service/point-of-sale-service.ts
+++ b/test/unit/service/point-of-sale-service.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { DataSource, getManager, IsNull, Not } from 'typeorm';
+import { DataSource, IsNull, Not } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import { json } from 'body-parser';
@@ -233,7 +233,7 @@ describe('PointOfSaleService', async (): Promise<void> => {
         expect(pos.owner.id).to.equal(owner.id);
       });
 
-      await AuthenticationService.setMemberAuthenticator(getManager(), [owner], usersOwningAPos[1]);
+      await new AuthenticationService().setMemberAuthenticator([owner], usersOwningAPos[1]);
 
       const ownerIds = [owner, usersOwningAPos[1]].map((o) => o.id);
       pointsOfSale = await PointOfSaleService.getPointsOfSale({}, {}, owner);

--- a/test/unit/service/point-of-sale-service.ts
+++ b/test/unit/service/point-of-sale-service.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection, getManager, IsNull, Not } from 'typeorm';
+import { DataSource, getManager, IsNull, Not } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import { json } from 'body-parser';
@@ -80,7 +80,7 @@ function updateResponseEqual(update: UpdatePointOfSaleParams,
 
 describe('PointOfSaleService', async (): Promise<void> => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     users: User[],

--- a/test/unit/service/product-service.ts
+++ b/test/unit/service/product-service.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection, getManager, IsNull, Not } from 'typeorm';
+import { DataSource, getManager, IsNull, Not } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import bodyParser from 'body-parser';
@@ -125,7 +125,7 @@ function validateProductProperties(response: ProductResponse, productParams: Cre
 
 describe('ProductService', async (): Promise<void> => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     users: User[],

--- a/test/unit/service/product-service.ts
+++ b/test/unit/service/product-service.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { DataSource, getManager, IsNull, Not } from 'typeorm';
+import { DataSource, IsNull, Not } from 'typeorm';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import bodyParser from 'body-parser';
@@ -298,8 +298,7 @@ describe('ProductService', async (): Promise<void> => {
         expect(prod.owner.id).to.equal(owner.id);
       });
 
-      await AuthenticationService
-        .setMemberAuthenticator(getManager(), [owner], usersOwningAProd[1]);
+      await new AuthenticationService().setMemberAuthenticator([owner], usersOwningAProd[1]);
 
       const ownerIds = [owner, usersOwningAProd[1]].map((o) => o.id);
       products = await ProductService.getProducts({}, {}, owner);

--- a/test/unit/service/stripe-service.ts
+++ b/test/unit/service/stripe-service.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { expect } from 'chai';
 import Stripe from 'stripe';
 import User from '../../../src/entity/user/user';
@@ -37,7 +37,7 @@ describe('StripeService', async (): Promise<void> => {
   let shouldSkip: boolean;
 
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     users: User[],
     stripeDeposits: StripeDeposit[],
     stripeService: StripeService,

--- a/test/unit/service/transaction-service.ts
+++ b/test/unit/service/transaction-service.ts
@@ -20,13 +20,13 @@
 
 import express, { Application } from 'express';
 import chai, { expect } from 'chai';
-import { DataSource, createQueryBuilder } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import log4js, { Logger } from 'log4js';
 import dinero from 'dinero.js';
 import deepEqualInAnyOrder from 'deep-equal-in-any-order';
 import Transaction from '../../../src/entity/transactions/transaction';
-import Database from '../../../src/database/database';
+import Database, { AppDataSource } from '../../../src/database/database';
 import TransactionService, { TransactionFilterParameters } from '../../../src/service/transaction-service';
 import { verifyBaseTransactionEntity } from '../validators';
 import Swagger from '../../../src/start/swagger';
@@ -693,7 +693,7 @@ describe('TransactionService', (): void => {
       const user = ctx.users[0];
       const { records } = await new TransactionService().getTransactions({}, {}, user);
 
-      const actualTransactions = await createQueryBuilder(Transaction, 'transaction')
+      const actualTransactions = await AppDataSource.createQueryBuilder(Transaction, 'transaction')
         .leftJoinAndSelect('transaction.from', 'from')
         .leftJoinAndSelect('transaction.createdBy', 'createdBy')
         .leftJoinAndSelect('transaction.pointOfSale', 'pointOfSaleRev')

--- a/test/unit/service/transaction-service.ts
+++ b/test/unit/service/transaction-service.ts
@@ -20,7 +20,7 @@
 
 import express, { Application } from 'express';
 import chai, { expect } from 'chai';
-import { Connection, createQueryBuilder } from 'typeorm';
+import { DataSource, createQueryBuilder } from 'typeorm';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import log4js, { Logger } from 'log4js';
 import dinero from 'dinero.js';
@@ -53,7 +53,7 @@ chai.use(deepEqualInAnyOrder);
 
 describe('TransactionService', (): void => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     transactions: Transaction[],
     users: User[],

--- a/test/unit/service/transfer-service.ts
+++ b/test/unit/service/transfer-service.ts
@@ -23,7 +23,7 @@ import bodyParser from 'body-parser';
 import { expect } from 'chai';
 import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import TransferRequest from '../../../src/controller/request/transfer-request';
 import { PaginatedTransferResponse } from '../../../src/controller/response/transfer-response';
 import Database from '../../../src/database/database';
@@ -46,7 +46,7 @@ import {
 
 describe('TransferService', async (): Promise<void> => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     app: Application,
     specification: SwaggerSpecification,
     users: User[],

--- a/test/unit/service/vat-group-service.ts
+++ b/test/unit/service/vat-group-service.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { expect } from 'chai';
 import VatGroup, { VatDeclarationPeriod } from '../../../src/entity/vat-group';
 import User from '../../../src/entity/user/user';
@@ -40,7 +40,7 @@ import {
 
 describe('VatGroupService', () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     users: User[],
     vatGroups: VatGroup[],
     transactions: Transaction[],

--- a/test/unit/service/voucher-group-service.ts
+++ b/test/unit/service/voucher-group-service.ts
@@ -20,7 +20,7 @@
 
 import { expect } from 'chai';
 import Sinon from 'sinon';
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { VoucherGroupParams, VoucherGroupRequest } from '../../../src/controller/request/voucher-group-request';
 import VoucherGroupResponse from '../../../src/controller/response/voucher-group-response';
 import Database from '../../../src/database/database';
@@ -65,7 +65,7 @@ export async function seedVoucherGroups(): Promise<{ paramss: VoucherGroupParams
 
 describe('VoucherGroupService', async (): Promise<void> => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     clock: Sinon.SinonFakeTimers
   };
 

--- a/test/unit/subscribe/transaction-subscriber.ts
+++ b/test/unit/subscribe/transaction-subscriber.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import User, { NotifyDebtUserTypes, TermsOfServiceStatus, UserType } from '../../../src/entity/user/user';
 import Transaction from '../../../src/entity/transactions/transaction';
 import SubTransaction from '../../../src/entity/transactions/sub-transaction';
@@ -47,7 +47,7 @@ import {
 
 describe('TransactionSubscriber', () => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     adminUser: User,
     users: User[],
     usersNotInDebt: User[],

--- a/test/unit/subscribe/transfer-subscriber.ts
+++ b/test/unit/subscribe/transfer-subscriber.ts
@@ -18,7 +18,7 @@
  *  @license
  */
 
-import { Connection } from 'typeorm';
+import { DataSource } from 'typeorm';
 import User from '../../../src/entity/user/user';
 import Transaction from '../../../src/entity/transactions/transaction';
 import Transfer from '../../../src/entity/transactions/transfer';
@@ -37,7 +37,7 @@ import { TransactionSeeder, TransferSeeder, UserSeeder } from '../../seed';
 
 describe('TransferSubscriber', (): void => {
   let ctx: {
-    connection: Connection,
+    connection: DataSource,
     users: User[],
     usersInDebt: User[],
     transactions: Transaction[],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Replaces all deprecated TypeORM functions with their `DataSource`-method counterparts. The only deprecated function still in use is `createConnection`, so a default connection is still created. If we are sure nothing is broken, we can delete this final reference in a new PR.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Fixes https://github.com/GEWIS/sudosos-backend/issues/304.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Style _(Change that do not affect the functionality of the code)_