### PR TITLE
fix: handle ObjectGUID as Buffer correctly

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -97,6 +97,7 @@ import SellerPayoutPdf from '../entity/file/seller-payout-pdf';
 import { UserTypeEnums1725196803203 } from '../migrations/1725196803203-user-type-enums';
 import { CustomInvoiceEntries1725388477226 } from '../migrations/1725388477226-custom-invoice-entries';
 import { SellerPayoutPdf1726066600389 } from '../migrations/1726066600389-seller-payout-pdf';
+import { LDAPObjectGUID1726689003147 } from '../migrations/1726689003147-ldap-objectguid';
 
 // We need to load the dotenv to prevent the env from being undefined.
 dotenv.config();
@@ -132,6 +133,7 @@ const options: DataSourceOptions = {
     UserTypeEnums1725196803203,
     CustomInvoiceEntries1725388477226,
     SellerPayoutPdf1726066600389,
+    LDAPObjectGUID1726689003147,
   ],
   extra: {
     authPlugins: {

--- a/src/entity/authenticator/ldap-authenticator.ts
+++ b/src/entity/authenticator/ldap-authenticator.ts
@@ -23,6 +23,17 @@ import {
 } from 'typeorm';
 import AuthenticationMethod from './authentication-method';
 
+const bufferTransformer = {
+  to: (buffer: Buffer): string => {
+    // Convert Buffer to hex string when saving to DB
+    return buffer.toString('hex');
+  },
+  from: (hex: string): Buffer => {
+    // Convert hex string back to Buffer when retrieving from DB
+    return Buffer.from(hex, 'hex');
+  },
+};
+
 /**
  * @typedef {AuthenticationMethod} LDAPAuthenticator
  * @property {string} accountName.required - The associated AD account name
@@ -30,7 +41,9 @@ import AuthenticationMethod from './authentication-method';
 @Entity()
 export default class LDAPAuthenticator extends AuthenticationMethod {
   @Column({
+    type: 'varchar',
     length: 32,
+    transformer: bufferTransformer,
   })
-  public UUID: string;
+  public UUID: Buffer;
 }

--- a/src/helpers/ad.ts
+++ b/src/helpers/ad.ts
@@ -68,12 +68,10 @@ export interface LDAPUser {
  */
 export async function bindUser(manager: EntityManager,
   ADUser: { objectGUID: Buffer }, user: User): Promise<LDAPAuthenticator> {
-  const auth = manager.create(LDAPAuthenticator, {
+  return manager.save(LDAPAuthenticator, {
     user: user,
     UUID: ADUser.objectGUID,
   });
-  await manager.save(auth);
-  return auth;
 }
 
 /**

--- a/src/helpers/ad.ts
+++ b/src/helpers/ad.ts
@@ -38,7 +38,7 @@ export function getLDAPSettings() {
 }
 
 export interface LDAPResponse {
-  objectGUID: string,
+  objectGUID: Buffer,
   whenChanged: string,
 }
 
@@ -54,7 +54,7 @@ export interface LDAPUser {
   memberOfFlattened: string[],
   givenName: string,
   sn: string,
-  objectGUID: string,
+  objectGUID: Buffer,
   mail: string,
   mNumber: number | undefined;
 }
@@ -67,11 +67,11 @@ export interface LDAPUser {
  * @param user - The User to bind to.
  */
 export async function bindUser(manager: EntityManager,
-  ADUser: { objectGUID: string }, user: User): Promise<LDAPAuthenticator> {
-  const auth = Object.assign(new LDAPAuthenticator(), {
-    user,
+  ADUser: { objectGUID: Buffer }, user: User): Promise<LDAPAuthenticator> {
+  const auth = manager.create(LDAPAuthenticator, {
+    user: user,
     UUID: ADUser.objectGUID,
-  }) as LDAPAuthenticator;
+  });
   await manager.save(auth);
   return auth;
 }
@@ -100,11 +100,22 @@ export async function getLDAPConnection(): Promise<Client> {
   return client;
 }
 
+export interface LDAPResult {
+  dn: string,
+  whenChanged: string,
+  memberOfFlattened: string[],
+  givenName: string,
+  sn: string,
+  objectGUID: Buffer,
+  mail: string,
+  employeeNumber: number | undefined;
+}
+
 /**
  * Wrapper for typing the untyped ldap result.
  * @param ldapResult - Search result to type
  */
-export function userFromLDAP(ldapResult: any): LDAPUser {
+export function userFromLDAP(ldapResult: LDAPResult): LDAPUser {
   const {
     dn, memberOfFlattened, givenName, sn,
     objectGUID, mail, employeeNumber, whenChanged,

--- a/src/migrations/1726689003147-ldap-objectguid.ts
+++ b/src/migrations/1726689003147-ldap-objectguid.ts
@@ -1,0 +1,116 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+import { In, MigrationInterface, Not, QueryRunner } from 'typeorm';
+import { getLDAPConnection, LDAPResult } from '../helpers/ad';
+import ADService from '../service/ad-service';
+import LDAPAuthenticator from '../entity/authenticator/ldap-authenticator';
+import { UserType } from '../entity/user/user';
+
+export class LDAPObjectGUID1726689003147 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Check if ENV vars are set
+    if (!process.env.LDAP_BASE || !process.env.LDAP_USER_BASE || !process.env.LDAP_SHARED_ACCOUNT_FILTER) {
+      console.log('LDAP_BASE, LDAP_USER_BASE, LDAP_SHARED_ACCOUNT_FILTER must be for the migration to work, skipping.');
+      return;
+    }
+
+    // Get LDAP connection
+    const client = await getLDAPConnection();
+    const adService = new ADService();
+
+    const oldUsers = await client.search(process.env.LDAP_BASE, {
+      filter: `(&(objectClass=user)(objectCategory=person)(memberOf:1.2.840.113556.1.4.1941:=${process.env.LDAP_USER_BASE}))`,
+    });
+
+    const oldOrgans = await client.search(process.env.LDAP_SHARED_ACCOUNT_FILTER, {
+      filter: '(CN=*)',
+    });
+
+    const oldGUIDs = [...oldUsers.searchEntries, ...oldOrgans.searchEntries].map((entry: any) => ({
+      dn: entry.dn,
+      objectGUID: entry.objectGUID,
+    }));
+
+    // Create a map of cn to old objectGUID
+    const oldGUIDMap = new Map(oldGUIDs.map(({ dn, objectGUID }) => [dn, objectGUID]));
+
+    // Fetch new LDAP users to get new objectGUIDs
+    const newUsers = await adService.getLDAPGroupMembers(client, process.env.LDAP_USER_BASE);
+
+    const newOrgans = await adService.getLDAPGroups<LDAPResult>(client, process.env.LDAP_SHARED_ACCOUNT_FILTER);
+
+    const newGUIDs = [...newUsers.searchEntries, ...newOrgans].map((entry: any) => ({
+      dn: entry.dn,
+      objectGUID: entry.objectGUID,
+    }));
+
+    // Create a map of cn to new objectGUID
+    const newGUIDMap = new Map(newGUIDs.map(({ dn, objectGUID }) => [dn, objectGUID]));
+
+    const membersToFix = new Set<number>();
+    await queryRunner.manager.find(LDAPAuthenticator, { where: { user: { type: UserType.MEMBER } } }).then((auths) => {
+      auths.forEach((auth) => {
+        membersToFix.add(auth.userId);
+      });
+    });
+
+    const otherToFix = new Set<number>();
+    await queryRunner.manager.find(LDAPAuthenticator, { where: { user: { type: Not(UserType.MEMBER) } } }).then((auths) => {
+      auths.forEach((auth) => {
+        otherToFix.add(auth.userId);
+      });
+    });
+
+
+    for (const [dn, objectGUID] of oldGUIDMap) {
+      console.info(`Checking ${dn}`);
+      const auth = await queryRunner.manager.findOne(LDAPAuthenticator, {
+        where: { UUID: objectGUID },
+      });
+      if (!auth) throw new Error(`Could not find LDAPAuthenticator for ${dn}`);
+      const newObjectGUID = newGUIDMap.get(dn);
+      if (!newObjectGUID) throw new Error(`Could not find new objectGUID for ${dn}`);
+
+      console.error(auth.UUID, newObjectGUID);
+      membersToFix.delete(auth.userId);
+      otherToFix.delete(auth.userId);
+    }
+
+    if (membersToFix.size > 0) {
+      // These AD accounts have been unlinked and can be removed
+      const ids = Array.from(membersToFix.values());
+      console.error('Removing old LDAPAuthenticators:', ids);
+      await queryRunner.manager.delete(LDAPAuthenticator, { userId: In(ids) });
+    }
+
+    if (otherToFix.size > 0) {
+      console.error('Others to fix:', otherToFix);
+      throw new Error('Not all users have been fixed');
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // no-op
+  }
+
+}

--- a/src/service/authentication-service.ts
+++ b/src/service/authentication-service.ts
@@ -32,7 +32,7 @@ import RoleManager from '../rbac/role-manager';
 import LDAPAuthenticator from '../entity/authenticator/ldap-authenticator';
 import MemberAuthenticator from '../entity/authenticator/member-authenticator';
 import {
-  bindUser, getLDAPConnection, getLDAPSettings, LDAPUser, userFromLDAP,
+  bindUser, getLDAPConnection, getLDAPSettings, LDAPResult, LDAPUser, userFromLDAP,
 } from '../helpers/ad';
 import { parseUserToResponse } from '../helpers/revision-to-response';
 import HashBasedAuthenticationMethod from '../entity/authenticator/hash-based-authentication-method';
@@ -268,9 +268,10 @@ export default class AuthenticationService extends WithManager {
       const { searchEntries } = await client.search(ldapSettings.base, {
         scope: 'sub',
         filter: filterstr,
+        explicitBufferAttributes: ['objectGUID'],
       });
       if (searchEntries[0]) {
-        ADUser = userFromLDAP(searchEntries[0]);
+        ADUser = userFromLDAP(searchEntries[0] as any as LDAPResult);
       } else {
         logger.trace(`User ${uid} not found in DB`);
         return undefined;

--- a/test/unit/controller/authentication-controller.ts
+++ b/test/unit/controller/authentication-controller.ts
@@ -377,7 +377,7 @@ describe('AuthenticationController', async (): Promise<void> => {
       ],
       givenName: 'Sudo',
       sn: 'SOS',
-      objectGUID: '1',
+      objectGUID: Buffer.from('11', 'hex'),
       sAMAccountName: 'm4141',
       mail: 'm4141@gewis.nl',
     };

--- a/test/unit/gewis/controller/gewis-authentication-controller.ts
+++ b/test/unit/gewis/controller/gewis-authentication-controller.ts
@@ -237,7 +237,7 @@ describe('GewisAuthenticationController', async (): Promise<void> => {
       ],
       givenName: 'Sudo',
       sn: 'SOS',
-      objectGUID: '1',
+      objectGUID: Buffer.from('11', 'hex'),
       employeeNumber: '4141',
       sAMAccountName: 'm4141',
       mail: 'm4141@gewis.nl',

--- a/test/unit/gewis/gewis.ts
+++ b/test/unit/gewis/gewis.ts
@@ -89,7 +89,7 @@ describe('GEWIS Helper functions', async (): Promise<void> => {
       ],
       givenName: 'Sudo',
       sn: 'SOS',
-      objectGUID: '1',
+      objectGUID: Buffer.from('11', 'hex'),
       employeeNumber: '4141',
       sAMAccountName: 'm4141',
       mail: 'm4141@gewis.nl',
@@ -172,7 +172,9 @@ describe('GEWIS Helper functions', async (): Promise<void> => {
     it('should bind to GEWIS User if already exists', async () => {
       await inUserContext(await (await UserFactory()).clone(1), async (user: User) => {
         const ADuser = {
-          ...ctx.validADUser, givenName: `Sudo #${user.firstName}`, sn: `SOS #${user.lastName}`, objectGUID: user.id, employeeNumber: `${user.id}`,
+          ...ctx.validADUser, givenName: `Sudo #${user.firstName}`, sn: `SOS #${user.lastName}`,
+          objectGUID: Buffer.from(((user.id).toString().length % 2 ? '0' : '') + (user.id).toString(), 'hex'),
+          employeeNumber: `${user.id}`,
         };
         const userCount = await User.count();
 
@@ -207,7 +209,9 @@ describe('GEWIS Helper functions', async (): Promise<void> => {
     it('should login and create a user + GEWIS user using LDAP ', async () => {
       await inUserContext(await (await UserFactory()).clone(1), async (user: User) => {
         const ADuser = {
-          ...ctx.validADUser, givenName: `Sudo #${user.firstName}`, sn: `SOS #${user.lastName}`, objectGUID: user.id, employeeNumber: `${user.id}`,
+          ...ctx.validADUser, givenName: `Sudo #${user.firstName}`, sn: `SOS #${user.lastName}`,
+          objectGUID: Buffer.from(((user.id).toString().length % 2 ? '0' : '') + (user.id).toString(), 'hex'),
+          employeeNumber: `${user.id}`,
         };
         let DBUser = await User.findOne(
           { where: { firstName: ctx.validADUser.givenName, lastName: ctx.validADUser.sn } },

--- a/test/unit/service/ad-service.ts
+++ b/test/unit/service/ad-service.ts
@@ -317,10 +317,6 @@ describe('AD Service', (): void => {
         { where: { authenticateAs: { id: newOrgan.id } }, relations: ['user'] },
       )).map((mAuth) => mAuth.user.id);
 
-      console.error((await MemberAuthenticator.find(
-        { where: { authenticateAs: { id: newOrgan.id } }, relations: ['user'] },
-      )));
-      console.error(secondMembers);
       const currentMemberIDs = secondMembers.map((u: any) => u.id);
       expect(canAuthenticateAsIDs).to.deep.equalInAnyOrder(currentMemberIDs);
     });

--- a/test/unit/service/ad-service.ts
+++ b/test/unit/service/ad-service.ts
@@ -88,7 +88,7 @@ describe('AD Service', (): void => {
       ],
       givenName: `Sudo (${mNumber})`,
       sn: 'SOS',
-      objectGUID: `${mNumber}`,
+      objectGUID: Buffer.from((mNumber.toString().length % 2 ? '0' : '') + mNumber.toString(), 'hex'),
       mNumber: mNumber,
       mail: `m${mNumber}@gewis.nl`,
       whenChanged: '202204151213.0Z',
@@ -134,7 +134,7 @@ describe('AD Service', (): void => {
     }
     it('should create an account for new shared accounts', async () => {
       const newADSharedAccount = {
-        objectGUID: '1',
+        objectGUID: Buffer.from('111111', 'hex'),
         displayName: 'Shared Organ #1',
         dn: 'CN=SudoSOSAccount - Shared Organ #1,OU=SudoSOS Shared Accounts,OU=Groups,DC=sudososwg,DC=sudosos,DC=nl',
       };
@@ -149,6 +149,7 @@ describe('AD Service', (): void => {
 
       clientSearchStub.withArgs(process.env.LDAP_SHARED_ACCOUNT_FILTER, {
         filter: '(CN=*)',
+        explicitBufferAttributes: ['objectGUID'],
       }).resolves({ searchReferences: [], searchEntries: [newADSharedAccount] });
 
       stubs.push(clientBindStub);
@@ -166,7 +167,7 @@ describe('AD Service', (): void => {
     });
     it('should give member access to shared account', async () => {
       const newADSharedAccount = {
-        objectGUID: '2',
+        objectGUID: Buffer.from('22', 'hex'),
         displayName: 'Shared Organ #2',
         dn: 'CN=SudoSOSAccount - Shared Organ #2,OU=SudoSOS Shared Accounts,OU=Groups,DC=sudososwg,DC=sudosos,DC=nl',
       };
@@ -186,7 +187,7 @@ describe('AD Service', (): void => {
         ],
         givenName: 'Sudo Organ #2',
         sn: 'SOS',
-        objectGUID: '4141',
+        objectGUID: Buffer.from('4141', 'hex'),
         sAMAccountName: 'm4141',
         mail: 'm4141@gewis.nl',
         // TODO: Fix this type inconsistency between ADUser and ldapts.Client
@@ -201,10 +202,12 @@ describe('AD Service', (): void => {
 
       clientSearchStub.withArgs(process.env.LDAP_SHARED_ACCOUNT_FILTER, {
         filter: '(CN=*)',
+        explicitBufferAttributes: ['objectGUID'],
       }).resolves({ searchReferences: [], searchEntries: [newADSharedAccount] });
 
       clientSearchStub.withArgs(process.env.LDAP_BASE, {
         filter: `(&(objectClass=user)(objectCategory=person)(memberOf:1.2.840.113556.1.4.1941:=${newADSharedAccount.dn}))`,
+        explicitBufferAttributes: ['objectGUID'],
       })
         .resolves({ searchReferences: [], searchEntries: [sharedAccountMember] });
 
@@ -224,7 +227,7 @@ describe('AD Service', (): void => {
     });
     it('should update the members of an existing shared account', async () => {
       const newADSharedAccount = {
-        objectGUID: '39',
+        objectGUID: Buffer.from('39', 'hex'),
         displayName: 'Shared Organ #3',
         dn: 'CN=SudoSOSAccount - Shared Organ #3,OU=SudoSOS Shared Accounts,OU=Groups,DC=sudososwg,DC=sudosos,DC=nl',
       };
@@ -245,7 +248,7 @@ describe('AD Service', (): void => {
         givenName: `Sudo Organ #3 ${number}`,
         sn: 'SOS',
         mNumber: `${number}`,
-        objectGUID: `${number}`,
+        objectGUID: Buffer.from((number.toString().length % 2 ? '0' : '') + number.toString(), 'hex'),
         sAMAccountName: `m${number}`,
         mail: `m${number}@gewis.nl`,
       });
@@ -257,10 +260,12 @@ describe('AD Service', (): void => {
 
       clientSearchStub.withArgs(process.env.LDAP_SHARED_ACCOUNT_FILTER, {
         filter: '(CN=*)',
+        explicitBufferAttributes: ['objectGUID'],
       }).resolves({ searchReferences: [], searchEntries: [newADSharedAccount] });
 
       clientSearchStub.withArgs(process.env.LDAP_BASE, {
         filter: `(&(objectClass=user)(objectCategory=person)(memberOf:1.2.840.113556.1.4.1941:=${newADSharedAccount.dn}))`,
+        explicitBufferAttributes: ['objectGUID'],
       })
         .resolves({ searchReferences: [], searchEntries: sharedAccountMembers });
 
@@ -271,10 +276,12 @@ describe('AD Service', (): void => {
 
       // Should contain the first users
       const newOrgan = (await LDAPAuthenticator.findOne({ where: { UUID: newADSharedAccount.objectGUID }, relations: ['user'] })).user;
+      expect(newOrgan).to.not.be.undefined;
 
-      let canAuthenticateAsIDs = (await MemberAuthenticator.find(
+      const canAuthenticateAs = await MemberAuthenticator.find(
         { where: { authenticateAs: { id: newOrgan.id } }, relations: ['user'] },
-      )).map((mAuth) => mAuth.user.id);
+      );
+      let canAuthenticateAsIDs = canAuthenticateAs.map((mAuth) => mAuth.user.id);
 
       expect(canAuthenticateAsIDs).to.deep.equalInAnyOrder(firstMembers.map((u: any) => u.id));
 
@@ -292,10 +299,12 @@ describe('AD Service', (): void => {
 
       clientSearchStub2.withArgs(process.env.LDAP_SHARED_ACCOUNT_FILTER, {
         filter: '(CN=*)',
+        explicitBufferAttributes: ['objectGUID'],
       }).resolves({ searchReferences: [], searchEntries: [newADSharedAccount] });
 
       clientSearchStub2.withArgs(process.env.LDAP_BASE, {
         filter: `(&(objectClass=user)(objectCategory=person)(memberOf:1.2.840.113556.1.4.1941:=${newADSharedAccount.dn}))`,
+        explicitBufferAttributes: ['objectGUID'],
       })
         .resolves({ searchReferences: [], searchEntries: sharedAccountMembers });
 
@@ -308,6 +317,10 @@ describe('AD Service', (): void => {
         { where: { authenticateAs: { id: newOrgan.id } }, relations: ['user'] },
       )).map((mAuth) => mAuth.user.id);
 
+      console.error((await MemberAuthenticator.find(
+        { where: { authenticateAs: { id: newOrgan.id } }, relations: ['user'] },
+      )));
+      console.error(secondMembers);
       const currentMemberIDs = secondMembers.map((u: any) => u.id);
       expect(canAuthenticateAsIDs).to.deep.equalInAnyOrder(currentMemberIDs);
     });
@@ -352,7 +365,7 @@ describe('AD Service', (): void => {
         cn: 'SudoSOS - Test',
         displayName: 'Test group',
         dn: 'CN=PRIV - SudoSOS Test,OU=SudoSOS Roles,OU=Groups,DC=gewiswg,DC=gewis,DC=nl',
-        objectGUID: '1234',
+        objectGUID: Buffer.from('1234', 'hex'),
         whenChanged: '',
       };
 
@@ -361,10 +374,12 @@ describe('AD Service', (): void => {
 
       clientSearchStub.withArgs(process.env.LDAP_ROLE_FILTER, {
         filter: '(CN=*)',
+        explicitBufferAttributes: ['objectGUID'],
       }).resolves({ searchReferences: [], searchEntries: [roleGroup as any] });
 
       clientSearchStub.withArgs(process.env.LDAP_BASE, {
         filter: `(&(objectClass=user)(objectCategory=person)(memberOf:1.2.840.113556.1.4.1941:=${roleGroup.dn}))`,
+        explicitBufferAttributes: ['objectGUID'],
       })
         .resolves({ searchReferences: [], searchEntries: [newUser as any, existingUser as any] });
 
@@ -403,6 +418,7 @@ describe('AD Service', (): void => {
 
       clientSearchStub.withArgs(process.env.LDAP_BASE, {
         filter: `(&(objectClass=user)(objectCategory=person)(memberOf:1.2.840.113556.1.4.1941:=${process.env.LDAP_USER_BASE}))`,
+        explicitBufferAttributes: ['objectGUID'],
       })
         .resolves({ searchReferences: [], searchEntries: [newUser as any] });
 

--- a/test/unit/service/authentication-service.ts
+++ b/test/unit/service/authentication-service.ts
@@ -91,7 +91,7 @@ describe('AuthenticationService', (): void => {
       ],
       givenName: 'Sudo',
       sn: 'SOS',
-      objectGUID: '1',
+      objectGUID: Buffer.from('11', 'hex'),
       sAMAccountName: 'm4141',
       mail: 'm4141@gewis.nl',
     };
@@ -149,7 +149,7 @@ describe('AuthenticationService', (): void => {
     });
     it('should login without creating a user if already bound', async () => {
       const otherValidADUser = {
-        ...ctx.validADUser, givenName: 'Test', objectGUID: 2, sAMAccountName: 'm0041',
+        ...ctx.validADUser, givenName: 'Test', objectGUID: Buffer.from('22', 'hex'), sAMAccountName: 'm0041',
       };
       let DBUser = await User.findOne(
         { where: { firstName: otherValidADUser.givenName, lastName: otherValidADUser.sn } },


### PR DESCRIPTION
# Description
Mixing little endian and big endian should be considered a warcrime. 
https://joelitechlife.ca/2021/04/05/get-objectguid-of-microsoft-active-directory-using-ldapsearch/

## Related issues/external references

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
