### PR TITLE
fix: missing save in migration

### DIFF
--- a/src/migrations/1726689003147-ldap-objectguid.ts
+++ b/src/migrations/1726689003147-ldap-objectguid.ts
@@ -95,7 +95,9 @@ export class LDAPObjectGUID1726689003147 implements MigrationInterface {
       const newObjectGUID = newGUIDMap.get(dn);
       if (!newObjectGUID) throw new Error(`Could not find new objectGUID for ${dn}`);
 
-      console.error(auth.UUID, newObjectGUID);
+      auth.UUID = newObjectGUID;
+      await auth.save();
+
       membersToFix.delete(auth.userId);
       otherToFix.delete(auth.userId);
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Guess this went wrong somewhere during the testing on sudosos-test db. 

Verified the migration locally using an old recovery.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_