### PR TITLE
fix: remove invoice from local user types

### DIFF
--- a/src/entity/user/user.ts
+++ b/src/entity/user/user.ts
@@ -53,7 +53,7 @@ export enum UserType {
  * All user types that should be allowed to have a local password.
  */
 export const LocalUserTypes = [
-  UserType.LOCAL_USER, UserType.LOCAL_ADMIN, UserType.INVOICE,
+  UserType.LOCAL_USER, UserType.LOCAL_ADMIN,
 ];
 
 /**

--- a/test/unit/service/user-service.ts
+++ b/test/unit/service/user-service.ts
@@ -1,0 +1,104 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+import { describe } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { DataSource } from 'typeorm';
+import UserService from '../../../src/service/user-service';
+import { LocalUserTypes } from '../../../src/entity/user/user';
+import WelcomeWithReset from '../../../src/mailer/messages/welcome-with-reset';
+import WelcomeToSudosos from '../../../src/mailer/messages/welcome-to-sudosos';
+import Mailer from '../../../src/mailer';
+import AuthenticationService from '../../../src/service/authentication-service';
+import Database from '../../../src/database/database';
+import { truncateAllTables } from '../../setup';
+import { finishTestDB } from '../../helpers/test-helpers';
+
+describe('UserService', async (): Promise<void> => {
+  let ctx: {
+    connection: DataSource
+  };
+  let sendStub: sinon.SinonStub;
+  let createResetTokenStub: sinon.SinonStub;
+
+  before(async () => {
+    const connection = await Database.initialize();
+    await truncateAllTables(connection);
+
+    ctx = { connection };
+  });
+
+  beforeEach(() => {
+    // Setup mailer stub
+    sendStub = sinon.stub().resolves();
+    sinon.stub(Mailer, 'getInstance').returns({ send: sendStub } as any);
+
+    // Setup authentication service stub
+    createResetTokenStub = sinon.stub(AuthenticationService.prototype, 'createResetToken')
+      .resolves({ token: 'reset-token' } as any);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  after(async () => {
+    await finishTestDB(ctx.connection);
+  });
+
+  describe('createUser', () => {
+    it('should send WelcomeWithReset for local user types', async () => {
+      const localType = LocalUserTypes[0];
+      const result = await UserService.createUser({
+        type: localType,
+        email: 'test@local.com',
+        firstName: 'Test',
+        lastName: 'User',
+      } as any);
+
+      expect(result).to.not.be.undefined;
+      expect(sendStub.calledOnce).to.be.true;
+
+      const [user, message] = sendStub.getCall(0).args;
+      expect(user.email).to.equal('test@local.com');
+      expect(message).to.be.instanceOf(WelcomeWithReset);
+      expect(createResetTokenStub.calledOnce).to.be.true;
+    });
+
+    it('should send WelcomeToSudosos for non-local user types', async () => {
+      // Use a valid non-local user type
+      const nonLocalType = 'NON_LOCAL_USER_TYPE';
+      const result = await UserService.createUser({
+        type: nonLocalType,
+        email: 'test@nonlocal.com',
+        firstName: 'Test',
+        lastName: 'User',
+      } as any);
+
+      expect(result).to.not.be.undefined;
+      expect(sendStub.calledOnce).to.be.true;
+
+      const [user, message] = sendStub.getCall(0).args;
+      expect(user.email).to.equal('test@nonlocal.com');
+      expect(message).to.be.instanceOf(WelcomeToSudosos);
+      expect(createResetTokenStub.called).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
The changes in this PR remove the `INVOICE` account type from the `LocaluserTypes` list.
This makes it so that no reset password mail is sent out the the associated email.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
https://github.com/GEWIS/sudosos-backend/issues/549

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
