### PR TITLE
feat: add query param to fetch inactive user balances

### DIFF
--- a/src/controller/balance-controller.ts
+++ b/src/controller/balance-controller.ts
@@ -117,6 +117,7 @@ export default class BalanceController extends BaseController {
    * @param {string} orderBy.query - Column to order balance by - eg: id,amount
    * @param {string} orderDirection.query - enum:ASC,DESC - Order direction
    * @param {boolean} allowDeleted.query - Whether to include deleted users
+   * @param {boolean} inactive.query - Whether to only return inactive users
    * @param {integer} take.query - How many transactions the endpoint should return
    * @param {integer} skip.query - How many transactions should be skipped (for pagination)
    * @return {PaginatedBalanceResponse} 200 - The requested user's balance
@@ -141,6 +142,7 @@ export default class BalanceController extends BaseController {
         orderBy: asBalanceOrderColumn(req.query.orderBy),
         orderDirection: asOrderingDirection(req.query.orderDirection),
         allowDeleted: asBoolean(req.query.allowDeleted),
+        inactive: asBoolean(req.query.inactive),
       };
       const pagination = parseRequestPagination(req);
       take = pagination.take;

--- a/src/service/balance-service.ts
+++ b/src/service/balance-service.ts
@@ -61,6 +61,7 @@ export interface GetBalanceParameters extends UpdateBalanceParameters {
   orderBy?: BalanceOrderColumn;
   orderDirection?: OrderingDirection;
   allowDeleted?: boolean;
+  inactive?: boolean;
 }
 
 
@@ -215,11 +216,12 @@ export default class BalanceService extends WithManager {
    * @param orderDirection column to order result at
    * @param orderBy order direction
    * @param allowDeleted allow balances of deleted users to be returned
+   * @param inactive only return inactive users
    * @param pagination pagination options
    * @returns the current balance of a user
    */
   public async getBalances({
-    ids, date, minBalance, maxBalance, hasFine, minFine, maxFine, userTypes, orderDirection, orderBy, allowDeleted,
+    ids, date, minBalance, maxBalance, hasFine, minFine, maxFine, userTypes, orderDirection, orderBy, allowDeleted, inactive,
   }: GetBalanceParameters, pagination: PaginationParameters = {}): Promise<PaginatedBalanceResponse> {
     // Return the empty response if request has no ids.
     if (ids?.length === 0) {
@@ -356,6 +358,7 @@ export default class BalanceService extends WithManager {
     if (maxFine !== undefined) query += `and f.fine <= ${maxFine.getAmount()} `;
     if (userTypes !== undefined) query += `and u.type in (${userTypes.map((t) => `"${t}"`).join(',')}) `;
     if (!allowDeleted) query += 'and u.deleted = 0 ';
+    if (inactive) query += 'and u.active = 0 ';
 
     if (orderBy !== undefined) query += `order by ${orderBy} ${orderDirection ?? ''} `;
 

--- a/test/unit/service/balance-service.ts
+++ b/test/unit/service/balance-service.ts
@@ -340,6 +340,17 @@ describe('BalanceService', (): void => {
         expect(balanceIds).to.include(u.id);
       });
     });
+    it('should return all inactive users', async () => {
+      const users = ctx.users.filter((u) => u.active === false);
+      const balances = await new BalanceService().getBalances({ inactive: true });
+      expect(balances.records.length).to.be.greaterThan(0);
+      expect(balances.records.length).to.equal(users.length);
+
+      const userIds = users.map((u) => u.id);
+      balances.records.forEach((bal) => {
+        expect(userIds).to.include(bal.id);
+      });
+    });
     it('should return all users with certain user type from set of types', async () => {
       const userTypes = [UserType.LOCAL_USER, UserType.LOCAL_ADMIN];
       const users = ctx.users.filter((u) => userTypes.includes(u.type));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Adds query param to `getBalances` to fetch inactive users' balances.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
- New feature _(non-breaking change which adds functionality)_
