### PR TITLE
chore: deprecate all Event-related code

### DIFF
--- a/src/controller/event-controller.ts
+++ b/src/controller/event-controller.ts
@@ -22,6 +22,7 @@
  * This is the module page of event-controller.
  *
  * @module events
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 
 import log4js, { Logger } from 'log4js';
@@ -40,6 +41,9 @@ import Event from '../entity/event/event';
 import EventShiftAnswer from '../entity/event/event-shift-answer';
 import { asShiftAvailability } from '../helpers/validators';
 
+/**
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
+ */
 export default class EventController extends BaseController {
   private logger: Logger = log4js.getLogger('EventLogger');
 
@@ -129,6 +133,7 @@ export default class EventController extends BaseController {
    * @return {PaginatedBaseEventResponse} 200 - All existing events
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
+   * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
    */
   public async getAllEvents(req: RequestWithToken, res: Response): Promise<void> {
     this.logger.trace('Get all events by user', req.token.user);
@@ -172,6 +177,7 @@ export default class EventController extends BaseController {
    * @return {EventResponse} 200 - All existing events
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
+   * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
    */
   public async getSingleEvent(req: RequestWithToken, res: Response) {
     const { id } = req.params;
@@ -201,6 +207,7 @@ export default class EventController extends BaseController {
    * @return {EventResponse} 200 - Created event
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
+   * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
    */
   public async createEvent(req: RequestWithToken, res: Response) {
     const body = req.body as EventRequest;
@@ -237,6 +244,7 @@ export default class EventController extends BaseController {
    * @return {EventResponse} 200 - Created event
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
+   * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
    */
   public async updateEvent(req: RequestWithToken, res: Response) {
     const { id } = req.params;
@@ -284,6 +292,7 @@ export default class EventController extends BaseController {
    * @return 204 - Success
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
+   * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
    */
   public async deleteEvent(req: RequestWithToken, res: Response) {
     const { id } = req.params;
@@ -316,6 +325,7 @@ export default class EventController extends BaseController {
    * @return {EventResponse} 200 - All existing events
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
+   * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
    */
   public async syncEventShiftAnswers(req: RequestWithToken, res: Response) {
     const { id } = req.params;
@@ -350,6 +360,7 @@ export default class EventController extends BaseController {
    * @return {BaseEventAnswerResponse} 200 - Created event
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
+   * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
    */
   public async assignEventShift(req: RequestWithToken, res: Response) {
     const { eventId: rawEventId, shiftId: rawShiftId, userId: rawUserId } = req.params;
@@ -402,6 +413,7 @@ export default class EventController extends BaseController {
    * @return {BaseEventAnswerResponse} 200 - Created event
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
+   * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
    */
   public async updateShiftAvailability(req: RequestWithToken, res: Response) {
     const { userId: rawUserId, shiftId: rawShiftId, eventId: rawEventId } = req.params;

--- a/src/controller/event-shift-controller.ts
+++ b/src/controller/event-shift-controller.ts
@@ -22,6 +22,7 @@
  * This is the module page of event-shift-controller.
  *
  * @module events
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 
 import BaseController, { BaseControllerOptions } from './base-controller';
@@ -35,6 +36,9 @@ import EventShift from '../entity/event/event-shift';
 import { parseRequestPagination } from '../helpers/pagination';
 import { asDate, asEventType } from '../helpers/validators';
 
+/**
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
+ */
 export default class EventShiftController extends BaseController {
   private logger: Logger = log4js.getLogger('EventShiftLogger');
 
@@ -95,6 +99,7 @@ export default class EventShiftController extends BaseController {
    * @return {PaginatedEventShiftResponse} 200 - All existing event shifts
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
+   * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
    */
   public async getAllShifts(req: RequestWithToken, res: Response) {
     this.logger.trace('Get all shifts by user', req.token.user);
@@ -129,6 +134,7 @@ export default class EventShiftController extends BaseController {
    * @return {EventShiftResponse} 200 - Created event shift
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
+   * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
    */
   public async createShift(req: RequestWithToken, res: Response) {
     const body = req.body as EventShiftRequest;
@@ -169,6 +175,7 @@ export default class EventShiftController extends BaseController {
    * @return {EventShiftResponse} 200 - Created event shift
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
+   * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
    */
   public async updateShift(req: RequestWithToken, res: Response) {
     const { id: rawId } = req.params;
@@ -221,6 +228,7 @@ export default class EventShiftController extends BaseController {
    * @return 204 - Success
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
+   * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
    */
   public async deleteShift(req: RequestWithToken, res: Response) {
     const { id: rawId } = req.params;
@@ -255,6 +263,7 @@ export default class EventShiftController extends BaseController {
    * @return {Array<PaginatedEventShiftResponse>} 200 - All existing event shifts
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
+   * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
    */
   public async getShiftSelectedCount(req: RequestWithToken, res: Response) {
     const { id: rawId } = req.params;

--- a/src/controller/request/event-request.ts
+++ b/src/controller/request/event-request.ts
@@ -22,6 +22,7 @@
  * This is the module page of the event-request.
  *
  * @module events
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 
 import { Availability } from '../../entity/event/event-shift-answer';
@@ -34,6 +35,7 @@ import { Availability } from '../../entity/event/event-shift-answer';
  * @property {string} type - The type of the event.
  * @property {Array<integer>} shiftIds.required - IDs of shifts that are in this event
  * per participant per borrel.
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 
 /**
@@ -44,6 +46,7 @@ import { Availability } from '../../entity/event/event-shift-answer';
  * @property {string} type - The type of the event.
  * @property {Array<integer>} shiftIds - IDs of shifts that are in this event
  * per participant per borrel.
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 export interface EventRequest {
   name: string,
@@ -57,12 +60,14 @@ export interface EventRequest {
  * @typedef {object} CreateShiftRequest
  * @property {string} name.required - Name of the event
  * @property {Array<string>} roles.required - Roles that (can) have this shift
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 
 /**
  * @typedef {object} UpdateShiftRequest
  * @property {string} name - Name of the event
  * @property {Array<string>} roles - Roles that (can) have this shift
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 export interface EventShiftRequest {
   name: string,
@@ -72,6 +77,7 @@ export interface EventShiftRequest {
 /**
  * @typedef {object} EventAnswerAssignmentRequest
  * @property {boolean} selected.required - Whether this user is selected for the given shift at the given event
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 export interface EventAnswerAssignmentRequest {
   selected: boolean,
@@ -80,6 +86,7 @@ export interface EventAnswerAssignmentRequest {
 /**
  * @typedef {object} EventAnswerAvailabilityRequest
  * @property {string} availability.required - New availability of the given user for the given event (YES, NO, LATER, NA)
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 export interface EventAnswerAvailabilityRequest {
   availability: Availability,

--- a/src/controller/response/event-response.ts
+++ b/src/controller/response/event-response.ts
@@ -22,6 +22,7 @@
  * This is the module page of the event-response.
  *
  * @module events
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 
 import { PaginationResult } from '../../helpers/pagination';
@@ -36,6 +37,7 @@ import { EventType } from '../../entity/event/event';
  * @property {string} startDate.required - The starting date of the event.
  * @property {string} endDate.required - The end date of the event.
  * @property {string} type.required - The tpye of event.
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 export interface BaseEventResponse extends BaseResponse {
   createdBy: BaseUserResponse,
@@ -48,6 +50,7 @@ export interface BaseEventResponse extends BaseResponse {
 /**
  * @typedef {allOf|BaseResponse} BaseEventShiftResponse
  * @property {string} name.required - Name of the shift.
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 export interface BaseEventShiftResponse extends BaseResponse {
   name: string,
@@ -56,6 +59,7 @@ export interface BaseEventShiftResponse extends BaseResponse {
 /**
  * @typedef {allOf|BaseEventShiftResponse} EventShiftResponse
  * @property {Array<string>} roles.required - Which roles can fill in this shift.
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 export interface EventShiftResponse extends BaseEventShiftResponse {
   roles: string[],
@@ -64,6 +68,7 @@ export interface EventShiftResponse extends BaseEventShiftResponse {
 /**
  * @typedef {allOf|EventShiftResponse} EventInShiftResponse
  * @property {Array<BaseEventAnswerResponse>} answers - Answers for this shift.
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 export interface EventInShiftResponse extends EventShiftResponse {
   answers: BaseEventAnswerResponse[];
@@ -73,6 +78,7 @@ export interface EventInShiftResponse extends EventShiftResponse {
  * @typedef {object} PaginatedEventShiftResponse
  * @property {PaginationResult} _pagination.required - Pagination metadata
  * @property {Array<EventShiftResponse>} records.required - Returned event shifts
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 export interface PaginatedEventShiftResponse {
   _pagination: PaginationResult,
@@ -82,6 +88,7 @@ export interface PaginatedEventShiftResponse {
 /**
  * @typedef {allOf|BaseEventResponse} EventResponse
  * @property {Array<EventInShiftResponse>} shifts.required - Shifts for this event
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 export interface EventResponse extends BaseEventResponse {
   shifts: EventInShiftResponse[],
@@ -92,6 +99,7 @@ export interface EventResponse extends BaseEventResponse {
  * @property {BaseUserResponse} user.required - Participant that filled in their availability
  * @property {string} availability - Filled in availability per slot.
  * @property {boolean} selected.required - Whether this user is selected for the shift in the event
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 export interface BaseEventAnswerResponse {
   user: BaseUserResponse,
@@ -103,6 +111,7 @@ export interface BaseEventAnswerResponse {
  * @typedef {object} PaginatedBaseEventResponse
  * @property {PaginationResult} _pagination.required - Pagination metadata
  * @property {Array<BaseEventResponse>} records.required - Returned borrel Schemas
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 export interface PaginatedBaseEventResponse {
   _pagination: PaginationResult,
@@ -112,6 +121,7 @@ export interface PaginatedBaseEventResponse {
 /**
  * @typedef {allOf|BaseUserResponse} EventPlanningSelectedCount
  * @property {integer} count.required - Number of times this user was selected for this shift
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 export interface EventPlanningSelectedCount extends BaseUserResponse {
   count: number;

--- a/src/entity/event/event-shift-answer.ts
+++ b/src/entity/event/event-shift-answer.ts
@@ -22,6 +22,7 @@
  * This is the module page of event-shift-answer.
  *
  * @module events
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 
 import {
@@ -48,6 +49,7 @@ export enum Availability {
  * during the related borrel.
  * @property {EventShift.model} shift - Shift that answers are related to.
  * @property {Event.model} event - Event that answers are related to
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 
 @Entity()

--- a/src/entity/event/event-shift.ts
+++ b/src/entity/event/event-shift.ts
@@ -22,6 +22,7 @@
  * This is the module page of event-shift.
  *
  * @module events
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 
 import {
@@ -34,6 +35,7 @@ import Role from '../rbac/role';
  * @typedef {BaseEntity} EventShift
  * @property {string} name - Name of the shift.
  * @property {boolean} default - Indicator whether the shift is a regular shift.
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 
 @Entity()

--- a/src/entity/event/event.ts
+++ b/src/entity/event/event.ts
@@ -21,6 +21,7 @@
 /**
  * This is the module page of event.
  *
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  * @module events
  * @mergeTarget
  */
@@ -45,6 +46,7 @@ export enum EventType {
  * @property {User.model} createdBy - Creator of the event.
  * @property {string} startDate - The starting date from which the banner should be shown.
  * @property {string} endDate - The end date from which the banner should no longer be shown.
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 
 @Entity()

--- a/src/mailer/messages/forgot-event-planning.ts
+++ b/src/mailer/messages/forgot-event-planning.ts
@@ -67,6 +67,9 @@ const mailContents: MailLanguageMap<ForgotEventPlanningOptions> = {
   [Language.ENGLISH]: forgotEventPlanningEnglish,
 };
 
+/**
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
+ */
 export default class ForgotEventPlanning extends MailMessage<ForgotEventPlanningOptions> {
   public constructor(options: ForgotEventPlanningOptions) {
     super(options, mailContents);

--- a/src/service/event-service.ts
+++ b/src/service/event-service.ts
@@ -103,6 +103,7 @@ export function parseEventFilterParameters(
  * @param req
  * @param partial - Whether all attributes are required or not
  * @param id
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  * @throws Error - validation failed
  */
 export async function parseUpdateEventRequestParameters(
@@ -149,6 +150,7 @@ export async function parseUpdateEventRequestParameters(
 
 /**
  * Wrapper for all Borrel-schema related logic.
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 export default class EventService {
   private static asBaseEventResponse(entity: Event): BaseEventResponse {

--- a/test/seed/event-seeder.ts
+++ b/test/seed/event-seeder.ts
@@ -26,6 +26,9 @@ import Event, { EventType } from '../../src/entity/event/event';
 import EventShiftAnswer, { Availability } from '../../src/entity/event/event-shift-answer';
 import AssignedRole from '../../src/entity/rbac/assigned-role';
 
+/**
+ * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
+ */
 export default class EventSeeder extends WithManager {
   /**
    * Seeds a default dataset of borrelSchemaShifts and stores them in the database


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
I have marked all event-related code as deprecated to the best of my abilities. I also added a comment in the deprecation that these deprecations can be removed from November 1st 2026 onwards (two years from now). If we have never moved this code to another project before that time, I assume it will never happen.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
Fixes https://github.com/GEWIS/sudosos-backend/issues/347.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Style _(Change that do not affect the functionality of the code)_
