### PR TITLE
fix(docker): reduce size of image by about half

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN npm install
 COPY ./ ./
 RUN npm run build \
  && npm run swagger
+RUN npm ci --production
 
 # The target image that will be run
 FROM node:18-alpine as target
@@ -13,8 +14,7 @@ FROM node:18-alpine as target
 RUN apk add openssl
 
 WORKDIR /app
-COPY ./package.json ./package-lock.json ./
-RUN npm ci
+COPY --from=build --chown=node /app/node_modules /app/node_modules
 RUN npm install pm2 pm2-graceful-intercom -g
 RUN npm install -g typeorm
 ARG TYPEORM_USERNAME


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->
During the Ubuntu Summit I was lead down a rabbit hole of inspecting docker images. I noticed that the sudosos-backend could use some improvement.

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
I noticed that the npm ci still installed dev dependencies in the runtime container, so that was fixed. Furthermore when installing npm packages, it also adds to the cache. Meaning it used to have 2x the node_modules installed in the image. By installing in the build container and copying to the runtime container, we circumvent this issue.

![image](https://github.com/user-attachments/assets/42e37187-fa9f-4529-97e2-4908d2ec0620)
The build from 6 days ago is the current develop docker image, the docker image from 9 minutes ago is this the one that has the improvement. 

Here you can see the cache being added which is about the same size as the node_modules themself:
![image](https://github.com/user-attachments/assets/f14b77cb-6e4a-4911-ab1a-5a7ff276e2b9)

My improved image is currently running on develop (28-10-2024 10:53), it seems to work, only the pdf is broken, but pretty sure that has always been broken on develop?


## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- CI/CD _(Changes to the CI/CD configuration)_
