### PR TITLE
Fix UserDebtNotification not triggered when first product in multi-item transaction does not cause debt

### DIFF
--- a/test/unit/subscribe/transaction-subscriber.ts
+++ b/test/unit/subscribe/transaction-subscriber.ts
@@ -46,8 +46,8 @@ import {
 } from '../../seed';
 import { rootStubs } from '../../root-hooks';
 import { SubTransactionRequest } from '../../../src/controller/request/transaction-request';
-import {inUserContext, UserFactory} from "../../helpers/user-factory";
-import UserDebtNotification from "../../../src/mailer/messages/user-debt-notification";
+import { inUserContext, UserFactory } from '../../helpers/user-factory';
+import UserDebtNotification from '../../../src/mailer/messages/user-debt-notification';
 import { DineroObjectRequest } from '../../../src/controller/request/dinero-request';
 
 describe('TransactionSubscriber', () => {
@@ -267,7 +267,7 @@ describe('TransactionSubscriber', () => {
       expect(sendMailFake).to.not.be.called;
     });
 
-    it('should send an email if someone goes in debt after a multi-item transaction (issue #596)', async () => {
+    it('should send an email if someone goes in debt after a multi-item transaction', async () => {
 
       const pos = ctx.pointOfSales[0];
       const container = ctx.containers[0];
@@ -293,7 +293,6 @@ describe('TransactionSubscriber', () => {
         
         // test case goes here
         const balance = await new BalanceService().getBalance(u.id);
-        const priceCents = pricePerItemDinero.getAmount();
         const balanceCents = balance.amount.amount;
 
         expect(balanceCents).to.be.at.least(0);        
@@ -301,9 +300,8 @@ describe('TransactionSubscriber', () => {
         const amount = 1;
 
         const pricePerItem: DineroObjectRequest = pricePerItemDinero.toObject();
-        const totalPriceInclVat: DineroObjectRequest = pricePerItemDinero.multiply(amount).toObject();
+        const totalPriceInclVat: DineroObjectRequest = pricePerItemDinero.multiply(2).toObject();
 
-        expect(amount).to.be.at.least(1);
 
         // Stub BalanceService.getBalance so the subscriber sees the pre-transaction snapshot
         // This exploits the poor transaction-subscriber logic which only checks the first row


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

This code fixes the bug presented in issue #596 that caused a user to not receive an email notifying them of entering into debt if this happens following a multi-item transaction where the first row of the transaction would not have put the user into debt and the BalanceService does not experience an immediate update to the balance of the user before the next transaction event in the multi-item transaction occurs.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

Issue #596 

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
