### PR TITLE
ci: fix `cron` and `watch` command missing quote

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "out/index.js",
   "scripts": {
     "build": "tsc",
-    "watch": "nodemon --watch \"src/**\" --ext \"ts,json\" --exec \"ts-node src/index.ts",
-    "cron": "nodemon --watch \"src/**\" --ext \"ts,json\" --exec \"ts-node src/cron.ts",
+    "watch": "nodemon --watch \"src/**\" --ext \"ts,json\" --exec \"ts-node src/index.ts\"",
+    "cron": "nodemon --watch \"src/**\" --ext \"ts,json\" --exec \"ts-node src/cron.ts\"",
     "serve": "node out/src/index.js",
     "schema": "ts-node src/database/schema.ts",
     "seed": "ts-node src/database/seed.ts",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Because of this:

```
> sudosos-back-end@0.1.0 watch
> nodemon --watch "src/**" --ext "ts,json" --exec "ts-node src/index.ts

sh: 1: Syntax error: Unterminated quoted string
```

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- CI/CD _(Changes to the CI/CD configuration)_
