### PR TITLE
fix: pos auth creates lesser token

### DIFF
--- a/src/controller/authentication-controller.ts
+++ b/src/controller/authentication-controller.ts
@@ -584,7 +584,7 @@ export default class AuthenticationController extends BaseController {
       };
 
       const result = await new AuthenticationService().HashAuthentication(body.key,
-        keyAuthenticator, context, keyAuthenticator.user.pointOfSale?.id);
+        keyAuthenticator, context);
 
       if (!result) {
         res.status(403).json({

--- a/src/service/authentication-service.ts
+++ b/src/service/authentication-service.ts
@@ -245,11 +245,9 @@ export default class AuthenticationService extends WithManager {
     const valid = await this.compareHash(pass, authenticator.hash);
     if (!valid) return undefined;
 
-    let expiry: number | undefined = undefined;
-
-    if (posId) {
-      expiry = ServerSettingsStore.getInstance().getSetting('jwtExpiryPointOfSale') as ISettings['jwtExpiryPointOfSale'];
-    }
+    const expiry = authenticator.user.type === UserType.POINT_OF_SALE ?
+      ServerSettingsStore.getInstance().getSetting('jwtExpiryPointOfSale') as ISettings['jwtExpiryPointOfSale']
+      : undefined;
 
     return this.getSaltedToken({ user: authenticator.user, context, posId, expiry });
   }

--- a/test/unit/controller/authentication-controller.ts
+++ b/test/unit/controller/authentication-controller.ts
@@ -434,7 +434,7 @@ describe('AuthenticationController', async (): Promise<void> => {
         const callArgs = hashAuthStub.getCall(0).args;
         expect(callArgs[0]).to.equal('1');
         expect(callArgs[2]).to.deep.include({ roleManager: ctx.roleManager, tokenHandler: ctx.tokenHandler });
-        expect(callArgs[3]).to.equal(pos.id); // posId
+        expect(callArgs).to.not.include(pos.id); // posId
       });
 
       it('should call HashAuthentication without a posId when user is not a POS', async () => {


### PR DESCRIPTION
Authenticating with a posId would create a lesser token with a longer expiry for a POS user. This is now fixed as it should not be a lesser token but have a longer expiry.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_

---

## ✅ PR Checklist

- [x] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [x] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [x] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB

## 🔗 Additional Notes
<!-- Any additional information that reviewers should know -->