### PR TITLE
feat: total-balances-sudosos

### DIFF
--- a/src/controller/balance-controller.ts
+++ b/src/controller/balance-controller.ts
@@ -71,6 +71,12 @@ export default class BalanceController extends BaseController {
           handler: this.getBalance.bind(this),
         },
       },
+      '/summary': {
+        GET: {
+          policy: async (req) => this.roleManager.can(req.token.roles, 'get', 'all', 'Balance', ['*']),
+          handler: this.calculateTotalBalances.bind(this),
+        },
+      },
     };
   }
 
@@ -176,6 +182,34 @@ export default class BalanceController extends BaseController {
     } catch (error) {
       const id = req?.params?.id ?? req.token.user.id;
       this.logger.error(`Could not get balance of user with id ${id}`, error);
+      res.status(500).json('Internal server error.');
+    }
+  }
+
+  /**
+   * GET /balances/summary
+   * @summary Get the calculated total balances in SudoSOS
+   * @operationId calculateTotalBalances
+   * @tags balance - Operations of balance controller
+   * @security JWT
+   * @param {string} date.query.required - The date for which to calculate the balance.
+   * @return {TotalBalanceResponse} 200 - The requested user's balance
+   * @return {string} 400 - Validation error
+   * @return {string} 404 - Could not calculate error
+   * @return {string} 500 - Internal server error
+   */
+  private async calculateTotalBalances(req: RequestWithToken, res: Response): Promise<void> {
+    try {
+      const date = asDate(req.query.date);
+
+      try {
+        const balances = await new BalanceService().calculateTotalBalances(date);
+        res.json(balances);
+      } catch (error) {
+        res.status(404).json('Could not calculate the total balances');
+      }
+    } catch (error) {
+      this.logger.error('Could not calculate the total balances', error);
       res.status(500).json('Internal server error.');
     }
   }

--- a/src/controller/response/balance-response.ts
+++ b/src/controller/response/balance-response.ts
@@ -63,6 +63,32 @@ export default interface BalanceResponse extends BaseUserResponse {
 }
 
 /**
+ * @typedef {object} UserTypeTotalBalanceResponse
+ * @property {string} userType - The user type
+ * @property {DineroObjectResponse} totalPositive - The total amount of positive balance for this user type
+ * @property {DineroObjectResponse} totalNegative - The total amount of negative balance for this uer type
+ */
+export interface UserTypeTotalBalanceResponse {
+  userType: UserType,
+  totalPositive: DineroObjectResponse,
+  totalNegative: DineroObjectResponse,
+}
+
+/**
+ * @typedef {object} TotalBalanceResponse
+ * @property {string} date - Date at which this total balance was calculated
+ * @property {number} totalPositive - The total amount of positive balance in SudoSOS
+ * @property {number} totalNegative - The total amount of negative balance in SudoSOS
+ * @property {UserTypeTotalBalanceResponse} userTypeBalances - The total balances for the different user types
+ */
+export interface TotalBalanceResponse {
+  date: string;
+  totalPositive: DineroObjectResponse;
+  totalNegative: DineroObjectResponse;
+  userTypeBalances: UserTypeTotalBalanceResponse[];
+}
+
+/**
  * @typedef {object} PaginatedBalanceResponse
  * @property {PaginationResult} _pagination - Pagination metadata
  * @property {Array<BalanceResponse>} records - Returned balance responses

--- a/src/controller/response/balance-response.ts
+++ b/src/controller/response/balance-response.ts
@@ -76,10 +76,10 @@ export interface UserTypeTotalBalanceResponse {
 
 /**
  * @typedef {object} TotalBalanceResponse
- * @property {string} date - Date at which this total balance was calculated
- * @property {number} totalPositive - The total amount of positive balance in SudoSOS
- * @property {number} totalNegative - The total amount of negative balance in SudoSOS
- * @property {UserTypeTotalBalanceResponse} userTypeBalances - The total balances for the different user types
+ * @property {string} date.required - Date at which this total balance was calculated
+ * @property {number} totalPositive.required - The total amount of positive balance in SudoSOS
+ * @property {number} totalNegative.required - The total amount of negative balance in SudoSOS
+ * @property {UserTypeTotalBalanceResponse} userTypeBalances.required - The total balances for the different user types
  */
 export interface TotalBalanceResponse {
   date: string;

--- a/src/controller/response/balance-response.ts
+++ b/src/controller/response/balance-response.ts
@@ -64,9 +64,9 @@ export default interface BalanceResponse extends BaseUserResponse {
 
 /**
  * @typedef {object} UserTypeTotalBalanceResponse
- * @property {string} userType - The user type
- * @property {DineroObjectResponse} totalPositive - The total amount of positive balance for this user type
- * @property {DineroObjectResponse} totalNegative - The total amount of negative balance for this uer type
+ * @property {string} userType.required - The user type
+ * @property {DineroObjectResponse} totalPositive.required - The total amount of positive balance for this user type
+ * @property {DineroObjectResponse} totalNegative.required - The total amount of negative balance for this uer type
  */
 export interface UserTypeTotalBalanceResponse {
   userType: UserType,


### PR DESCRIPTION
Added a balance service function to get a added up value of positive and negative balances. you can also decide to do this for all users or only for users that can top up (member and local)

# Description
This should decrease the time it takes to calculate this as in the frontend this now takes +- 14 seconds.

## Types of changes
- New feature _(non-breaking change which adds functionality)_
- Breaking change _(fix or feature that would cause existing functionality to change)_
