### PR TITLE
feat: change bcrypt rounds for PIN authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,6 @@ PDF_GEN_URL =  http://localhost:3001/pdf
 HTML_PDF_GEN_URL = http://localhost:8080/api/v1
 
 WRAPPED_YEAR = 2025
+
+BCRYPT_ROUNDS_PIN = 1
+BCRYPT_ROUNDS = 12

--- a/src/entity/authenticator/pin-authenticator.ts
+++ b/src/entity/authenticator/pin-authenticator.ts
@@ -41,4 +41,9 @@ import HashBasedAuthenticationMethod from './hash-based-authentication-method';
  * @index 0
  */
 @Entity()
-export default class PinAuthenticator extends HashBasedAuthenticationMethod {}
+export default class PinAuthenticator extends HashBasedAuthenticationMethod {
+  /**
+   * Static property to identify PIN authenticators for type checking.
+   */
+  public static readonly IS_PIN_AUTHENTICATOR = true;
+}

--- a/src/service/authentication-service.ts
+++ b/src/service/authentication-service.ts
@@ -210,9 +210,9 @@ export default class AuthenticationService extends WithManager {
     pass: string, Type: new () => T): Promise<T> {
     const repo = this.manager.getRepository(Type);
     let authenticator = await repo.findOne({ where: { user: { id: user.id } } as FindOptionsWhere<T>, relations: ['user'] });
-    
+
     // Use lower rounds for PIN authenticators
-    const hash = Type.name === 'PinAuthenticator'
+    const hash = (Type as any).IS_PIN_AUTHENTICATOR === true
       ? await this.hashPinPassword(pass)
       : await this.hashPassword(pass);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Decrease bcrypt rounds for PIN auth for increased speed since we have 1.5FA

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_

---

## ✅ PR Checklist

- [x] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [x] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [x] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB