### PR TITLE
feature: send maintenance status on ws connection

### DIFF
--- a/src/service/websocket-service.ts
+++ b/src/service/websocket-service.ts
@@ -67,8 +67,12 @@ export default class WebSocketService {
         void client.join(room);
 
         if (room === SYSTEM_ROOM) {
-          const maintenanceMode = await ServerSettingsStore.getInstance().getSettingFromDatabase('maintenanceMode') as boolean;
-          WebSocketService.sendMaintenanceMode(maintenanceMode);
+          try {
+            const maintenanceMode = await ServerSettingsStore.getInstance().getSettingFromDatabase('maintenanceMode') as boolean;
+            WebSocketService.sendMaintenanceMode(maintenanceMode);
+          } catch (error) {
+            this.logger.error(`Failed to retrieve maintenance mode setting: ${error}`);
+          }
         }
       });
 
@@ -80,7 +84,7 @@ export default class WebSocketService {
   }
 
   public static sendMaintenanceMode(enabled: boolean): void {
-    this.logger.info('Set maintenance mode to ' + enabled);
+    this.logger.info(`Sent maintenance mode ${enabled} to ${SYSTEM_ROOM}`);
     this.io.sockets.in(SYSTEM_ROOM).emit('maintenance-mode', enabled);
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Send the current maintenance status when a client connects to the `system` room on the WS.
This is so that if the POS gets refreshed when it is in maintenance, the overlay gets shown again.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_