### PR TITLE
fix: balance cache invalidation on transaction creation

### DIFF
--- a/src/service/transaction-service.ts
+++ b/src/service/transaction-service.ts
@@ -667,12 +667,8 @@ export default class TransactionService extends WithManager {
 
     await transaction.save();
 
-    // save the transaction and invalidate user balance cache
-    const savedTransaction = await this.asTransactionResponse(transaction);
-    await TransactionService.invalidateBalanceCache(savedTransaction);
-
     // save transaction and return response
-    return savedTransaction;
+    return this.asTransactionResponse(transaction);
   }
 
   /**


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Currently, balance cache is cleared when a transaction is created/updated/ deleted for a user. However, balance cache should not be invalidated when creating a transaction.

Creating a transaction is an action forward; new balance is just the sum of balance cache + all new transactions for that user. Thus, no need to remove it. Invalidating it is also bad for performance, as balance has to be calculated on the fly until next balance cache calculation (cronjob).

This removes balance cache invalidation for transaction creations.

---

Here confirmation of the old behaviour:
![image](https://github.com/user-attachments/assets/4598995d-a556-4f05-a5fc-f1ab56db4ee7)
After creating a transaction:
![image](https://github.com/user-attachments/assets/27f53156-c9e9-4105-8d36-044352a2780d)


## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
GH-466

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_