### PR TITLE
feat: add `createdAt` filter params for write-offs

### DIFF
--- a/src/controller/write-off-controller.ts
+++ b/src/controller/write-off-controller.ts
@@ -78,6 +78,8 @@ export default class WriteOffController extends BaseController {
    * @param {integer} amount.query - Filter on the amount of the write-off
    * @param {integer} take.query - Number of write-offs to return
    * @param {integer} skip.query - Number of write-offs to skip
+   * @param {string} fromDate.query - Start date for selected write-offs (inclusive)
+   * @param {string} tillDate.query - End date for selected write-offs (exclusive)
    * @return {PaginatedWriteOffResponse} 200 - All existing write-offs
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error

--- a/src/service/write-off-service.ts
+++ b/src/service/write-off-service.ts
@@ -45,7 +45,7 @@ import BalanceService from './balance-service';
 import DineroTransformer from '../entity/transformer/dinero-transformer';
 import UserService from './user-service';
 import { RequestWithToken } from '../middleware/token-middleware';
-import { asNumber } from '../helpers/validators';
+import { asDate, asNumber } from '../helpers/validators';
 import VatGroup from '../entity/vat-group';
 import ServerSettingsStore from '../server-settings/server-settings-store';
 import Transfer from '../entity/transactions/transfer';
@@ -61,12 +61,22 @@ export interface WriteOffFilterParameters {
    * Filter based on write-off id.
    */
   writeOffId?: number;
+  /**
+   * Filter based on the from date.
+   */
+  fromDate?: Date;
+  /**
+   * Filter based on the till date.
+   */
+  tillDate?: Date;
 }
 
 export function parseWriteOffFilterParameters(req: RequestWithToken): WriteOffFilterParameters {
   return {
     writeOffId: asNumber(req.query.writeOffId),
     toId: asNumber(req.query.toId),
+    fromDate: asDate(req.query.fromDate),
+    tillDate: asDate(req.query.tillDate),
   };
 }
 export default class WriteOffService extends WithManager {
@@ -186,6 +196,7 @@ export default class WriteOffService extends WithManager {
 
     let where: FindOptionsWhere<ContainerRevision> = {
       ...QueryFilter.createFilterWhereClause(filterMapping, params),
+      createdAt: QueryFilter.createFilterWhereDate(params.fromDate, params.tillDate),
     };
 
     const options: FindManyOptions<WriteOff> = {

--- a/test/unit/controller/write-off-controller.ts
+++ b/test/unit/controller/write-off-controller.ts
@@ -125,16 +125,18 @@ describe('WriteOffController', () => {
       expect(res.status).to.equal(403);
     });
     it('should filter by fromDate', async () => {
-      const fromDate = new Date(ctx.writeOffs[1].createdAt).getTime();
+      const onemin = 60000;
+      const f = new Date(new Date(ctx.writeOffs[1].createdAt).getTime() - onemin);
       const res = await request(ctx.app)
         .get('/writeoffs')
         .set('Authorization', `Bearer ${ctx.adminToken}`)
-        .query({ fromDate: ctx.writeOffs[1].createdAt.toISOString() });
+        .query({ fromDate: f.toISOString() });
       expect(res.status).to.equal(200);
       const records = res.body.records as WriteOffResponse[];
       expect(records.length).to.be.greaterThan(0);
       records.forEach(r => {
-        expect(new Date(r.createdAt).getTime()).to.be.at.least(fromDate);
+        const created = new Date(r.createdAt).getTime();
+        expect(created).to.be.at.least(f.getTime());
       });
     });
 
@@ -148,26 +150,11 @@ describe('WriteOffController', () => {
       const records = res.body.records as WriteOffResponse[];
       expect(records.length).to.be.greaterThan(0);
       records.forEach(r => {
-        expect(new Date(r.createdAt).getTime()).to.be.at.most(tillDate);
+        const created = new Date(r.createdAt).getTime();
+        expect(created).to.be.at.most(tillDate);
       });
     });
 
-    it('should return 400 for invalid fromDate', async () => {
-      const res = await request(ctx.app)
-        .get('/writeoffs')
-        .set('Authorization', `Bearer ${ctx.adminToken}`)
-        .query({ fromDate: 'not a date' });
-      expect(res.status).to.equal(400);
-    });
-
-    it('should return 400 for invalid tillDate', async () => {
-      const res = await request(ctx.app)
-        .get('/writeoffs')
-        .set('Authorization', `Bearer ${ctx.adminToken}`)
-        .query({ tillDate: 'not a date' });
-      expect(res.status).to.equal(400);
-    });
-    
     it('should filter by both fromDate and tillDate', async () => {
       const onemin = 60000;
       const f = new Date(new Date(ctx.writeOffs[1].createdAt).getTime() - onemin);

--- a/test/unit/controller/write-off-controller.ts
+++ b/test/unit/controller/write-off-controller.ts
@@ -124,6 +124,73 @@ describe('WriteOffController', () => {
         .set('Authorization', `Bearer ${ctx.token}`);
       expect(res.status).to.equal(403);
     });
+    it('should filter by fromDate', async () => {
+      const fromDate = new Date(ctx.writeOffs[1].createdAt).getTime();
+      const res = await request(ctx.app)
+        .get('/writeoffs')
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .query({ fromDate: ctx.writeOffs[1].createdAt.toISOString() });
+      expect(res.status).to.equal(200);
+      const records = res.body.records as WriteOffResponse[];
+      expect(records.length).to.be.greaterThan(0);
+      records.forEach(r => {
+        expect(new Date(r.createdAt).getTime()).to.be.at.least(fromDate);
+      });
+    });
+
+    it('should filter by tillDate', async () => {
+      const tillDate = new Date(ctx.writeOffs[1].createdAt).getTime();
+      const res = await request(ctx.app)
+        .get('/writeoffs')
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .query({ tillDate: ctx.writeOffs[1].createdAt.toISOString() });
+      expect(res.status).to.equal(200);
+      const records = res.body.records as WriteOffResponse[];
+      expect(records.length).to.be.greaterThan(0);
+      records.forEach(r => {
+        expect(new Date(r.createdAt).getTime()).to.be.at.most(tillDate);
+      });
+    });
+
+    it('should return 400 for invalid fromDate', async () => {
+      const res = await request(ctx.app)
+        .get('/writeoffs')
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .query({ fromDate: 'not a date' });
+      expect(res.status).to.equal(400);
+    });
+
+    it('should return 400 for invalid tillDate', async () => {
+      const res = await request(ctx.app)
+        .get('/writeoffs')
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .query({ tillDate: 'not a date' });
+      expect(res.status).to.equal(400);
+    });
+    
+    it('should filter by both fromDate and tillDate', async () => {
+      const onemin = 60000;
+      const f = new Date(new Date(ctx.writeOffs[1].createdAt).getTime() - onemin);
+      const t = new Date(new Date(ctx.writeOffs[ctx.writeOffs.length - 1].createdAt).getTime() + onemin);
+
+      const res = await request(ctx.app)
+        .get('/writeoffs')
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .query({
+          fromDate: f.toISOString(),
+          tillDate: t.toISOString(),
+        });
+
+      expect(res.status).to.equal(200);
+      const records = res.body.records as WriteOffResponse[];
+      expect(records.length).to.be.greaterThan(0);
+      records.forEach(r => {
+        const created = new Date(r.createdAt).getTime();
+        expect(created).to.be.at.least(f.getTime());
+        expect(created).to.be.at.most(new Date(t).getTime());
+      });
+    });
+
   });
   describe('GET /writeoffs/:id', () => {
     it('should return correct model', async () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Simple feature to add createdAt as query params for `GET /write-offs`. Useful with the idea of working on a financial overview later (e.g., get all write-offs in a fiscal year).

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
- New feature _(non-breaking change which adds functionality)_
