### PR TITLE
feat: transaction notifications

### DIFF
--- a/src/controller/request/user-request.ts
+++ b/src/controller/request/user-request.ts
@@ -24,7 +24,7 @@
  * @module users
  */
 
-import { UserType } from '../../entity/user/user';
+import { TransactionReceiptsOption, UserType } from '../../entity/user/user';
 
 export default interface BaseUserRequest {
   firstName: string;
@@ -61,12 +61,14 @@ export interface CreateUserRequest extends BaseUserRequest {
  * @property {boolean} active
  * @property {boolean} extensiveDataProcessing
  * @property {boolean} inactiveNotificationSend
+ * @property {string} transactionReceipts
  */
 export interface UpdateUserRequest extends Partial<BaseUserRequest> {
   active?: boolean;
   deleted?: boolean;
   extensiveDataProcessing?: boolean
   inactiveNotificationSend?: boolean
+  transactionReceipts?: TransactionReceiptsOption;
 }
 
 

--- a/src/controller/response/user-response.ts
+++ b/src/controller/response/user-response.ts
@@ -51,6 +51,7 @@ export interface BaseUserResponse extends BaseResponse {
  * user can be used (non-anonymously) for more data science!
  * @property {boolean} ofAge - Whether someone is old enough to drink beer
  * @property {boolean} canGoIntoDebt.required - Whether this user can get a negative balance
+ * @property {string} transactionReceipts - What transactions notifications the user wants to receive
  */
 export interface UserResponse extends BaseUserResponse {
   active: boolean;
@@ -61,6 +62,7 @@ export interface UserResponse extends BaseUserResponse {
   extensiveDataProcessing?: boolean;
   ofAge?: boolean;
   canGoIntoDebt: boolean;
+  transactionReceipts?: string;
 }
 
 

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -96,6 +96,7 @@ import InactiveAdministrativeCost from '../entity/transactions/inactive-administ
 import {
   UserAdministrativeCost1761845457283,
 } from '../migrations/1761845457283-user-administrative-cost';
+import { TransactionNotification1762861469829 } from '../migrations/1762861469829-transaction-notification-migrations';
 
 // We need to load the dotenv to prevent the env from being undefined.
 dotenv.config();
@@ -124,6 +125,7 @@ const options: DataSourceOptions = {
     MemberAuthenticator1761324427011,
     AddOrganMembershipIndex1761328648026,
     UserAdministrativeCost1761845457283,
+    TransactionNotification1762861469829,
   ],
   extra: {
     authPlugins: {

--- a/src/entity/user/user.ts
+++ b/src/entity/user/user.ts
@@ -50,6 +50,15 @@ export enum UserType {
 }
 
 /**
+ * All choices a user can make for their receipts
+ */
+export enum TransactionReceiptsOption {
+  NEVER = 'NEVER',
+  CHARGEDBYOTHERS = 'CHARGEDBYOTHERS',
+  ALWAYS = 'ALWAYS',
+}
+
+/**
  * All user types that should be allowed to have a local password.
  */
 export const LocalUserTypes = [
@@ -88,6 +97,7 @@ export const EligibleInactiveUsers: UserType[] = [
  * @property {string} email - The email of the user.
  * @property {boolean} deleted - Whether the user was deleted. Defaults to false.
  * @property {string} type.required - The type of user.
+ * @property {string} transactionReceipt.required - Which transaction receipts a user would like to receive
  */
 @Entity()
 export default class User extends BaseEntity {
@@ -156,6 +166,12 @@ export default class User extends BaseEntity {
     default: false,
   })
   public inactiveNotificationSend: boolean;
+
+  @Column({
+    nullable: false,
+    default: TransactionReceiptsOption.NEVER,
+  })
+  public transactionReceipts: TransactionReceiptsOption;
 
   @OneToOne(() => UserFineGroup, {
     nullable: true,

--- a/src/helpers/revision-to-response.ts
+++ b/src/helpers/revision-to-response.ts
@@ -123,6 +123,7 @@ export function parseUserToResponse(user: User, timestamps = false): UserRespons
     extensiveDataProcessing: user.extensiveDataProcessing,
     ofAge: user.ofAge,
     canGoIntoDebt: user.canGoIntoDebt,
+    transactionReceipts: user.transactionReceipts,
   };
 }
 
@@ -142,6 +143,7 @@ export interface RawUser {
   acceptedToS: TermsOfServiceStatus,
   extensiveDataProcessing: number,
   canGoIntoDebt: number,
+  transactionReceipts: string,
 }
 
 /**
@@ -165,6 +167,7 @@ export function parseRawUserToResponse(user: RawUser, timestamps = false): UserR
     extensiveDataProcessing: user.extensiveDataProcessing === 1,
     ofAge: user.ofAge === 1,
     canGoIntoDebt: user.canGoIntoDebt === 1,
+    transactionReceipts: user.transactionReceipts,
   };
 }
 

--- a/src/mailer/messages/transaction-notification.ts
+++ b/src/mailer/messages/transaction-notification.ts
@@ -1,0 +1,164 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+import { TransactionResponse } from '../../controller/response/transaction-response';
+import Dinero from 'dinero.js';
+import MailContentBuilder from './mail-content-builder';
+import MailMessage, { Language, MailLanguageMap } from '../mail-message';
+import { DineroObjectResponse } from '../../controller/response/dinero-response';
+
+/**
+ * This is the module page of the transaction notification.
+ *
+ * @module internal/mailer
+ */
+
+// We make it an type to use Dinero itself for declarations
+type DineroObject = Dinero.Dinero;
+
+interface TransactionNotificationOptions {
+  transaction: TransactionResponse;
+  balance: DineroObject;
+}
+
+const formatAmount = (dineroResponse: DineroObjectResponse): string => {
+  const dineroObject = Dinero({
+    amount: dineroResponse.amount,
+    currency: dineroResponse.currency,
+    precision: dineroResponse.precision,
+  });
+  return dineroObject.toFormat();
+};
+
+const tableBuilder = (transaction: TransactionResponse): string => {
+  let htmlString = "<table style='width:100%;'> " +
+        "<tr><th style='width:20%;'>Quantity</th><th style='width:60%;'>Product</th><th style='width:20%;'>Total Price</th></tr>";
+
+  const subTransactionRows = transaction.subTransactions.flatMap(s => s.subTransactionRows);
+
+  for (const subRow of subTransactionRows) {
+    const name = subRow.product.name;
+
+    const formattedProductPrice = formatAmount(subRow.product.priceInclVat);
+    const formattedTotalPrice = formatAmount(subRow.totalPriceInclVat);
+
+    const quantity = subRow.amount;
+
+    htmlString += `
+        <tr><td>${quantity}</td>
+        <td>${name} for ${formattedProductPrice} each</td>
+        <td>${formattedTotalPrice}</td></tr>`;
+  }
+
+  htmlString += '</table>';
+  return htmlString;
+};
+
+export const purchaseType = (
+  t: TransactionResponse,
+  lang: 'en' | 'nl',
+): string => {
+  const self = t.from.id === t.createdBy.id;
+
+  if (lang === 'nl') {
+    return self
+      ? 'je hebt deze aankoop zelf gedaan.'
+      : 'iemand anders heeft deze aankoop namens jou gedaan.';
+  }
+
+  return self
+    ? 'you made this purchase.'
+    : 'someone else made this purchase on your behalf.';
+};
+
+const balanceOrDebtDutch = (balance: DineroObject) => {return balance.getAmount() < 0 ? 'schuld' : 'saldo';};
+const balanceOrDebtEnglish = (balance: DineroObject) => {return balance.getAmount() < 0 ? 'debt' : 'balance';};
+
+const debtTextDutch = (balance: DineroObject) => {
+  return balance.getAmount() < 0
+    ? 'Let op: bij een negatief saldo worden er elke donderdag na de borrel extra kosten in rekening gebracht.'
+    : '';
+};
+
+const debtTextEnglish = (balance: DineroObject) => {
+  return balance.getAmount() < 0 ? 
+    'Please note that late fees are charged each Thursday after the social drink.' 
+    : '';
+};
+
+const transactionNotificationDutch = new MailContentBuilder<TransactionNotificationOptions>({
+  getHTML: (context) => `
+      Hierbij informeren we je dat ${purchaseType(context.transaction, 'nl')} Hieronder vind je de details: 
+      </p> ${tableBuilder(context.transaction)} 
+      <p>Het totaal bedraagt <strong>${formatAmount(context.transaction.totalPriceInclVat)}</strong>, 
+      wat je met een totaal ${balanceOrDebtDutch(context.balance)} van ${context.balance.toFormat()} achterlaat.</p> 
+      <p>${debtTextDutch(context.balance)}
+       Je kunt je saldo op elk moment verhogen via de SudoSOS website.</p>
+       <p>Als je vragen hebt over deze transactie, neem dan contact op via het e-mailadres in de footer van deze e-mail.</p> 
+    `,
+  getSubject: 'Jouw transactie bon',
+  getTitle: 'Transactie bon',
+  getText: (context) =>
+    `
+      Hierbij informeren we je dat ${purchaseType(context.transaction, 'nl')} Hieronder vind je de details: 
+       ${tableBuilder(context.transaction)} 
+      Het totaal bedraagt ${formatAmount(context.transaction.totalPriceInclVat)}, 
+      wat je met een totaal ${balanceOrDebtDutch(context.balance)} van ${context.balance.toFormat()} achterlaat.
+      ${debtTextDutch(context.balance)}
+       Je kunt je saldo op elk moment verhogen via de SudoSOS website.
+       Als je vragen hebt over deze transactie, neem dan contact op via het e-mailadres in de footer van deze e-mail.
+    `,
+});
+
+const transactionNotificationEnglish = new MailContentBuilder<TransactionNotificationOptions>({
+  getHTML: (context) => `
+          We love to inform you that ${purchaseType(context.transaction, 'en')} Below are the details:
+        </p>
+        ${tableBuilder(context.transaction)}
+    <p>We have debited your account for the total amount <strong>${formatAmount(context.transaction.totalPriceInclVat)}</strong> 
+    which leaves you with a total ${balanceOrDebtEnglish(context.balance)} of ${context.balance.toFormat()}.</p>
+    <p>${debtTextEnglish(context.balance)}
+    You can increase your balance at any time on the SudoSOS website.</p>
+    <p>If you have any questions about this transaction, please reach out to the email address in the footer of this email.
+    `,
+  getSubject: 'Your transaction receipt',
+  getTitle: 'Your transaction receipt',
+  getText: (context) =>
+    `
+    We love to inform you that ${purchaseType(context.transaction, 'en')} Below are the details:
+    ${tableBuilder(context.transaction)}
+    We have debited your account for the total amount ${formatAmount(context.transaction.totalPriceInclVat)}
+    which leaves you with a total ${balanceOrDebtEnglish(context.balance)} of ${context.balance.toFormat()}.
+    ${debtTextEnglish(context.balance)}
+    You can increase your balance at any time on the SudoSOS website.
+    If you have any questions about this transaction, please reach out to the email address in the footer of this email.
+    `,
+});
+
+const mailContents: MailLanguageMap<TransactionNotificationOptions> = {
+  [Language.DUTCH]: transactionNotificationDutch,
+  [Language.ENGLISH]: transactionNotificationEnglish,
+};
+
+export default class TransactionNotification extends MailMessage<TransactionNotificationOptions> {
+  public constructor(options: TransactionNotificationOptions) {
+    super(options, mailContents);
+  }
+}

--- a/src/migrations/1762861469829-transaction-notification-migrations.ts
+++ b/src/migrations/1762861469829-transaction-notification-migrations.ts
@@ -1,0 +1,38 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2024  Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class TransactionNotification1762861469829 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn('user', new TableColumn({
+      name: 'transactionReceipts',
+      type: 'varchar',
+      default: "'NEVER'",
+      isNullable: false,
+      isUnique: false,
+    }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('user', 'transactionReceipts');
+  }
+
+}


### PR DESCRIPTION
Add options for certain users to get notifications when a transaction is made for them

# Description
- Added the options: NEVER, CHARGEDBYOTHERS, ALL
- On transaction made check if these notifications must be sent
- Send an email with a table of the products, amounts and total price

<img width="932" height="656" alt="image" src="https://github.com/user-attachments/assets/29db2856-3bc4-43c4-a525-25ea73436e9a" />

<img width="932" height="656" alt="image" src="https://github.com/user-attachments/assets/e359df07-50ef-45e3-8559-7b4737499d50" />


## Related issues/external references
#144 

## Types of changes
- New feature _(non-breaking change which adds functionality)_

---

## ✅ PR Checklist

- [x] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [x] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [x] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB
