### PR TITLE
feat: isMandatory on notification response

### DIFF
--- a/src/controller/response/user-notification-preference-response.ts
+++ b/src/controller/response/user-notification-preference-response.ts
@@ -34,7 +34,7 @@ import BaseResponse from './base-response';
  * @property {string} type - The notification type
  * @property {string} channel - The notification channel
  * @property {boolean} enabled - Whether the preference is enabled
- * @property {boolean} isMadatory - Whether the type is mandatory
+ * @property {boolean} isMandatory - Whether the type is mandatory
  */
 export interface BaseUserNotificationPreferenceResponse extends BaseResponse {
   user: BaseUserResponse;

--- a/src/entity/notifications/user-notification-preference.ts
+++ b/src/entity/notifications/user-notification-preference.ts
@@ -60,6 +60,11 @@ export default class UserNotificationPreference extends BaseEntity {
   @Column({ nullable: false })
   public enabled: boolean;
 
+  /**
+   * Returns whether this notification type is mandatory.
+   *
+   * @returns {boolean} True if this notification type is mandatory, false otherwise.
+   */
   get isMandatory(): boolean {
     return NotificationTypeRegistry.isTypeMandatory(this.type);
   }

--- a/src/notifications/notification-types.ts
+++ b/src/notifications/notification-types.ts
@@ -87,8 +87,14 @@ export class NotificationTypeRegistry {
     return this.types;
   }
 
+  /**
+   * Checks whether a given notification type is marked as mandatory.
+   *
+   * @param type The notification type to check.
+   * @returns True if the notification type is mandatory; otherwise, false.
+   */
   public static isTypeMandatory(type: NotificationTypes): boolean {
-    return this.get(type).isMandatory;
+    return this.get(type)?.isMandatory ?? false;
   }
 }
 

--- a/src/service/user-notification-preference-service.ts
+++ b/src/service/user-notification-preference-service.ts
@@ -82,7 +82,7 @@ export function parseUserNotificationPreferenceFilters(req: RequestWithToken): U
     type: req.query.type as string,
     channel: req.query.channel as string,
     enabled: req.query.enabled === undefined ? undefined : Boolean(req.query.enabled),
-    isMandatory: Boolean(req.query.isMandatory),
+    isMandatory: req.query.isMandatory === undefined ? undefined : Boolean(req.query.isMandatory),
   };
 }
 
@@ -258,7 +258,7 @@ export default class UserNotificationPreferenceService extends WithManager {
 
       if (restParams.type) {
         if (!matchingTypes.includes(restParams.type as NotificationTypes)) {
-          whereClause.type = 'NON_EXISTENT_TYPE_MATCH';
+          whereClause.type = In([]);
         }
       } else {
         whereClause.type = In(matchingTypes);

--- a/test/unit/service/user-notification-preference-service.ts
+++ b/test/unit/service/user-notification-preference-service.ts
@@ -170,6 +170,16 @@ describe('UserNotificationPreferenceService', async (): Promise<void> => {
 
       expect(res.length).to.equal(expectedCount);
     });
+
+    it('should return an empty array if type and isMandatory filter conflict', async () => {
+      const mandatoryType = NotificationTypes.ChangedPin;
+      
+      const res: UserNotificationPreference[] = await new UserNotificationPreferenceService().getUserNotificationPreferences(
+        { type: mandatoryType, isMandatory: false },
+      );
+
+      expect(res.length).to.equal(0);
+    });
   });
 
   describe('paginatedUserNotificationPreferences function', async (): Promise<void> => {


### PR DESCRIPTION
Adds isMandatory for the type in the response to make it easier to search. Also adds it do filters

<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_

---

## ✅ PR Checklist

- [x] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [x] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [x] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB

## 🔗 Additional Notes
<!-- Any additional information that reviewers should know -->