### PR TITLE
fix: dates not being used in fine report

### DIFF
--- a/test/unit/service/debtor-service.ts
+++ b/test/unit/service/debtor-service.ts
@@ -619,7 +619,6 @@ describe('DebtorService', (): void => {
       const endDate = new Date();
       endDate.setTime(endDate.getTime() + 1000);
       const report = await DebtorService.getFineReport(fromDate, endDate);
-      console.error(fineHandoutEvent);
 
       expect(report.fromDate.toISOString()).to.equal(fromDate.toISOString());
       expect(report.toDate.toISOString()).to.equal(endDate.toISOString());


### PR DESCRIPTION
# Description
Fine reports were always across the full existence of SudoSOS.

## Related issues/external references

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
