### PR TITLE
feat: exclude-own-transactions

### DIFF
--- a/src/controller/transaction-controller.ts
+++ b/src/controller/transaction-controller.ts
@@ -103,6 +103,7 @@ export default class TransactionController extends BaseController {
    * @param {integer} createdById.query - User that created selected transaction
    * @param {integer} toId.query - To-user for selected transactions
    * transactions. Requires ContainerId
+   * @param {integer} excludeById.query - Your own ID to not include in transactions
    * @param {integer} pointOfSaleId.query - Point of sale ID for selected transactions
    * @param {integer} productId.query - Product ID for selected transactions
    * @param {integer} productRevision.query - Product Revision for selected

--- a/src/service/transaction-service.ts
+++ b/src/service/transaction-service.ts
@@ -96,6 +96,7 @@ export interface TransactionFilterParameters {
   fromDate?: Date,
   tillDate?: Date,
   invoiceId?: number,
+  excludeById?: number,
 }
 
 export function parseGetTransactionsFilters(req: RequestWithToken): TransactionFilterParameters {
@@ -121,6 +122,7 @@ export function parseGetTransactionsFilters(req: RequestWithToken): TransactionF
     fromDate: asDate(req.query.fromDate),
     tillDate: asDate(req.query.tillDate),
     invoiceId: asNumber(req.query.invoiceId),
+    excludeById: asNumber(req.query.excludeById),
   };
 
   return filters;
@@ -571,6 +573,7 @@ export default class TransactionService extends WithManager {
 
     query.orderBy({ 'transaction.createdAt': 'DESC' });
 
+    if (p.excludeById) query.andWhere('createdById != :excludeById', { excludeById: p.excludeById });
     if (fromDate) query.andWhere('transaction.createdAt >= :fromDate', { fromDate: toMySQLString(fromDate) });
     if (tillDate) query.andWhere('transaction.createdAt < :tillDate', { tillDate: toMySQLString(tillDate) });
 

--- a/test/unit/service/transaction-service.ts
+++ b/test/unit/service/transaction-service.ts
@@ -686,6 +686,15 @@ describe('TransactionService', (): void => {
 
       expect(records.length).to.equal(0);
     });
+
+    it('should not return transactions createdBy given user', async () => {
+      const transaction = ctx.transactions[0];
+
+      const records = (await new TransactionService().getTransactions({ excludeById: transaction.createdBy.id })).records;
+      records.forEach((r) => {
+        expect(r.createdBy).to.not.eq(transaction.createdBy.id);
+      });
+    });
   });
 
   describe('Get all transactions involving a user', () => {


### PR DESCRIPTION
Added that you can assign your own id as a filter to exclude transactions created by yourself.
