### PR TITLE
feat: add deleted flag for calculateAllBalances

### DIFF
--- a/src/controller/balance-controller.ts
+++ b/src/controller/balance-controller.ts
@@ -195,6 +195,7 @@ export default class BalanceController extends BaseController {
    * @tags balance - Operations of balance controller
    * @security JWT
    * @param {string} date.query.required - The date for which to calculate the balance.
+   * @param {boolean} allowDeleted.query - Whether to include deleted users
    * @return {TotalBalanceResponse} 200 - The requested user's balance
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
@@ -202,8 +203,9 @@ export default class BalanceController extends BaseController {
   private async calculateTotalBalances(req: RequestWithToken, res: Response): Promise<void> {
     try {
       const date = asDate(req.query.date);
+      const allowDeleted = asBoolean(req.query.allowDeleted);
 
-      const balances = await new BalanceService().calculateTotalBalances(date);
+      const balances = await new BalanceService().calculateTotalBalances(date, allowDeleted);
       res.json(balances);
     } catch (error) {
       this.logger.error('Could not calculate the total balances', error);

--- a/src/service/balance-service.ts
+++ b/src/service/balance-service.ts
@@ -394,12 +394,13 @@ export default class BalanceService extends WithManager {
   /**
    * Get the total balance of SudoSOS and
    * @param date Date to check the balances for
+   * @param allowDeleted allow balances of deleted users to be returned
    */
-  public async calculateTotalBalances(date: Date): Promise<TotalBalanceResponse> {
+  public async calculateTotalBalances(date: Date, allowDeleted?: boolean): Promise<TotalBalanceResponse> {
     const posBalanceRes = (await this.getBalances(
-      { date, minBalance: DineroTransformer.Instance.from(0) })).records;
+      { date, minBalance: DineroTransformer.Instance.from(0), allowDeleted })).records;
     const negBalanceRes = (await this.getBalances(
-      { date, maxBalance: DineroTransformer.Instance.from(0) })).records;
+      { date, maxBalance: DineroTransformer.Instance.from(0), allowDeleted })).records;
 
     const totalPos =  BalanceService.calculateTotal(posBalanceRes);
     const totalNeg = BalanceService.calculateTotal(negBalanceRes);
@@ -413,9 +414,9 @@ export default class BalanceService extends WithManager {
 
     for (const [index, type] of userTypes.entries()) {
       promises.push(this.getBalances(
-        { userTypes: [type], date, minBalance: DineroTransformer.Instance.from(0) })
+        { userTypes: [type], date, minBalance: DineroTransformer.Instance.from(0), allowDeleted })
         .then((r) => typedPosBalance[index] = r.records));
-      promises.push(this.getBalances({ userTypes: [type], date, maxBalance: DineroTransformer.Instance.from(0) })
+      promises.push(this.getBalances({ userTypes: [type], date, maxBalance: DineroTransformer.Instance.from(0), allowDeleted })
         .then((r) => typedNegBalance[index] = r.records));
     }
 

--- a/test/unit/service/balance-service.ts
+++ b/test/unit/service/balance-service.ts
@@ -864,4 +864,28 @@ describe('BalanceService', (): void => {
       });
     });
   });
+  it('should return the total balances including deleted users', async () => {
+    const date = new Date('2021-01-01');
+    await new BalanceService().clearBalanceCache();
+
+    const allBalances = await new BalanceService().getBalances({
+      date,
+      allowDeleted: true,
+    });
+
+    const { positiveBalances, negativeBalances } = allBalances.records
+      .reduce((acc, balance) => {
+        const amount = balance.amount.amount;
+        if (amount > 0) {
+          acc.positiveBalances += amount;
+        } else {
+          acc.negativeBalances += amount;
+        }
+        return acc;
+      }, { positiveBalances: 0, negativeBalances: 0 });
+
+    const totalBalanceResponse = await new BalanceService().calculateTotalBalances(date, true);
+    expect(totalBalanceResponse.totalPositive.amount).to.eq(positiveBalances);
+    expect(totalBalanceResponse.totalNegative.amount).to.eq(negativeBalances);
+  });
 });


### PR DESCRIPTION
Adds a allowDeleted flag to the calculateAllBalances to include deleted users in the calculation
