### PR TITLE
chore: increase memory for docs:build

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "predocs:dev": "typedoc",
     "typedoc": "typedoc",
     "docs:dev": "vitepress dev docs",
-    "docs:build": "NODE_OPTIONS=--max-old-space-size=8192 vitepress build docs --mode production",
+    "docs:build": "NODE_OPTIONS=--max-old-space-size=12288 vitepress build docs --mode production",
     "docs:preview": "vitepress preview docs"
   },
   "author": "",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
It is a known issue that vitepress needs a lot of memory, and my initial guess of 8 was not enough it looks like:
https://github.com/GEWIS/sudosos-backend/actions/runs/11384654463/job/31672832304?pr=338

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- CI/CD _(Changes to the CI/CD configuration)_
