### PR TITLE
chore(tests): globally mock mailer SMTP connection

### DIFF
--- a/test/root-hooks.ts
+++ b/test/root-hooks.ts
@@ -14,7 +14,10 @@
  *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
  */
+
 import * as mocha from 'mocha';
 import sinon from 'sinon';
 import nodemailer, { Transporter } from 'nodemailer';

--- a/test/root-hooks.ts
+++ b/test/root-hooks.ts
@@ -1,0 +1,46 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import * as mocha from 'mocha';
+import sinon from 'sinon';
+import nodemailer, { Transporter } from 'nodemailer';
+
+/**
+ * Object containing all global stubs that are set before each test case.
+ * Note that these stubs are reinitialized before each test case.
+ * Therefore, if you wish to restore these stubs to create your own,
+ * ensure that you restore them before each test case.
+ */
+export let rootStubs: {
+  /**
+   * Mail stub, which mocks a new SMTP connection.
+   */
+  mail: sinon.SinonStub;
+} | undefined;
+
+export const mochaHooks: mocha.RootHookObject = {
+  beforeEach: () => {
+    const sendMailFake = sinon.spy();
+    const mail = sinon.stub(nodemailer, 'createTransport').returns({
+      sendMail: sendMailFake,
+    } as any as Transporter);
+    rootStubs = { mail };
+  },
+  afterEach: () => {
+    rootStubs?.mail.restore();
+  },
+};

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -35,6 +35,9 @@ import { DataSource } from 'typeorm';
 import { PERSISTENT_TEST_DATABASES } from '../src/helpers/database';
 import '../src/database/database';
 
+// Root hooks
+export { mochaHooks } from './root-hooks';
+
 use(chaiAsPromised);
 use(chaiHttp);
 use(chaiSwag);

--- a/test/unit/controller/debtor-controller.ts
+++ b/test/unit/controller/debtor-controller.ts
@@ -51,6 +51,7 @@ import { finishTestDB } from '../../helpers/test-helpers';
 import { Client } from 'pdf-generator-client';
 import { BasePdfService } from '../../../src/service/pdf/pdf-service';
 import { FineSeeder, RbacSeeder, TransactionSeeder, TransferSeeder, UserSeeder } from '../../seed';
+import { rootStubs } from '../../root-hooks';
 
 describe('DebtorController', () => {
   let ctx: {
@@ -156,7 +157,13 @@ describe('DebtorController', () => {
       fines,
       fineHandoutEvents,
     };
+  });
 
+  beforeEach(() => {
+    // Restore the default stub
+    rootStubs?.mail.restore();
+
+    // Reset the mailer, because it was created with an old, expired stub
     Mailer.reset();
 
     sandbox = sinon.createSandbox();
@@ -169,11 +176,10 @@ describe('DebtorController', () => {
   // close database connection
   after( async () => {
     await finishTestDB(ctx.connection);
-    sandbox.restore();
   });
 
   afterEach(() => {
-    sendMailFake.resetHistory();
+    sandbox.restore();
   });
 
   describe('GET /fines', () => {

--- a/test/unit/gewis/gewisdb.ts
+++ b/test/unit/gewis/gewisdb.ts
@@ -30,6 +30,7 @@ import nodemailer, { Transporter } from 'nodemailer';
 import Mailer from '../../../src/mailer';
 import { In } from 'typeorm';
 import { UserSeeder } from '../../seed';
+import { rootStubs } from '../../root-hooks';
 
 describe('GEWISDB Service', () => {
 
@@ -50,7 +51,13 @@ describe('GEWISDB Service', () => {
     } as any;
     ctx.users = await new UserSeeder().seed();
     ctx.gewisUsers = await seedGEWISUsers(ctx.users);
+  });
 
+  beforeEach(() => {
+    // Restore the default stub
+    rootStubs?.mail.restore();
+
+    // Reset the mailer, because it was created with an old, expired stub
     Mailer.reset();
 
     sandbox = sinon.createSandbox();
@@ -62,12 +69,11 @@ describe('GEWISDB Service', () => {
 
   after(async () => {
     await finishTestDB(ctx.connection);
-    sinon.restore();
-    sandbox.restore();
   });
 
   afterEach(() => {
-    sendMailFake.resetHistory();
+    sandbox.restore();
+    sinon.restore();
   });
 
   describe('sync', () => {

--- a/test/unit/service/event-service.ts
+++ b/test/unit/service/event-service.ts
@@ -36,6 +36,7 @@ import { truncateAllTables } from '../../setup';
 import { finishTestDB } from '../../helpers/test-helpers';
 import Role from '../../../src/entity/rbac/role';
 import { EventSeeder, UserSeeder } from '../../seed';
+import { rootStubs } from '../../root-hooks';
 
 describe('eventService', () => {
   let ctx: {
@@ -234,7 +235,11 @@ describe('eventService', () => {
     let sandbox: SinonSandbox;
     let sendMailFake: SinonSpy;
 
-    before(() => {
+    beforeEach(() => {
+      // Restore the default stub
+      rootStubs?.mail.restore();
+
+      // Reset the mailer, because it was created with an old, expired stub
       Mailer.reset();
 
       sandbox = sinon.createSandbox();
@@ -244,12 +249,8 @@ describe('eventService', () => {
       } as any as Transporter);
     });
 
-    after(() => {
-      sandbox.restore();
-    });
-
     afterEach(() => {
-      sendMailFake.resetHistory();
+      sandbox.restore();
     });
 
     it('should send a reminder to all users that have not given up their availability', async () => {

--- a/test/unit/subscribe/transaction-subscriber.ts
+++ b/test/unit/subscribe/transaction-subscriber.ts
@@ -44,6 +44,7 @@ import {
   TransferSeeder,
   UserSeeder,
 } from '../../seed';
+import { rootStubs } from '../../root-hooks';
 
 describe('TransactionSubscriber', () => {
   let ctx: {
@@ -101,6 +102,18 @@ describe('TransactionSubscriber', () => {
       transfers,
     };
 
+    env = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'test-transactions';
+
+    // Sanity check
+    expect(ctx.usersInDebt.length).to.be.at.least(3);
+  });
+
+  beforeEach(() => {
+    // Restore the default stub
+    rootStubs?.mail.restore();
+
+    // Reset the mailer, because it was created with an old, expired stub
     Mailer.reset();
 
     sandbox = sinon.createSandbox();
@@ -108,12 +121,6 @@ describe('TransactionSubscriber', () => {
     sandbox.stub(nodemailer, 'createTransport').returns({
       sendMail: sendMailFake,
     } as any as Transporter);
-
-    env = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'test-transactions';
-
-    // Sanity check
-    expect(ctx.usersInDebt.length).to.be.at.least(3);
   });
 
   after(async () => {
@@ -124,7 +131,7 @@ describe('TransactionSubscriber', () => {
   });
 
   afterEach(() => {
-    sendMailFake.resetHistory();
+    sandbox.restore();
   });
 
   describe('afterInsert', () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds mocha root hooks to the test suite. Right now, the only root hook is one to stub `nodemailer.createTransport`, which prevents all the "SMTP connection refused" error messages during the tests. But more importantly, if a SMTP server is configured in the environment variables, no connection shall actually be made.

The root hooks are implemented in such a way that more stubs can be added in the future.

When you want to use your own stub instead of a root stub, you have to manually restore these stubs **before running each test case**. Examples can be found in the existing test cases. Due to limitations of Mocha, it is not possible to run these hooks before every suite (either once before all tests, or once for each test case).

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Style _(Change that do not affect the functionality of the code)_