### PR TITLE
feat: partially waive user's fines

### DIFF
--- a/src/controller/debtor-controller.ts
+++ b/src/controller/debtor-controller.ts
@@ -129,7 +129,7 @@ export default class DebtorController extends BaseController {
     }
 
     try {
-      res.json(await DebtorService.getFineHandoutEvents({ take, skip }));
+      res.json(await new DebtorService().getFineHandoutEvents({ take, skip }));
     } catch (error) {
       this.logger.error('Could not return all fine handout event:', error);
       res.status(500).json('Internal server error.');
@@ -152,7 +152,7 @@ export default class DebtorController extends BaseController {
     this.logger.trace('Get fine handout event', id, 'by', req.token.user);
 
     try {
-      res.json(await DebtorService.getSingleFineHandoutEvent(Number.parseInt(id, 10)));
+      res.json(await new DebtorService().getSingleFineHandoutEvent(Number.parseInt(id, 10)));
     } catch (error) {
       this.logger.error('Could not return fine handout event:', error);
       res.status(500).json('Internal server error.');
@@ -182,7 +182,7 @@ export default class DebtorController extends BaseController {
         return;
       }
 
-      await DebtorService.deleteFine(parsedId);
+      await new DebtorService().deleteFine(parsedId);
       res.status(204).send();
     } catch (error) {
       this.logger.error('Could not return fine handout event:', error);
@@ -223,7 +223,7 @@ export default class DebtorController extends BaseController {
     }
 
     try {
-      res.json(await DebtorService.calculateFinesOnDate(params));
+      res.json(await new DebtorService().calculateFinesOnDate(params));
     } catch (error) {
       this.logger.error('Could not calculate fines:', error);
       res.status(500).json('Internal server error.');
@@ -261,7 +261,7 @@ export default class DebtorController extends BaseController {
     }
 
     try {
-      const result = await DebtorService.handOutFines({ referenceDate, userIds: body.userIds }, req.token.user);
+      const result = await new DebtorService().handOutFines({ referenceDate, userIds: body.userIds }, req.token.user);
       res.json(result);
     } catch (error) {
       this.logger.error('Could not handout fines:', error);
@@ -300,7 +300,7 @@ export default class DebtorController extends BaseController {
     }
 
     try {
-      await DebtorService.sendFineWarnings({ referenceDate, userIds: body.userIds });
+      await new DebtorService().sendFineWarnings({ referenceDate, userIds: body.userIds });
       res.status(204).send();
     } catch (error) {
       this.logger.error('Could not send future fine notification emails:', error);
@@ -334,7 +334,7 @@ export default class DebtorController extends BaseController {
     }
 
     try {
-      const report = await DebtorService.getFineReport(fromDate, toDate);
+      const report = await new DebtorService().getFineReport(fromDate, toDate);
       res.json(report.toResponse());
     } catch (error) {
       this.logger.error('Could not get fine report:', error);
@@ -371,7 +371,7 @@ export default class DebtorController extends BaseController {
     }
 
     try {
-      const report = await DebtorService.getFineReport(fromDate, toDate);
+      const report = await new DebtorService().getFineReport(fromDate, toDate);
 
       const buffer = fileType === 'PDF' ? await report.createPdf() : await report.createTex();
       const from = `${fromDate.getFullYear()}${fromDate.getMonth() + 1}${fromDate.getDate()}`;

--- a/src/controller/request/debtor-request.ts
+++ b/src/controller/request/debtor-request.ts
@@ -37,6 +37,11 @@ export interface HandoutFinesRequest {
 }
 
 /**
+ * The total request and all its fields are optional for backwards compatibility's sake.
+ * If this request object is extended, it is probably best to make everything required
+ * and remove the backwards compatibility, as the frontend will (and should) already use
+ * this new object. See https://github.com/GEWIS/sudosos-backend/pull/344
+ *
  * @typedef {object} WaiveFinesRequest
  * @property {DineroObjectRequest} amount - The amount of fines that have to be
  * waived. Cannot be negative or more than the total amount of unpaid fines.

--- a/src/controller/request/debtor-request.ts
+++ b/src/controller/request/debtor-request.ts
@@ -24,6 +24,8 @@
  * @module debtors
  */
 
+import { DineroObjectRequest } from './dinero-request';
+
 /**
  * @typedef {object} HandoutFinesRequest
  * @property {Array<integer>} userIds.required - Users to fine. If a user is not eligible for a fine, a fine of 0,00 will be handed out.
@@ -32,4 +34,17 @@
 export interface HandoutFinesRequest {
   userIds: number[];
   referenceDate: string;
+}
+
+/**
+ * @typedef {object} WaiveFinesREquest
+ * @property {DineroObjectRequest} amount.required - The amount of fines that have to be
+ * waived. Cannot be negative or more than the total amount of unpaid fines.
+ */
+export interface WaiveFinesRequest {
+  /**
+   * The amount of fines that have to be waived. Cannot be
+   * negative or more than the total amount of unpaid fines.
+   */
+  amount: DineroObjectRequest;
 }

--- a/src/controller/request/debtor-request.ts
+++ b/src/controller/request/debtor-request.ts
@@ -37,8 +37,8 @@ export interface HandoutFinesRequest {
 }
 
 /**
- * @typedef {object} WaiveFinesREquest
- * @property {DineroObjectRequest} amount.required - The amount of fines that have to be
+ * @typedef {object} WaiveFinesRequest
+ * @property {DineroObjectRequest} amount - The amount of fines that have to be
  * waived. Cannot be negative or more than the total amount of unpaid fines.
  */
 export interface WaiveFinesRequest {
@@ -46,5 +46,5 @@ export interface WaiveFinesRequest {
    * The amount of fines that have to be waived. Cannot be
    * negative or more than the total amount of unpaid fines.
    */
-  amount: DineroObjectRequest;
+  amount?: DineroObjectRequest;
 }

--- a/src/controller/user-controller.ts
+++ b/src/controller/user-controller.ts
@@ -1606,6 +1606,7 @@ export default class UserController extends BaseController {
    * @tags users - Operations of user controller
    * @param {integer} id.path.required - The id of the user
    * @param {WaiveFinesRequest} request.body
+   * Optional body, see https://github.com/GEWIS/sudosos-backend/pull/344
    * @operationId waiveUserFines
    * @security JWT
    * @return 204 - Success

--- a/src/service/debtor-service.ts
+++ b/src/service/debtor-service.ts
@@ -50,7 +50,6 @@ import UserWillGetFined from '../mailer/messages/user-will-get-fined';
 import { FineReport } from '../entity/report/fine-report';
 import WithManager from '../database/with-manager';
 import QueryFilter from '../helpers/query-filter';
-import { WaiveFinesRequest } from '../controller/request/debtor-request';
 
 export interface CalculateFinesParams {
   userTypes?: UserType[];
@@ -61,6 +60,10 @@ export interface CalculateFinesParams {
 export interface HandOutFinesParams {
   referenceDate: Date;
   userIds: number[];
+}
+
+export interface WaiveFinesParams {
+  amount: DineroObjectRequest;
 }
 
 /**
@@ -299,7 +302,7 @@ export default class DebtorService extends WithManager {
    * @param userId User to waive fines for
    * @param params
    */
-  public async waiveFines(userId: number, params: WaiveFinesRequest): Promise<UserFineGroup> {
+  public async waiveFines(userId: number, params: WaiveFinesParams): Promise<UserFineGroup> {
     const user: User = await this.manager.findOne(User, {
       where: { id: userId },
       relations: { currentFines: { fines: true, waivedTransfer: true } },

--- a/src/service/debtor-service.ts
+++ b/src/service/debtor-service.ts
@@ -48,9 +48,9 @@ import UserGotFined from '../mailer/messages/user-got-fined';
 import MailMessage from '../mailer/mail-message';
 import UserWillGetFined from '../mailer/messages/user-will-get-fined';
 import { FineReport } from '../entity/report/fine-report';
-import { AppDataSource } from '../database/database';
-import { Raw } from 'typeorm';
-import { toMySQLString } from '../helpers/timestamps';
+import WithManager from '../database/with-manager';
+import QueryFilter from '../helpers/query-filter';
+import { WaiveFinesRequest } from '../controller/request/debtor-request';
 
 export interface CalculateFinesParams {
   userTypes?: UserType[];
@@ -80,7 +80,7 @@ function calculateFine(balance: DineroObject | DineroObjectResponse | DineroObje
   );
 }
 
-export default class DebtorService {
+export default class DebtorService extends WithManager {
   static asFineResponse(fine: Fine): FineResponse {
     return {
       id: fine.id,
@@ -117,13 +117,13 @@ export default class DebtorService {
   /**
    * Get a list of all fine handout events in chronological order
    */
-  public static async getFineHandoutEvents(pagination: PaginationParameters = {}): Promise<PaginatedFineHandoutEventResponse> {
+  public async getFineHandoutEvents(pagination: PaginationParameters = {}): Promise<PaginatedFineHandoutEventResponse> {
     const { take, skip } = pagination;
 
-    const events = await FineHandoutEvent.find({ take, skip, order: {
+    const events = await this.manager.find(FineHandoutEvent, { take, skip, order: {
       createdAt: 'DESC',
     } });
-    const count = await FineHandoutEvent.count();
+    const count = await this.manager.count(FineHandoutEvent);
 
     const records = events.map((e) => DebtorService.asBaseFineHandoutEventResponse(e));
 
@@ -138,10 +138,10 @@ export default class DebtorService {
   /**
    * Return the fine handout event with the given id. Includes all its fines with the corresponding user
    */
-  public static async getSingleFineHandoutEvent(id: number): Promise<FineHandoutEventResponse> {
-    const fineHandoutEvent = await FineHandoutEvent.findOne({
+  public async getSingleFineHandoutEvent(id: number): Promise<FineHandoutEventResponse> {
+    const fineHandoutEvent = await this.manager.findOne(FineHandoutEvent, {
       where: { id },
-      relations: ['fines', 'fines.userFineGroup', 'fines.userFineGroup.user'],
+      relations: { fines: { userFineGroup: { user: true } } },
       order: { createdAt: 'DESC' },
     });
 
@@ -156,7 +156,7 @@ export default class DebtorService {
    * @param referenceDates Dates at which a user needs to have a negative balance. The first
    * date will be used to determine the size of the fine
    */
-  public static async calculateFinesOnDate({ userTypes, userIds, referenceDates }: CalculateFinesParams): Promise<UserToFineResponse[]> {
+  public async calculateFinesOnDate({ userTypes, userIds, referenceDates }: CalculateFinesParams): Promise<UserToFineResponse[]> {
     if (referenceDates.length === 0) throw new Error('No reference dates given.');
 
     const balances = await Promise.all(referenceDates.map((date) => new BalanceService().getBalances({
@@ -187,22 +187,22 @@ export default class DebtorService {
    * @param userIds Ids of all users to fine
    * @param createdBy User handing out fines
    */
-  public static async handOutFines({
+  public async handOutFines({
     referenceDate, userIds,
   }: HandOutFinesParams, createdBy: User): Promise<FineHandoutEventResponse> {
-    const previousFineGroup = (await FineHandoutEvent.find({
+    const previousFineGroup = (await this.manager.find(FineHandoutEvent, {
       order: { id: 'desc' },
       relations: ['fines', 'fines.userFineGroup'],
       take: 1,
     }))[0];
 
-    const balances = await new BalanceService().getBalances({
+    const balances = await new BalanceService(this.manager).getBalances({
       date: referenceDate,
       ids: userIds,
     });
 
     // NOTE: executed in single transaction
-    const { fines: fines1, fineHandoutEvent: fineHandoutEvent1, emails: emails1 } = await AppDataSource.transaction(async (manager) => {
+    const { fines: fines1, fineHandoutEvent: fineHandoutEvent1, emails: emails1 } = await this.manager.transaction(async (manager) => {
       // Create a new fine group to "connect" all these fines
       const fineHandoutEvent = Object.assign(new FineHandoutEvent(), {
         referenceDate,
@@ -225,10 +225,10 @@ export default class DebtorService {
             user: user,
             fines: [],
           });
-          userFineGroup = await userFineGroup.save();
+          userFineGroup = await manager.save(UserFineGroup, userFineGroup);
           if (amount.getAmount() > 0) {
             user.currentFines = userFineGroup;
-            await manager.save(user);
+            await manager.save(User, user);
           }
         }
 
@@ -265,7 +265,7 @@ export default class DebtorService {
       updatedAt: fineHandoutEvent1.updatedAt.toISOString(),
       referenceDate: fineHandoutEvent1.referenceDate.toISOString(),
       createdBy: parseUserToBaseResponse(fineHandoutEvent1.createdBy, false),
-      fines: fines1.map((f) => this.asFineResponse(f)),
+      fines: fines1.map((f) => DebtorService.asFineResponse(f)),
     };
   }
 
@@ -273,33 +273,36 @@ export default class DebtorService {
    * Delete a fine with its transfer, but keep the FineHandoutEvent (they can be empty)
    * @param id
    */
-  public static async deleteFine(id: number): Promise<void> {
-    const fine = await Fine.findOne({ where: { id }, relations: ['transfer', 'userFineGroup', 'userFineGroup.fines'] });
+  public async deleteFine(id: number): Promise<void> {
+    const fine = await this.manager.findOne(Fine, { where: { id }, relations: ['transfer', 'userFineGroup', 'userFineGroup.fines'] });
     if (fine == null) return;
 
     const { transfer, userFineGroup } = fine;
 
-    await Fine.remove(fine);
-    await Transfer.remove(transfer);
+    await this.manager.remove(Fine, fine);
+    await this.manager.remove(Transfer, transfer);
     if (userFineGroup.fines.length === 1) {
-      await UserFineGroup.remove(userFineGroup);
+      await this.manager.remove(UserFineGroup, userFineGroup);
     }
     if (userFineGroup.fines.length > 1) {
       // If user does not have a debt anymore, remove the UserFineGroup reference
       const newBalance = await new BalanceService().getBalance(userFineGroup.userId);
       if (newBalance.amount.amount < 0) return;
-      await User.update(userFineGroup.userId, { currentFines: null });
+      await this.manager.update(User, userFineGroup.userId, { currentFines: null });
     }
   }
 
   /**
-   * Waive a user's unpaid fines by creating a transfer nullifying them
-   * @param userId
+   * Waive a user's unpaid fines (partially) by creating a transfer which puts some money
+   * back into the user's account. If the user's fines were already (partially) waived, the
+   * existing transfer waiving the fines will be replaced by a new transfer.
+   * @param userId User to waive fines for
+   * @param params
    */
-  public static async waiveFines(userId: number): Promise<UserFineGroup> {
-    const user = await User.findOne({
+  public async waiveFines(userId: number, params: WaiveFinesRequest): Promise<UserFineGroup> {
+    const user: User = await this.manager.findOne(User, {
       where: { id: userId },
-      relations: ['currentFines', 'currentFines.fines'],
+      relations: { currentFines: { fines: true, waivedTransfer: true } },
     });
     if (user == null) throw new Error(`User with ID ${userId} does not exist`);
     if (user.currentFines == null) return;
@@ -307,20 +310,30 @@ export default class DebtorService {
     const userFineGroup = user.currentFines;
     const amount = userFineGroup.fines.reduce((sum, f) => sum.add(f.amount), dinero({ amount: 0 }));
 
-    // Create the waived transfer
-    userFineGroup.waivedTransfer = await new TransferService().createTransfer({
+    if (params.amount.amount < 0) throw new Error('Amount to waive cannot be negative.');
+    if (params.amount.amount > amount.getAmount()) throw new Error('Amount to waive cannot be greater than the total amount of fines.');
+
+    // If the fine is already partially waived, delete the old transfer
+    if (userFineGroup.waivedTransfer) {
+      await this.manager.remove(Transfer, userFineGroup.waivedTransfer);
+    }
+
+    // Create the transfer for the waived amount
+    userFineGroup.waivedTransfer = await new TransferService(this.manager).createTransfer({
       amount: amount.toObject(),
       toId: user.id,
       description: 'Waived fines',
       fromId: undefined,
     });
-    await userFineGroup.save();
+    await this.manager.save(UserFineGroup, userFineGroup);
 
-    // Remove the fine from the user. This must be done manually,
-    // because the user can still have a negative balance when the
-    // fine is waived.
-    user.currentFines = null;
-    await user.save();
+    if (params.amount.amount === amount.getAmount()) {
+      // Remove the fine from the user when the total amount is waived.
+      // This must be done manually, because the user can still have a
+      // negative balance when the fine is waived.
+      user.currentFines = null;
+    }
+    await this.manager.save(User, user);
   }
 
   /**
@@ -332,13 +345,13 @@ export default class DebtorService {
    * @param referenceDate
    * @param userIds
    */
-  public static async sendFineWarnings({
+  public async sendFineWarnings({
     referenceDate, userIds,
   }: HandOutFinesParams): Promise<void> {
     const fines = await this.calculateFinesOnDate({ userIds, referenceDates: [referenceDate] });
 
     await Promise.all(fines.map(async (f) => {
-      const user = await User.findOne({ where: { id: f.id } });
+      const user = await this.manager.findOne(User, { where: { id: f.id } });
       const balance = f.balances[0];
       if (balance == null) throw new Error('Missing balance');
       return Mailer.getInstance().send(user, new UserWillGetFined({
@@ -354,7 +367,7 @@ export default class DebtorService {
    * @param fromDate
    * @param toDate
    */
-  public static async getFineReport(fromDate: Date, toDate: Date): Promise<FineReport> {
+  public async getFineReport(fromDate: Date, toDate: Date): Promise<FineReport> {
     let handedOut = dinero({ amount: 0 });
     let waivedAmount = dinero({ amount: 0 });
     const count = {
@@ -363,16 +376,12 @@ export default class DebtorService {
     };
 
     // Get all transfers that have a fine or waived fine
-    const transfers = await Transfer.find({
-      relations: ['fine', 'fine.transfer',  'waivedFines', 'waivedFines.waivedTransfer'],
-      where: [{ fine: true, createdAt: Raw(
-        (alias) => `${alias} >= :fromDate AND ${alias} < :tillDate`,
-        { fromDate: toMySQLString(fromDate), tillDate: toMySQLString(toDate) },
-      ) },
-      { waivedFines: true, createdAt: Raw(
-        (alias) => `${alias} >= :fromDate AND ${alias} < :tillDate`,
-        { fromDate: toMySQLString(fromDate), tillDate: toMySQLString(toDate) },
-      ) }],
+    const transfers = await this.manager.find(Transfer, {
+      relations: { fine: { transfer: true }, waivedFines: { waivedTransfer: true } },
+      where: [
+        { fine: true, createdAt: QueryFilter.createFilterWhereDate(fromDate, toDate) },
+        { waivedFines: true, createdAt: QueryFilter.createFilterWhereDate(fromDate, toDate) },
+      ],
     });
 
     transfers.forEach((transfer) => {

--- a/test/unit/service/debtor-service.ts
+++ b/test/unit/service/debtor-service.ts
@@ -42,6 +42,7 @@ import TransferService from '../../../src/service/transfer-service';
 import FineHandoutEvent from '../../../src/entity/fine/fineHandoutEvent';
 import { FineSeeder, TransactionSeeder, TransferSeeder, UserSeeder } from '../../seed';
 import { rootStubs } from '../../root-hooks';
+import { WaiveFinesRequest } from '../../../src/controller/request/debtor-request';
 
 describe('DebtorService', (): void => {
   let ctx: {
@@ -54,6 +55,7 @@ describe('DebtorService', (): void => {
     fines: Fine[],
     userFineGroups: UserFineGroup[],
     actor: User,
+    waiveFinesRequest: WaiveFinesRequest,
   };
 
   let sandbox: SinonSandbox;
@@ -85,6 +87,9 @@ describe('DebtorService', (): void => {
       fines,
       userFineGroups,
       actor: usersWithFines[0],
+      waiveFinesRequest: {
+        amount: { amount: 100, currency: 'EUR', precision: 2 },
+      },
     };
   });
 
@@ -113,7 +118,7 @@ describe('DebtorService', (): void => {
   describe('calculateFinesOnDate', () => {
     it('should return everyone who should get fined', async () => {
       const now = new Date();
-      const calculatedFines = await DebtorService.calculateFinesOnDate({
+      const calculatedFines = await new DebtorService().calculateFinesOnDate({
         referenceDates: [now],
       });
       const usersToFine = ctx.users
@@ -133,7 +138,7 @@ describe('DebtorService', (): void => {
 
     it('should only return users from given userTypes', async () => {
       const userTypes = [UserType.LOCAL_USER, UserType.INVOICE];
-      const calculatedFines = await DebtorService.calculateFinesOnDate({
+      const calculatedFines = await new DebtorService().calculateFinesOnDate({
         userTypes,
         referenceDates: [new Date()],
       });
@@ -153,7 +158,7 @@ describe('DebtorService', (): void => {
 
     it('should only return users that have more than 5 euros debt now and on reference date', async () => {
       const referenceDates = [new Date('2021-02-12'), new Date()];
-      const calculatedFines = await DebtorService.calculateFinesOnDate({
+      const calculatedFines = await new DebtorService().calculateFinesOnDate({
         referenceDates,
       });
       const usersToFine = ctx.users
@@ -193,7 +198,7 @@ describe('DebtorService', (): void => {
       const balance = await new BalanceService().getBalance(newUser.id);
       expect(balance.amount.amount).to.equal(-500);
 
-      const fines = await DebtorService.calculateFinesOnDate({
+      const fines = await new DebtorService().calculateFinesOnDate({
         referenceDates: [new Date()],
       });
       const fineForUser = fines.find((f) => f.id === newUser.id);
@@ -211,7 +216,7 @@ describe('DebtorService', (): void => {
       const usersWithDebt = users.filter((u) => calculateBalance(u, ctx.transactions, ctx.subTransactions, ctx.transfersInclFines).amount.getAmount() <= -500);
       const userIds = usersWithDebt.map((u) => u.id);
 
-      await DebtorService.sendFineWarnings({ referenceDate: new Date(), userIds });
+      await new DebtorService().sendFineWarnings({ referenceDate: new Date(), userIds });
 
       expect(sendMailFake.callCount).to.equal(usersWithDebt.length);
     });
@@ -224,7 +229,7 @@ describe('DebtorService', (): void => {
       const userIds = usersWithDebt.map((u) => u.id);
       expect(userIds.length).to.be.at.least(0);
 
-      await DebtorService.sendFineWarnings({ referenceDate, userIds });
+      await new DebtorService().sendFineWarnings({ referenceDate, userIds });
 
       expect(sendMailFake.callCount).to.equal(usersWithDebt.length);
     });
@@ -239,7 +244,7 @@ describe('DebtorService', (): void => {
       expect(dbUserFineGroup.fines.length).to.equal(1);
 
       const fine = dbUserFineGroup.fines[0];
-      expect(await DebtorService.deleteFine(fine.id)).to.not.throw;
+      expect(await new DebtorService().deleteFine(fine.id)).to.not.throw;
 
       const dbFine = await Fine.findOne({ where: { id: fine.id } });
       expect(dbFine).to.be.null;
@@ -261,7 +266,7 @@ describe('DebtorService', (): void => {
       expect(dbUserFineGroup.fines.length).to.be.greaterThan(1);
 
       const fine = dbUserFineGroup.fines[0];
-      expect(await DebtorService.deleteFine(fine.id)).to.not.throw;
+      expect(await new DebtorService().deleteFine(fine.id)).to.not.throw;
 
       const dbFine = await Fine.findOne({ where: { id: fine.id } });
       expect(dbFine).to.be.null;
@@ -309,7 +314,7 @@ describe('DebtorService', (): void => {
       expect(dbBalance.fine).to.not.be.undefined;
       expect(dbBalance.fineSince).to.not.be.undefined;
 
-      expect(await DebtorService.deleteFine(fine.id)).to.not.throw;
+      expect(await new DebtorService().deleteFine(fine.id)).to.not.throw;
 
       const dbFine = await Fine.findOne({ where: { id: fine.id } });
       expect(dbFine).to.be.null;
@@ -334,12 +339,12 @@ describe('DebtorService', (): void => {
       const id = 9999999;
       const fine = await Fine.findOne({ where: { id } });
       expect(fine).to.be.null;
-      expect(await DebtorService.deleteFine(id)).to.not.throw;
+      expect(await new DebtorService().deleteFine(id)).to.not.throw;
     });
   });
 
   describe('waiveFines', () => {
-    it('should correctly waive fines', async () => {
+    it('should correctly waive all fines', async () => {
       const userFineGroupIndex = ctx.userFineGroups.findIndex((g) => g.fines.length > 1);
       const userFineGroup = ctx.userFineGroups[userFineGroupIndex];
       const dbUserFineGroupOld = await UserFineGroup.findOne({ where: { id: userFineGroup.id }, relations: ['fines', 'waivedTransfer', 'user', 'user.currentFines'] });
@@ -348,7 +353,7 @@ describe('DebtorService', (): void => {
       expect(dbUserFineGroupOld.user.currentFines).to.not.be.null;
       expect(dbUserFineGroupOld.fines.length).to.be.greaterThan(0);
 
-      await DebtorService.waiveFines(userFineGroup.userId);
+      await new DebtorService().waiveFines(userFineGroup.userId, { amount: { amount, currency: 'EUR', precision: 2 } });
 
       const dbUserFineGroupNew = await UserFineGroup.findOne({ where: { id: userFineGroup.id }, relations: ['fines', 'waivedTransfer', 'user', 'user.currentFines'] });
       expect(dbUserFineGroupNew.waivedTransfer).to.not.be.null;
@@ -366,14 +371,14 @@ describe('DebtorService', (): void => {
       const user = await User.findOne({ where: { id } });
       expect(user).to.be.null;
 
-      await expect(DebtorService.waiveFines(id)).to.eventually.rejectedWith(`User with ID ${id} does not exist`);
+      await expect(new DebtorService().waiveFines(id, ctx.waiveFinesRequest)).to.eventually.rejectedWith(`User with ID ${id} does not exist`);
     });
     it('should not do anything when user does not have fines', async () => {
       const user = ctx.users.find((u) => u.currentFines == null);
       expect(user).to.not.be.null;
       const nrTransfers = await Transfer.count();
 
-      await DebtorService.waiveFines(user.id);
+      await new DebtorService().waiveFines(user.id, ctx.waiveFinesRequest);
       expect(await Transfer.count()).to.equal(nrTransfers);
     });
   });
@@ -470,10 +475,11 @@ describe('DebtorService', (): void => {
 
     it('should correctly create fines with reference date', async () => {
       const referenceDate = new Date('2021-01-30');
-      const usersToFine = await DebtorService.calculateFinesOnDate({
+      const debtorService = new DebtorService();
+      const usersToFine = await debtorService.calculateFinesOnDate({
         referenceDates: [referenceDate],
       });
-      const fineHandoutEvent = await DebtorService.handOutFines({
+      const fineHandoutEvent = await debtorService.handOutFines({
         userIds: usersToFine.map((u) => u.id),
         referenceDate,
       }, ctx.actor);
@@ -499,7 +505,8 @@ describe('DebtorService', (): void => {
     });
     it('should correctly put two fines in same userFineGroup', async () => {
       const referenceDate = new Date('2021-01-30');
-      const usersToFine = await DebtorService.calculateFinesOnDate({
+      const debtorService = new DebtorService();
+      const usersToFine = await debtorService.calculateFinesOnDate({
         referenceDates: [referenceDate],
       });
       const usersWithoutFines = ctx.users.filter((u) => !ctx.userFineGroups.some((g) => g.userId === u.id));
@@ -512,11 +519,11 @@ describe('DebtorService', (): void => {
       });
       expect(userFineGroups).to.be.length(0);
 
-      const fineHandoutEvent1 = await DebtorService.handOutFines({
+      const fineHandoutEvent1 = await debtorService.handOutFines({
         userIds: [user.id],
         referenceDate,
       }, ctx.actor);
-      const fineHandoutEvent2 = await DebtorService.handOutFines({
+      const fineHandoutEvent2 = await debtorService.handOutFines({
         userIds: [user.id],
         referenceDate: new Date(),
       }, ctx.actor);
@@ -542,7 +549,7 @@ describe('DebtorService', (): void => {
       await deleteFineHandoutEvent(fineHandoutEvent2.id);
     });
     it('should create no fines if empty list of userIds is given', async function () {
-      const fineHandoutEvent = await DebtorService.handOutFines({ userIds: [], referenceDate: new Date() }, ctx.actor);
+      const fineHandoutEvent = await new DebtorService().handOutFines({ userIds: [], referenceDate: new Date() }, ctx.actor);
 
       expect(fineHandoutEvent.fines.length).to.equal(0);
       expect(await Fine.count()).to.equal(0);
@@ -555,7 +562,7 @@ describe('DebtorService', (): void => {
       let dbUser = await User.findOne({ where: { id: user.id }, relations: ['currentFines'] });
       expect(dbUser.currentFines).to.be.null;
 
-      const fineHandoutEvent = await DebtorService.handOutFines({ userIds: [user.id], referenceDate: new Date() }, ctx.actor);
+      const fineHandoutEvent = await new DebtorService().handOutFines({ userIds: [user.id], referenceDate: new Date() }, ctx.actor);
       expect(fineHandoutEvent.fines.length).to.equal(1);
       const fine = fineHandoutEvent.fines[0];
       expect(fine.user.id).to.equal(user.id);
@@ -573,7 +580,7 @@ describe('DebtorService', (): void => {
       const user = ctx.users[0];
       expect(user).to.not.be.undefined;
 
-      const fineHandoutEvent = await DebtorService.handOutFines({
+      const fineHandoutEvent = await new DebtorService().handOutFines({
         userIds: [user.id],
         referenceDate: new Date(),
       }, ctx.actor);
@@ -597,12 +604,13 @@ describe('DebtorService', (): void => {
 
     async function makeFines(): Promise<FineHandoutEventResponse> {
       const referenceDate = new Date('2021-01-30');
+      const debtorService = new DebtorService();
 
-      const usersToFine = await DebtorService.calculateFinesOnDate({
+      const usersToFine = await debtorService.calculateFinesOnDate({
         referenceDates: [referenceDate],
       });
 
-      return DebtorService.handOutFines({
+      return debtorService.handOutFines({
         userIds: usersToFine.map((u) => u.id),
         referenceDate,
       }, ctx.actor);
@@ -614,7 +622,7 @@ describe('DebtorService', (): void => {
       fromDate.setTime(fromDate.getTime() - 1000);
       const endDate = new Date();
       endDate.setTime(endDate.getTime() + 1000);
-      const report = await DebtorService.getFineReport(fromDate, endDate);
+      const report = await new DebtorService().getFineReport(fromDate, endDate);
 
       expect(report.fromDate.toISOString()).to.equal(fromDate.toISOString());
       expect(report.toDate.toISOString()).to.equal(endDate.toISOString());
@@ -629,7 +637,7 @@ describe('DebtorService', (): void => {
       await makeFines();
       const fromDate = new Date('2020-01-01');
       const endDate = new Date('2021-01-01');
-      const report = await DebtorService.getFineReport(fromDate, endDate);
+      const report = await new DebtorService().getFineReport(fromDate, endDate);
 
       expect(report.fromDate.toISOString()).to.equal(fromDate.toISOString());
       expect(report.toDate.toISOString()).to.equal(endDate.toISOString());
@@ -642,7 +650,7 @@ describe('DebtorService', (): void => {
       await makeFines();
       const fromDate = new Date('3020-01-01');
       const endDate = new Date('3021-01-01');
-      const report = await DebtorService.getFineReport(fromDate, endDate);
+      const report = await new DebtorService().getFineReport(fromDate, endDate);
 
       expect(report.fromDate.toISOString()).to.equal(fromDate.toISOString());
       expect(report.toDate.toISOString()).to.equal(endDate.toISOString());
@@ -653,7 +661,8 @@ describe('DebtorService', (): void => {
 
     it( 'should return error if transfer has fine and waivedFine', async () => {
       const fineHandoutEvent = await makeFines();
-      await DebtorService.waiveFines(fineHandoutEvent.fines[0].user.id);
+      const debtorService = new DebtorService();
+      await debtorService.waiveFines(fineHandoutEvent.fines[0].user.id, ctx.waiveFinesRequest);
 
       const transfer = await Transfer.findOne({ where: { waivedFines: { userId: fineHandoutEvent.fines[0].user.id } }, relations: ['fine', 'waivedFines'] });
       transfer.fine = await Fine.create({
@@ -668,7 +677,7 @@ describe('DebtorService', (): void => {
       const tillDate = new Date();
       tillDate.setTime(tillDate.getTime() + 1000);
       // Expect to error
-      await expect(DebtorService.getFineReport(date, tillDate)).to.eventually.rejectedWith('Transfer has both fine and waived fine');
+      await expect(debtorService.getFineReport(date, tillDate)).to.eventually.rejectedWith('Transfer has both fine and waived fine');
     });
 
     it('should deal with waived fines', async () => {
@@ -678,8 +687,8 @@ describe('DebtorService', (): void => {
       const tillDate = new Date();
       tillDate.setTime(tillDate.getTime() + 1000);
 
-      await DebtorService.waiveFines(fineHandoutEvent.fines[0].user.id);
-      const report = await DebtorService.getFineReport(date, tillDate);
+      await new DebtorService().waiveFines(fineHandoutEvent.fines[0].user.id, ctx.waiveFinesRequest);
+      const report = await new DebtorService().getFineReport(date, tillDate);
 
       expect(report.fromDate.toISOString()).to.equal(date.toISOString());
       expect(report.toDate.toISOString()).to.equal(tillDate.toISOString());

--- a/test/unit/subscribe/transfer-subscriber.ts
+++ b/test/unit/subscribe/transfer-subscriber.ts
@@ -78,7 +78,7 @@ describe('TransferSubscriber', (): void => {
       expect(debt.getAmount()).to.be.lessThan(0);
       expect((await new BalanceService().getBalance(user.id)).amount.amount).to.equal(debt.getAmount());
 
-      const { fines } = await DebtorService.handOutFines({ userIds: [user.id], referenceDate: new Date() }, ctx.users[0]);
+      const { fines } = await new DebtorService().handOutFines({ userIds: [user.id], referenceDate: new Date() }, ctx.users[0]);
       const fine = await Fine.findOne({
         where: { id: fines[0].id },
         relations: ['userFineGroup'],
@@ -108,7 +108,7 @@ describe('TransferSubscriber', (): void => {
       const debt = calculateBalance(user, ctx.transactions, ctx.subTransactions, ctx.transfers).amount;
       expect((await new BalanceService().getBalance(user.id)).amount.amount).to.equal(debt.getAmount());
 
-      const { fines } = await DebtorService.handOutFines({ userIds: [user.id], referenceDate: new Date() }, ctx.users[0]);
+      const { fines } = await new DebtorService().handOutFines({ userIds: [user.id], referenceDate: new Date() }, ctx.users[0]);
       const fine = await Fine.findOne({
         where: { id: fines[0].id },
         relations: ['userFineGroup'],
@@ -140,7 +140,7 @@ describe('TransferSubscriber', (): void => {
       const debt = calculateBalance(user, ctx.transactions, ctx.subTransactions, ctx.transfers).amount;
       expect((await new BalanceService().getBalance(user.id)).amount.amount).to.equal(debt.getAmount());
 
-      const { fines } = await DebtorService.handOutFines({ userIds: [user.id], referenceDate: new Date() }, ctx.users[0]);
+      const { fines } = await new DebtorService().handOutFines({ userIds: [user.id], referenceDate: new Date() }, ctx.users[0]);
       const fine = await Fine.findOne({
         where: { id: fines[0].id },
         relations: ['userFineGroup'],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
After merging the PR, a `UserFineGroup`'s can be partially waived, instead of only all of them. The following decision decisions/restrictions are made:
1. The workflow of waiving all user's fines has not changed. When all fines of a user are waived, the user will no longer have any outstanding fines.
2. When waiving fines partially, the user will no longer have any outstanding fines if they go out of debt after the waiving.
3. When a user gets its fines partially waived and remains in debt, the user will still have outstanding fines. If they get a new fine, this new fine will be added to the total outstanding amount (the same `UserFineGroup`).
4. When a user's fines of the same `UserFineGroup` are waived _again_, this new amount to waive will override the old amount. In other words, the old `waiveFineTransfer` is deleted and a new transfer is created.
5. For backwards compatibility with the current SudoSOS API spec, the waive amount is optional. When no amount is provided, the total fine amount will be waived. This behaviour should be seen as deprecated.

Note that the amount of fines responded by the `BalanceController` is still the total amount of fines and does not include any waived amounts. Having these numbers separately is required to support point 4 (so you know the total amount of fines and how much is already waived). This waived amount should be implemented as a seperate field in `BalanceResponse` and can probably be best done together with the rest of https://github.com/GEWIS/sudosos-backend/issues/334.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
https://github.com/GEWIS/sudosos-backend/issues/335

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_