### PR TITLE
Remove pushing of docker image to GitHub

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -34,22 +34,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Registry (GitHub)
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push to GitHub Container Registry
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: ghcr.io/gewis/${{ vars.DOCKER_TAG }}:${{ steps.meta.outputs.version }}
-          cache-from: type=gha
-
       - name: Login to SudoSOS Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Seems to work behind the WAF, and pushing to GitHub is "extra". Not sure yet what to do with the images we have on github, I suggest removing them so there is no mistake which one is leading.


## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

- CI/CD _(Changes to the CI/CD configuration)_
