### PR TITLE
feat: add user settings store

### DIFF
--- a/src/controller/request/user-request.ts
+++ b/src/controller/request/user-request.ts
@@ -25,6 +25,7 @@
  */
 
 import { UserType } from '../../entity/user/user';
+import { SupportedLanguage } from '../../entity/user-setting';
 
 export default interface BaseUserRequest {
   firstName: string;
@@ -93,4 +94,16 @@ export interface UpdateInvoiceUserRequest {
  */
 export interface AddRoleRequest {
   roleId: number;
+}
+
+/**
+ * @typedef {object} PatchUserSettingsRequest
+ * @property {boolean} betaEnabled - Whether beta features are enabled
+ * @property {object} dashboardTheme - Dashboard theme configuration with organId and organName, or null
+ * @property {string} language - enum:nl-NL,en-US,pl-PL - ISO language code or undefined
+ */
+export interface PatchUserSettingsRequest {
+  betaEnabled?: boolean;
+  dashboardTheme?: { organId: number; organName: string } | null;
+  language?: SupportedLanguage | undefined;
 }

--- a/src/controller/response/user-response.ts
+++ b/src/controller/response/user-response.ts
@@ -28,6 +28,7 @@ import BaseResponse from './base-response';
 import { PaginationResult } from '../../helpers/pagination';
 import { TermsOfServiceStatus } from '../../entity/user/user';
 import { BasePointOfSaleInfoResponse } from './point-of-sale-response';
+import { SupportedLanguage } from '../../entity/user-setting';
 
 /**
  * @typedef {allOf|BaseResponse} BaseUserResponse
@@ -99,4 +100,16 @@ export interface InvoiceUserResponse {
 export interface PaginatedUserResponse {
   _pagination: PaginationResult,
   records: UserResponse[],
+}
+
+/**
+ * @typedef {object} UserSettingsResponse
+ * @property {boolean} betaEnabled.required - Whether beta features are enabled
+ * @property {object} dashboardTheme.required - Dashboard theme configuration with organId and organName, or null
+ * @property {string} language - enum:nl-NL,en-US,pl-PL - ISO language code (e.g., "nl-NL", "en-US", "pl-PL") or undefined
+ */
+export interface UserSettingsResponse {
+  betaEnabled: boolean;
+  dashboardTheme: { organId: number; organName: string } | null;
+  language: SupportedLanguage | undefined;
 }

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -104,6 +104,8 @@ import Wrapped from '../entity/wrapped';
 import WrappedOrganMember from '../entity/wrapped/wrapped-organ-member';
 import { AddWrappedTable1764842063654 } from '../migrations/1764842063654-add-wrapped-table';
 import { AddWrappedOrganMember1765826596888 } from '../migrations/1765826596888-add-wrapped-organ-member';
+import UserSetting from '../entity/user-setting';
+import { UserSetting1768697568707 } from '../migrations/1768697568707-user-setting';
 
 // We need to load the dotenv to prevent the env from being undefined.
 dotenv.config();
@@ -136,6 +138,7 @@ const options: DataSourceOptions = {
     UserNotificationPreference1764615514906,
     AddWrappedTable1764842063654,
     AddWrappedOrganMember1765826596888,
+    UserSetting1768697568707,
   ],
   extra: {
     authPlugins: {
@@ -206,6 +209,7 @@ const options: DataSourceOptions = {
     QRAuthenticator,
     NotificationLog,
     UserNotificationPreference,
+    UserSetting,
   ],
   subscribers: [
     TransactionSubscriber,

--- a/src/entity/user-setting.ts
+++ b/src/entity/user-setting.ts
@@ -1,0 +1,87 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * This is the module page of the user-setting.
+ *
+ * @module internal/user-settings
+ */
+
+import { Column, Entity, Index, JoinColumn, ManyToOne, Unique } from 'typeorm';
+import BaseEntity from './base-entity';
+import User from './user/user';
+
+export interface DashboardTheme {
+  organId: number;
+  organName: string;
+}
+
+export const SUPPORTED_LANGUAGES = ['nl-NL', 'en-US', 'pl-PL'] as const;
+
+export type SupportedLanguage = typeof SUPPORTED_LANGUAGES[number];
+
+export interface IUserSettings {
+  betaEnabled: boolean;
+  dashboardTheme: DashboardTheme | null;
+  language: SupportedLanguage | undefined;
+}
+
+/**
+ * Key-value store for user-specific settings
+ */
+@Entity()
+@Unique(['userId', 'key'])
+@Index(['userId', 'key'])
+export default class UserSetting<T extends keyof IUserSettings = keyof IUserSettings> extends BaseEntity {
+  @Column({
+    type: 'integer',
+    nullable: false,
+  })
+  public userId: number;
+
+  @ManyToOne(() => User, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  public user: User;
+
+  @Column({
+    length: 64,
+    nullable: false,
+  })
+  public key: T;
+
+  /**
+   * JSON-stored value
+   */
+  @Column({
+    type: 'text',
+    nullable: true,
+    transformer: {
+      from(value: string | null): IUserSettings[T] | null {
+        if (value == null) return null;
+        return JSON.parse(value);
+      },
+      to(value: IUserSettings[T] | null | undefined): string | null {
+        if (value == null) return null;
+        return JSON.stringify(value);
+      },
+    },
+  })
+  public value: IUserSettings[T];
+}

--- a/src/migrations/1768697568707-user-setting.ts
+++ b/src/migrations/1768697568707-user-setting.ts
@@ -1,0 +1,109 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+export class UserSetting1768697568707 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'user_setting',
+        columns: [
+          {
+            name: 'id',
+            type: 'integer',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'version',
+            type: 'int',
+            isNullable: false,
+          },
+          {
+            name: 'userId',
+            type: 'integer',
+            isNullable: false,
+          },
+          {
+            name: 'key',
+            type: 'varchar',
+            length: '64',
+            isNullable: false,
+          },
+          {
+            name: 'value',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'datetime(6)',
+            default: 'current_timestamp',
+            isNullable: false,
+          },
+          {
+            name: 'updatedAt',
+            type: 'datetime(6)',
+            default: 'current_timestamp',
+            onUpdate: 'current_timestamp',
+            isNullable: false,
+          },
+        ],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'user_setting',
+      new TableIndex({
+        name: 'UQ_user_setting_userId_key',
+        columnNames: ['userId', 'key'],
+        isUnique: true,
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'user_setting',
+      new TableForeignKey({
+        name: 'FK_user_setting_userId',
+        columnNames: ['userId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'user',
+        onDelete: 'CASCADE',
+        onUpdate: 'NO ACTION',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey(
+      'user_setting',
+      'FK_user_setting_userId',
+    );
+
+    await queryRunner.dropIndex(
+      'user_setting',
+      'UQ_user_setting_userId_key',
+    );
+
+    await queryRunner.dropTable('user_setting');
+  }
+}

--- a/src/rbac/default-roles.ts
+++ b/src/rbac/default-roles.ts
@@ -65,6 +65,7 @@ export default class DefaultRoles {
         },
         User: {
           get: { own: star },
+          update: { own: new Set(['settings']) },
           authenticate: {
             own: new Set(['pointOfSale']),
             organ: new Set(['pointOfSale']),

--- a/src/user-settings/user-settings-defaults.ts
+++ b/src/user-settings/user-settings-defaults.ts
@@ -1,0 +1,35 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * This is the module page of the user-settings defaults.
+ *
+ * @module internal/user-settings
+ */
+
+import { IUserSettings } from '../entity/user-setting';
+
+const UserSettingsDefaults: IUserSettings = {
+  betaEnabled: false,
+  dashboardTheme: null,
+  language: undefined,
+};
+
+export default UserSettingsDefaults;

--- a/src/user-settings/user-settings-store.ts
+++ b/src/user-settings/user-settings-store.ts
@@ -1,0 +1,153 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * This is the module page of the user-settings store.
+ *
+ * @module internal/user-settings
+ */
+
+import { Repository } from 'typeorm';
+import UserSetting, { IUserSettings } from '../entity/user-setting';
+import UserSettingsDefaults from './user-settings-defaults';
+import { UserSettingsResponse } from '../controller/response/user-response';
+
+/**
+ * Store of user-specific settings, which are key-value pairs stored in the database.
+ * Unlike ServerSettingsStore, this is not a singleton and always queries the database
+ * to ensure settings are up-to-date.
+ */
+export default class UserSettingsStore<T extends keyof IUserSettings = keyof IUserSettings> {
+  private repo: Repository<UserSetting>;
+
+  constructor() {
+    this.repo = UserSetting.getRepository();
+  }
+
+  /**
+   * Get a user setting from the database. Returns the default value if the setting
+   * doesn't exist or is null/undefined.
+   * @param userId - The ID of the user
+   * @param key - The setting key
+   */
+  public async getSetting(userId: number, key: T): Promise<IUserSettings[T]> {
+    const setting = await this.repo.findOne({
+      where: { userId, key },
+    });
+
+    if (!setting || setting.value == null) {
+      return UserSettingsDefaults[key] as IUserSettings[T];
+    }
+
+    return setting.value as IUserSettings[T];
+  }
+
+  /**
+   * Get all settings for a user from the database. Returns defaults for any
+   * settings that don't exist or are null/undefined.
+   * @param userId - The ID of the user
+   */
+  public async getAllSettings(userId: number): Promise<IUserSettings> {
+    const settings = await this.repo.find({
+      where: { userId },
+    });
+
+    const result: IUserSettings = { ...UserSettingsDefaults };
+
+    settings.forEach((setting) => {
+      if (setting.value != null) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (result as any)[setting.key] = setting.value;
+      }
+    });
+
+    return result;
+  }
+
+  /**
+   * Update or create a single user setting
+   * If value is undefined, the setting is deleted (to distinguish from null).
+   * @param userId - The ID of the user
+   * @param key - The setting key
+   * @param value - The setting value
+   */
+  public async setSetting(userId: number, key: T, value: IUserSettings[T]): Promise<UserSetting | void> {
+    // If value is undefined, delete the setting to distinguish from null
+    if (value === undefined) {
+      const setting = await this.repo.findOne({
+        where: { userId, key },
+      });
+      if (setting) {
+        await this.repo.remove(setting);
+      }
+      return;
+    }
+
+    let setting = await this.repo.findOne({
+      where: { userId, key },
+    });
+
+    if (!setting) {
+      setting = this.repo.create({ userId, key, value });
+    } else {
+      setting.value = value;
+    }
+
+    return this.repo.save(setting);
+  }
+
+  /**
+   * Update or create multiple user settings at once
+   * Undefined values are ignored (not processed), allowing partial updates without
+   * accidentally resetting settings. To explicitly delete a setting, use setSetting
+   * with undefined.
+   * @param userId - The ID of the user
+   * @param settings - Partial settings object with key-value pairs to update
+   */
+  public async setSettings(userId: number, settings: Partial<IUserSettings>): Promise<UserSetting[]> {
+    const results = await Promise.all(
+      (Object.entries(settings) as [keyof IUserSettings, IUserSettings[keyof IUserSettings]][]).map(
+        async (entry) => {
+          const [key, value] = entry;
+          // Ignore undefined values in batch updates
+          if (value === undefined) {
+            return undefined;
+          }
+          return this.setSetting(userId, key as T, value as IUserSettings[T]);
+        },
+      ),
+    );
+
+    // Filter out void results (deleted settings or ignored undefined values)
+    return results.filter((result): result is UserSetting => result !== undefined);
+  }
+
+  /**
+   * Convert IUserSettings to UserSettingsResponse
+   * @param settings - The user settings to convert
+   */
+  public static toResponse(settings: IUserSettings): UserSettingsResponse {
+    return {
+      betaEnabled: settings.betaEnabled,
+      dashboardTheme: settings.dashboardTheme,
+      language: settings.language,
+    };
+  }
+}

--- a/test/unit/user-settings/user-settings-store.ts
+++ b/test/unit/user-settings/user-settings-store.ts
@@ -1,0 +1,361 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+import { DataSource } from 'typeorm';
+import database from '../../../src/database/database';
+import { finishTestDB } from '../../helpers/test-helpers';
+import UserSettingsStore from '../../../src/user-settings/user-settings-store';
+import UserSetting, { IUserSettings } from '../../../src/entity/user-setting';
+import { expect } from 'chai';
+import UserSettingsDefaults from '../../../src/user-settings/user-settings-defaults';
+import User, { UserType, TermsOfServiceStatus } from '../../../src/entity/user/user';
+
+describe('UserSettingsStore', () => {
+  let ctx: {
+    connection: DataSource,
+    user1: User,
+    user2: User,
+  };
+
+  before(async () => {
+    ctx = {
+      connection: await database.initialize(),
+      user1: undefined,
+      user2: undefined,
+    };
+
+    // Create test users
+    ctx.user1 = Object.assign(new User(), {
+      firstName: 'Test',
+      lastName: 'User1',
+      type: UserType.MEMBER,
+      active: true,
+      acceptedToS: TermsOfServiceStatus.ACCEPTED,
+    } as User);
+    await User.save(ctx.user1);
+
+    ctx.user2 = Object.assign(new User(), {
+      firstName: 'Test',
+      lastName: 'User2',
+      type: UserType.MEMBER,
+      active: true,
+      acceptedToS: TermsOfServiceStatus.ACCEPTED,
+    } as User);
+    await User.save(ctx.user2);
+  });
+
+  afterEach(async () => {
+    await UserSetting.clear();
+  });
+
+  after(async () => {
+    await finishTestDB(ctx.connection);
+  });
+
+  describe('#getSetting', () => {
+    it('should return default value when setting does not exist', async () => {
+      const store = new UserSettingsStore();
+
+      const betaEnabled = await store.getSetting(ctx.user1.id, 'betaEnabled');
+      expect(betaEnabled).to.equal(UserSettingsDefaults.betaEnabled);
+
+      const dashboardTheme = await store.getSetting(ctx.user1.id, 'dashboardTheme');
+      expect(dashboardTheme).to.deep.equal(UserSettingsDefaults.dashboardTheme);
+
+      const language = await store.getSetting(ctx.user1.id, 'language');
+      expect(language).to.equal(UserSettingsDefaults.language);
+    });
+
+    it('should return stored value when setting exists', async () => {
+      const store = new UserSettingsStore();
+
+      const key: keyof IUserSettings = 'betaEnabled';
+      const value: IUserSettings['betaEnabled'] = true;
+
+      await store.setSetting(ctx.user1.id, key, value);
+
+      const result = await store.getSetting(ctx.user1.id, key);
+      expect(result).to.equal(value);
+    });
+
+    it('should return different values for different users', async () => {
+      const store = new UserSettingsStore();
+
+      await store.setSetting(ctx.user1.id, 'betaEnabled', true);
+      await store.setSetting(ctx.user2.id, 'betaEnabled', false);
+
+      const user1Value = await store.getSetting(ctx.user1.id, 'betaEnabled');
+      const user2Value = await store.getSetting(ctx.user2.id, 'betaEnabled');
+
+      expect(user1Value).to.equal(true);
+      expect(user2Value).to.equal(false);
+    });
+
+    it('should handle dashboardTheme setting', async () => {
+      const store = new UserSettingsStore();
+
+      const theme = { organId: 1, organName: 'Test Organ' };
+      await store.setSetting(ctx.user1.id, 'dashboardTheme', theme);
+
+      const result = await store.getSetting(ctx.user1.id, 'dashboardTheme');
+      expect(result).to.deep.equal(theme);
+    });
+
+    it('should handle language setting', async () => {
+      const store = new UserSettingsStore();
+
+      const language: IUserSettings['language'] = 'nl-NL';
+      await store.setSetting(ctx.user1.id, 'language', language);
+
+      const result = await store.getSetting(ctx.user1.id, 'language');
+      expect(result).to.equal(language);
+    });
+
+    it('should handle undefined language setting', async () => {
+      const store = new UserSettingsStore();
+
+      // Set language to undefined (should not store it, return default)
+      const result = await store.getSetting(ctx.user1.id, 'language');
+      expect(result).to.equal(undefined);
+    });
+  });
+
+  describe('#getAllSettings', () => {
+    it('should return all defaults when no settings exist', async () => {
+      const store = new UserSettingsStore();
+
+      const settings = await store.getAllSettings(ctx.user1.id);
+
+      expect(settings).to.deep.equal(UserSettingsDefaults);
+    });
+
+    it('should return defaults merged with stored settings', async () => {
+      const store = new UserSettingsStore();
+
+      await store.setSetting(ctx.user1.id, 'betaEnabled', true);
+      await store.setSetting(ctx.user1.id, 'language', 'en-US');
+
+      const settings = await store.getAllSettings(ctx.user1.id);
+
+      expect(settings.betaEnabled).to.equal(true);
+      expect(settings.language).to.equal('en-US');
+      expect(settings.dashboardTheme).to.deep.equal(UserSettingsDefaults.dashboardTheme);
+    });
+
+    it('should return different settings for different users', async () => {
+      const store = new UserSettingsStore();
+
+      await store.setSetting(ctx.user1.id, 'betaEnabled', true);
+      await store.setSetting(ctx.user2.id, 'betaEnabled', false);
+      await store.setSetting(ctx.user1.id, 'language', 'nl-NL');
+      await store.setSetting(ctx.user2.id, 'language', 'pl-PL');
+
+      const user1Settings = await store.getAllSettings(ctx.user1.id);
+      const user2Settings = await store.getAllSettings(ctx.user2.id);
+
+      expect(user1Settings.betaEnabled).to.equal(true);
+      expect(user1Settings.language).to.equal('nl-NL');
+      expect(user2Settings.betaEnabled).to.equal(false);
+      expect(user2Settings.language).to.equal('pl-PL');
+    });
+  });
+
+  describe('#setSetting', () => {
+    it('should create a new setting when it does not exist', async () => {
+      const store = new UserSettingsStore();
+
+      const key: keyof IUserSettings = 'betaEnabled';
+      const value: IUserSettings['betaEnabled'] = true;
+
+      await store.setSetting(ctx.user1.id, key, value);
+
+      const dbSetting = await UserSetting.findOne({ where: { userId: ctx.user1.id, key } });
+      expect(dbSetting).to.not.be.null;
+      expect(dbSetting.value).to.equal(value);
+    });
+
+    it('should update an existing setting', async () => {
+      const store = new UserSettingsStore();
+
+      const key: keyof IUserSettings = 'betaEnabled';
+      const initialValue: IUserSettings['betaEnabled'] = false;
+      const newValue: IUserSettings['betaEnabled'] = true;
+
+      await store.setSetting(ctx.user1.id, key, initialValue);
+      await store.setSetting(ctx.user1.id, key, newValue);
+
+      const dbSetting = await UserSetting.findOne({ where: { userId: ctx.user1.id, key } });
+      expect(dbSetting.value).to.equal(newValue);
+    });
+
+    it('should store settings independently per user', async () => {
+      const store = new UserSettingsStore();
+
+      await store.setSetting(ctx.user1.id, 'betaEnabled', true);
+      await store.setSetting(ctx.user2.id, 'betaEnabled', false);
+
+      const user1Setting = await UserSetting.findOne({ where: { userId: ctx.user1.id, key: 'betaEnabled' } });
+      const user2Setting = await UserSetting.findOne({ where: { userId: ctx.user2.id, key: 'betaEnabled' } });
+
+      expect(user1Setting.value).to.equal(true);
+      expect(user2Setting.value).to.equal(false);
+    });
+
+    it('should handle dashboardTheme setting', async () => {
+      const store = new UserSettingsStore();
+
+      const theme = { organId: 1, organName: 'Test Organ' };
+      await store.setSetting(ctx.user1.id, 'dashboardTheme', theme);
+
+      const result = await store.getSetting(ctx.user1.id, 'dashboardTheme');
+      expect(result).to.deep.equal(theme);
+    });
+
+    it('should handle null dashboardTheme', async () => {
+      const store = new UserSettingsStore();
+
+      await store.setSetting(ctx.user1.id, 'dashboardTheme', null);
+
+      const result = await store.getSetting(ctx.user1.id, 'dashboardTheme');
+      expect(result).to.equal(null);
+    });
+
+    it('should handle language setting', async () => {
+      const store = new UserSettingsStore();
+
+      const language: IUserSettings['language'] = 'pl-PL';
+      await store.setSetting(ctx.user1.id, 'language', language);
+
+      const result = await store.getSetting(ctx.user1.id, 'language');
+      expect(result).to.equal(language);
+    });
+  });
+
+  describe('#setSettings', () => {
+    it('should update multiple settings at once', async () => {
+      const store = new UserSettingsStore();
+
+      const updates: Partial<IUserSettings> = {
+        betaEnabled: true,
+        language: 'nl-NL',
+      };
+
+      await store.setSettings(ctx.user1.id, updates);
+
+      const settings = await store.getAllSettings(ctx.user1.id);
+      expect(settings.betaEnabled).to.equal(true);
+      expect(settings.language).to.equal('nl-NL');
+    });
+
+    it('should only update provided settings', async () => {
+      const store = new UserSettingsStore();
+
+      // Set initial values
+      await store.setSetting(ctx.user1.id, 'betaEnabled', false);
+      await store.setSetting(ctx.user1.id, 'language', 'en-US');
+
+      // Update only betaEnabled
+      await store.setSettings(ctx.user1.id, { betaEnabled: true });
+
+      const settings = await store.getAllSettings(ctx.user1.id);
+      expect(settings.betaEnabled).to.equal(true);
+      expect(settings.language).to.equal('en-US'); // Should remain unchanged
+    });
+
+    it('should handle partial updates with undefined values', async () => {
+      const store = new UserSettingsStore();
+
+      // Set initial values
+      await store.setSetting(ctx.user1.id, 'betaEnabled', true);
+      await store.setSetting(ctx.user1.id, 'language', 'nl-NL');
+
+      // Update with undefined language (should not change it)
+      await store.setSettings(ctx.user1.id, { language: undefined });
+
+      const settings = await store.getAllSettings(ctx.user1.id);
+      expect(settings.betaEnabled).to.equal(true);
+      expect(settings.language).to.equal('nl-NL'); // Should remain unchanged
+    });
+
+    it('should handle dashboardTheme in batch update', async () => {
+      const store = new UserSettingsStore();
+
+      const theme = { organId: 2, organName: 'Batch Organ' };
+      const updates: Partial<IUserSettings> = {
+        betaEnabled: true,
+        dashboardTheme: theme,
+        language: 'pl-PL',
+      };
+
+      await store.setSettings(ctx.user1.id, updates);
+
+      const settings = await store.getAllSettings(ctx.user1.id);
+      expect(settings.betaEnabled).to.equal(true);
+      expect(settings.dashboardTheme).to.deep.equal(theme);
+      expect(settings.language).to.equal('pl-PL');
+    });
+  });
+
+  describe('#toResponse', () => {
+    it('should convert IUserSettings to UserSettingsResponse', () => {
+      const settings: IUserSettings = {
+        betaEnabled: true,
+        dashboardTheme: { organId: 1, organName: 'Test' },
+        language: 'nl-NL',
+      };
+
+      const response = UserSettingsStore.toResponse(settings);
+
+      expect(response).to.deep.equal({
+        betaEnabled: true,
+        dashboardTheme: { organId: 1, organName: 'Test' },
+        language: 'nl-NL',
+      });
+    });
+
+    it('should handle null dashboardTheme', () => {
+      const settings: IUserSettings = {
+        betaEnabled: false,
+        dashboardTheme: null,
+        language: undefined,
+      };
+
+      const response = UserSettingsStore.toResponse(settings);
+
+      expect(response).to.deep.equal({
+        betaEnabled: false,
+        dashboardTheme: null,
+        language: undefined,
+      });
+    });
+
+    it('should handle undefined language', () => {
+      const settings: IUserSettings = {
+        betaEnabled: true,
+        dashboardTheme: null,
+        language: undefined,
+      };
+
+      const response = UserSettingsStore.toResponse(settings);
+
+      expect(response.language).to.equal(undefined);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Adds endpoints for setting general typed user settings, such as language, beta mode, etc.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_
---

## ✅ PR Checklist

- [x] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [x] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [x] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB
