### PR TITLE
fix: product deletion propagation to unneeded containers

### DIFF
--- a/src/service/product-service.ts
+++ b/src/service/product-service.ts
@@ -349,7 +349,12 @@ export default class ProductService {
 
     const { containers } = productRevision;
     containers.forEach((c => c.products = c.products.filter((p) => p.productId !== productId)));
-    await this.executePropagation(containers);
+    // Make sure to filter out deleted and non-current containers
+    const current = containers
+      .filter((c) => c.container.deletedAt == null && c.revision === c.container.currentRevision)
+      .filter((c, index, self) => (
+        index === self.findIndex((c2) => c.container.id === c2.container.id)));
+    await this.executePropagation(current);
 
     await Product.softRemove(productRevision.product);
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
This filtering, which is present in the update product and container logic, was missing in the delete function. This caused deletions to be propagated to "burried" containers, resulting in immense amount of useless updates. 

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_