### PR TITLE
Fix  `getTransactionsForInvoice` returning invoiced transactions

### DIFF
--- a/src/controller/invoice-controller.ts
+++ b/src/controller/invoice-controller.ts
@@ -519,7 +519,7 @@ export default class InvoiceController extends BaseController {
     }
 
     try {
-      const transactions = await new InvoiceService().getTransactionsForInvoice({
+      const transactions = await new InvoiceService().getEligibleTransactions({
         forId,
         fromDate,
         tillDate,

--- a/test/unit/service/invoice-service.ts
+++ b/test/unit/service/invoice-service.ts
@@ -249,7 +249,7 @@ describe('InvoiceService', () => {
           );
           const total = transactionsAfterDate.total;
 
-          const transactions = await new InvoiceService().getTransactionsForInvoice({
+          const transactions = await new InvoiceService().getEligibleTransactions({
             forId: debtor.id,
             fromDate,
           });


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the title above. -->

# Description
Also changes the name to `getEligibleTransactions` since that describes the function better.

The function was used to ensure that a time range did not contain invoiced transaction, however since the big rework you are required to send all transaction ids anyhow, so this makes much more sense atm.

## Related issues/external references
#435 

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
