### PR TITLE
Change return signatures of service class methods

### DIFF
--- a/src/controller/authentication-controller.ts
+++ b/src/controller/authentication-controller.ts
@@ -167,7 +167,7 @@ export default class AuthenticationController extends BaseController {
     if (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test') return false;
 
     // Check the existence of the user
-    const user = await User.findOne({ where: { id: body.userId } });
+    const user = await User.findOne(UserService.getOptions({ id: body.userId }));
     if (!user) return false;
 
     return true;
@@ -229,9 +229,7 @@ export default class AuthenticationController extends BaseController {
   public static PINLoginConstructor(roleManager: RoleManager, tokenHandler: TokenHandler,
     pin: string, userId: number, posId?: number) {
     return async (req: Request, res: Response) => {
-      const user = await User.findOne({
-        where: { id: userId, deleted: false },
-      });
+      const user = await User.findOne(UserService.getOptions({ id: userId }));
 
       if (!user) {
         res.status(403).json({
@@ -259,9 +257,10 @@ export default class AuthenticationController extends BaseController {
         res.status(403).json({
           message: 'Invalid credentials.',
         });
+        return;
       }
 
-      res.json(result);
+      res.json(AuthenticationService.asAuthenticationResponse(result.user, result.roles, result.organs, result.token));
     };
   }
 
@@ -318,8 +317,8 @@ export default class AuthenticationController extends BaseController {
       };
 
       // AD login gives full access.
-      const token = await service.getSaltedToken({ user, context });
-      res.json(token);
+      const result = await service.getSaltedToken({ user, context });
+      res.json(AuthenticationService.asAuthenticationResponse(result.user, result.roles, result.organs, result.token));
     };
   }
 
@@ -338,6 +337,7 @@ export default class AuthenticationController extends BaseController {
     this.logger.trace('Local authentication for user', body.accountMail);
 
     try {
+      // Email-based lookup is specific to local auth; UserService.getOptions does not support email filter
       const user = await User.findOne({
         where: { email: body.accountMail, deleted: false },
       });
@@ -369,9 +369,10 @@ export default class AuthenticationController extends BaseController {
         res.status(403).json({
           message: 'Invalid credentials.',
         });
+        return;
       }
 
-      res.json(result);
+      res.json(AuthenticationService.asAuthenticationResponse(result.user, result.roles, result.organs, result.token));
     } catch (error) {
       this.logger.error('Could not authenticate using Local:', error);
       res.status(500).json('Internal server error.');
@@ -429,6 +430,7 @@ export default class AuthenticationController extends BaseController {
     const body = req.body as ResetLocalRequest;
     this.logger.trace('Reset request for user', body.accountMail);
     try {
+      // Email-based lookup is specific to local auth; UserService.getOptions does not support email filter
       const user = await User.findOne({
         where: { email: body.accountMail, deleted: false, type: UserType.LOCAL_USER },
       });
@@ -489,11 +491,11 @@ export default class AuthenticationController extends BaseController {
 
       this.logger.trace('Succesfull NFC authentication for user ', authenticator.user);
 
-      const token = await new AuthenticationService().getSaltedToken({
+      const result = await new AuthenticationService().getSaltedToken({
         user: authenticator.user,
         context,
       });
-      res.json(token);
+      res.json(AuthenticationService.asAuthenticationResponse(result.user, result.roles, result.organs, result.token));
     } catch (error) {
       this.logger.error('Could not authenticate using NFC:', error);
       res.status(500).json('Internal server error.');
@@ -532,11 +534,11 @@ export default class AuthenticationController extends BaseController {
         tokenHandler: this.tokenHandler,
       };
 
-      const token = await new AuthenticationService().getSaltedToken({
+      const result = await new AuthenticationService().getSaltedToken({
         user: authenticator.user,
         context,
       });
-      res.json(token);
+      res.json(AuthenticationService.asAuthenticationResponse(result.user, result.roles, result.organs, result.token));
     } catch (error) {
       this.logger.error('Could not authenticate using EAN:', error);
       res.status(500).json('Internal server error.');
@@ -559,9 +561,7 @@ export default class AuthenticationController extends BaseController {
     this.logger.trace('key authentication for user', body.userId);
 
     try {
-      const user = await User.findOne({
-        where: { id: body.userId, deleted: false },
-      });
+      const user = await User.findOne(UserService.getOptions({ id: body.userId, allowPos: true }));
 
       if (!user) {
         res.status(403).json({
@@ -593,9 +593,10 @@ export default class AuthenticationController extends BaseController {
         res.status(403).json({
           message: 'Invalid credentials.',
         });
+        return;
       }
 
-      res.json(result);
+      res.json(AuthenticationService.asAuthenticationResponse(result.user, result.roles, result.organs, result.token));
     } catch (error) {
       this.logger.error('Could not authenticate using key:', error);
       res.status(500).json('Internal server error.');
@@ -622,12 +623,12 @@ export default class AuthenticationController extends BaseController {
         res.status(404).json('User not found.');
         return;
       }
-      const response = await new AuthenticationService().getSaltedToken({
+      const result = await new AuthenticationService().getSaltedToken({
         user,
         context: { tokenHandler: this.tokenHandler, roleManager: this.roleManager },
         salt: body.nonce,
       });
-      res.json(response);
+      res.json(AuthenticationService.asAuthenticationResponse(result.user, result.roles, result.organs, result.token));
     } catch (error) {
       this.logger.error('Could not create token:', error);
       res.status(500).json('Internal server error.');

--- a/src/controller/authentication-secure-controller.ts
+++ b/src/controller/authentication-secure-controller.ts
@@ -152,7 +152,7 @@ export default class AuthenticationSecureController extends BaseController {
         expiry = ServerSettingsStore.getInstance().getSetting('jwtExpiryPointOfSale') as ISettings['jwtExpiryPointOfSale'];
       }
 
-      const token = await new AuthenticationService().getSaltedToken({
+      const result = await new AuthenticationService().getSaltedToken({
         user,
         context: {
           roleManager: this.roleManager,
@@ -161,7 +161,7 @@ export default class AuthenticationSecureController extends BaseController {
         expiry,
         posId: req.token.posId,
       });
-      res.json(token);
+      res.json(AuthenticationService.asAuthenticationResponse(result.user, result.roles, result.organs, result.token));
     } catch (error) {
       this.logger.error('Could not create token:', error);
       res.status(500).json('Internal server error.');
@@ -192,7 +192,7 @@ export default class AuthenticationSecureController extends BaseController {
       }
 
       const expiry = ServerSettingsStore.getInstance().getSetting('jwtExpiryPointOfSale') as ISettings['jwtExpiryPointOfSale'];
-      const token = await new AuthenticationService().getSaltedToken({
+      const result = await new AuthenticationService().getSaltedToken({
         user,
         context: {
           roleManager: this.roleManager,
@@ -200,7 +200,7 @@ export default class AuthenticationSecureController extends BaseController {
         },
         expiry,
       });
-      res.json(token);
+      res.json(AuthenticationService.asAuthenticationResponse(result.user, result.roles, result.organs, result.token));
     } catch (error) {
       this.logger.error('Could not create token:', error);
       res.status(500).json('Internal server error.');
@@ -247,7 +247,7 @@ export default class AuthenticationSecureController extends BaseController {
         res.status(404).json('User not found.');
         return;
       }
-      const token = await new AuthenticationService().getSaltedToken({
+      const result = await new AuthenticationService().getSaltedToken({
         user,
         context: {
           roleManager: this.roleManager,
@@ -255,12 +255,13 @@ export default class AuthenticationSecureController extends BaseController {
         },
         posId: req.token.posId,
       });
+      const authResponse = AuthenticationService.asAuthenticationResponse(result.user, result.roles, result.organs, result.token);
 
       // Let the service handle all business logic validation
       await (new QRService()).confirm(qrAuthenticator, user);
 
       // Notify WebSocket clients about the confirmation
-      WebSocketService.emitQRConfirmed(qrAuthenticator, token);
+      WebSocketService.emitQRConfirmed(qrAuthenticator, authResponse);
       res.status(200).json({ message: 'QR code confirmed successfully.' });
     } catch (error) {
       this.logger.error('Could not confirm QR code:', error);
@@ -285,7 +286,7 @@ export default class AuthenticationSecureController extends BaseController {
 
     try {
       // Verify the caller is a POS user
-      const tokenUser = await User.findOne({ where: { id: req.token.user.id } });
+      const tokenUser = await User.findOne(UserService.getOptions({ id: req.token.user.id, allowPos: true }));
       if (!tokenUser || tokenUser.type !== UserType.POINT_OF_SALE) {
         res.status(403).json('Only POS users can use secure PIN authentication.');
         return;
@@ -324,7 +325,7 @@ export default class AuthenticationSecureController extends BaseController {
 
     try {
       // Verify the caller is a POS user
-      const tokenUser = await User.findOne({ where: { id: req.token.user.id } });
+      const tokenUser = await User.findOne(UserService.getOptions({ id: req.token.user.id, allowPos: true }));
       if (!tokenUser || tokenUser.type !== UserType.POINT_OF_SALE) {
         res.status(403).json('Only POS users can use secure NFC authentication.');
         return;
@@ -356,12 +357,12 @@ export default class AuthenticationSecureController extends BaseController {
 
       this.logger.trace('Successful secure NFC authentication for user', authenticator.user);
 
-      const token = await new AuthenticationService().getSaltedToken({
+      const result = await new AuthenticationService().getSaltedToken({
         user: authenticator.user,
         context,
         posId: body.posId,
       });
-      res.json(token);
+      res.json(AuthenticationService.asAuthenticationResponse(result.user, result.roles, result.organs, result.token));
     } catch (error) {
       this.logger.error('Could not authenticate using secure NFC:', error);
       res.status(500).json('Internal server error.');
@@ -385,7 +386,7 @@ export default class AuthenticationSecureController extends BaseController {
 
     try {
       // Verify the caller is a POS user
-      const tokenUser = await User.findOne({ where: { id: req.token.user.id } });
+      const tokenUser = await User.findOne(UserService.getOptions({ id: req.token.user.id, allowPos: true }));
       if (!tokenUser || tokenUser.type !== UserType.POINT_OF_SALE) {
         res.status(403).json('Only POS users can use secure EAN authentication.');
         return;
@@ -417,12 +418,12 @@ export default class AuthenticationSecureController extends BaseController {
 
       this.logger.trace('Successful secure EAN authentication for user', authenticator.user);
 
-      const token = await new AuthenticationService().getSaltedToken({
+      const result = await new AuthenticationService().getSaltedToken({
         user: authenticator.user,
         context,
         posId: body.posId,
       });
-      res.json(token);
+      res.json(AuthenticationService.asAuthenticationResponse(result.user, result.roles, result.organs, result.token));
     } catch (error) {
       this.logger.error('Could not authenticate using secure EAN:', error);
       res.status(500).json('Internal server error.');

--- a/src/controller/balance-controller.ts
+++ b/src/controller/balance-controller.ts
@@ -34,7 +34,7 @@ import BalanceService, { asBalanceOrderColumn, GetBalanceParameters } from '../s
 import UserController from './user-controller';
 import { asArrayOfUserTypes, asBoolean, asDate, asDinero } from '../helpers/validators';
 import { asOrderingDirection } from '../helpers/ordering';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 
 export default class BalanceController extends BaseController {
   private logger: Logger = log4js.getLogger('BalanceController');
@@ -153,8 +153,8 @@ export default class BalanceController extends BaseController {
     }
 
     try {
-      const result = await new BalanceService().getBalances(params, { take, skip });
-      res.json(result);
+      const [records, count] = await new BalanceService().getBalances(params, { take, skip });
+      res.json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not get balances', error);
       res.status(500).json('Internal server error.');

--- a/src/controller/banner-controller.ts
+++ b/src/controller/banner-controller.ts
@@ -33,7 +33,7 @@ import BannerService, { BannerFilterParameters } from '../service/banner-service
 import Banner from '../entity/banner';
 import FileService from '../service/file-service';
 import { BANNER_IMAGE_LOCATION } from '../files/storage';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import { asBoolean } from '../helpers/validators';
 
 /**
@@ -152,7 +152,8 @@ export default class BannerController extends BaseController {
 
     // handle request
     try {
-      res.json(await BannerService.getBanners(filters, { take, skip }));
+      const [banners, count] = await BannerService.getBanners(filters, { take, skip });
+      res.json(toResponse(banners.map(BannerService.asBannerResponse), count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return all banners:', error);
       res.status(500).json('Internal server error.');
@@ -177,7 +178,8 @@ export default class BannerController extends BaseController {
     // handle request
     try {
       if (BannerService.verifyBanner(body)) {
-        res.json(await BannerService.createBanner(body));
+        const banner = await BannerService.createBanner(body);
+        res.json(BannerService.asBannerResponse(banner));
       } else {
         res.status(400).json('Invalid banner.');
       }
@@ -259,9 +261,9 @@ export default class BannerController extends BaseController {
     // handle request
     try {
       // check if banner in database
-      const { records } = await BannerService.getBanners({ bannerId: Number.parseInt(id, 10) });
-      if (records.length > 0) {
-        res.json(records[0]);
+      const [banners] = await BannerService.getBanners({ bannerId: Number.parseInt(id, 10) });
+      if (banners.length > 0) {
+        res.json(BannerService.asBannerResponse(banners[0]));
       } else {
         res.status(404).json('Banner not found.');
       }
@@ -295,7 +297,7 @@ export default class BannerController extends BaseController {
         // try patching the banner
         const banner = await BannerService.updateBanner(Number.parseInt(id, 10), body);
         if (banner) {
-          res.json(banner);
+          res.json(BannerService.asBannerResponse(banner));
         } else {
           res.status(404).json('Banner not found.');
         }
@@ -356,7 +358,8 @@ export default class BannerController extends BaseController {
 
     // handle request
     try {
-      res.json(await BannerService.getBanners({ active: true }, { take, skip }));
+      const [banners, count] = await BannerService.getBanners({ active: true }, { take, skip });
+      res.json(toResponse(banners.map(BannerService.asBannerResponse), count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return active banners:', error);
       res.status(500).json('Internal server error.');

--- a/src/controller/container-controller.ts
+++ b/src/controller/container-controller.ts
@@ -30,11 +30,10 @@ import BaseController, { BaseControllerOptions } from './base-controller';
 import Policy from './policy';
 import { RequestWithToken } from '../middleware/token-middleware';
 import ContainerService from '../service/container-service';
-import { PaginatedContainerResponse } from './response/container-response';
 import ContainerRevision from '../entity/container/container-revision';
 import Container from '../entity/container/container';
 import { asNumber } from '../helpers/validators';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import { verifyContainerRequest, verifyCreateContainerRequest } from './request/validators/container-request-spec';
 import { isFail } from '../helpers/specification-validation';
 import {
@@ -122,10 +121,11 @@ export default class ContainerController extends BaseController {
 
     // Handle request
     try {
-      const containers: PaginatedContainerResponse = await ContainerService.getContainers(
+      const [revisions, count] = await ContainerService.getContainers(
         {}, { take, skip },
       );
-      res.json(containers);
+      const records = revisions.map((r) => ContainerService.revisionToResponse(r));
+      res.json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return all containers:', error);
       res.status(500).json('Internal server error.');
@@ -152,13 +152,13 @@ export default class ContainerController extends BaseController {
 
     // Handle request
     try {
-      const container = (await ContainerService
-        .getContainers({ containerId, returnProducts: true })).records[0];
-      if (!container) {
+      const [revisions] = await ContainerService
+        .getContainers({ containerId, returnProducts: true });
+      if (!revisions.length) {
         res.status(404).json('Container not found.');
         return;
       }
-      res.json(container);
+      res.json(ContainerService.revisionToResponse(revisions[0]));
     } catch (error) {
       this.logger.error('Could not return single container:', error);
       res.status(500).json('Internal server error.');
@@ -190,8 +190,10 @@ export default class ContainerController extends BaseController {
         return;
       }
 
-      const products = (await ContainerService.getSingleContainer({ containerId, returnProducts: true })).products;
-      res.json(products ? products : []);
+      const revision = await ContainerService.getSingleContainer({ containerId, returnProducts: true });
+      const response = revision ? ContainerService.revisionToResponse(revision) : undefined;
+      const products = response && 'products' in response ? response.products : [];
+      res.json(products);
     } catch (error) {
       this.logger.error('Could not return all products in container:', error);
       res.status(500).json('Internal server error.');
@@ -227,7 +229,8 @@ export default class ContainerController extends BaseController {
         return;
       }
 
-      res.json(await ContainerService.createContainer(request));
+      const revision = await ContainerService.createContainer(request);
+      res.json(ContainerService.revisionToResponse(revision));
     } catch (error) {
       this.logger.error('Could not create container:', error);
       res.status(500).json('Internal server error.');
@@ -253,10 +256,11 @@ export default class ContainerController extends BaseController {
 
     // Handle request
     try {
-      const containers: PaginatedContainerResponse = await ContainerService.getContainers(
+      const [revisions, count] = await ContainerService.getContainers(
         { public: true }, { take, skip },
       );
-      res.json(containers);
+      const records = revisions.map((r) => ContainerService.revisionToResponse(r));
+      res.json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return all public containers:', error);
       res.status(500).json('Internal server error.');
@@ -302,7 +306,8 @@ export default class ContainerController extends BaseController {
         return;
       }
 
-      res.json(await ContainerService.updateContainer(request));
+      const revision = await ContainerService.updateContainer(request);
+      res.json(ContainerService.revisionToResponse(revision));
     } catch (error) {
       this.logger.error('Could not update container:', error);
       res.status(500).json('Internal server error.');

--- a/src/controller/debtor-controller.ts
+++ b/src/controller/debtor-controller.ts
@@ -29,7 +29,7 @@ import { Response } from 'express';
 import log4js, { Logger } from 'log4js';
 import Policy from './policy';
 import { RequestWithToken } from '../middleware/token-middleware';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import DebtorService from '../service/debtor-service';
 import User from '../entity/user/user';
 import { asArrayOfDates, asArrayOfUserTypes, asDate, asFromAndTillDate, asReturnFileType } from '../helpers/validators';
@@ -136,7 +136,9 @@ export default class DebtorController extends BaseController {
     }
 
     try {
-      res.json(await new DebtorService().getFineHandoutEvents({ take, skip }));
+      const [events, count] = await new DebtorService().getFineHandoutEvents({ take, skip });
+      const records = events.map((e) => DebtorService.asBaseFineHandoutEventResponse(e));
+      res.json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return all fine handout event:', error);
       res.status(500).json('Internal server error.');
@@ -159,7 +161,12 @@ export default class DebtorController extends BaseController {
     this.logger.trace('Get fine handout event', id, 'by', req.token.user);
 
     try {
-      res.json(await new DebtorService().getSingleFineHandoutEvent(Number.parseInt(id, 10)));
+      const event = await new DebtorService().getSingleFineHandoutEvent(Number.parseInt(id, 10));
+      if (!event) {
+        res.status(404).json('Fine handout event not found.');
+        return;
+      }
+      res.json(DebtorService.asFineHandoutEventResponse(event));
     } catch (error) {
       this.logger.error('Could not return fine handout event:', error);
       res.status(500).json('Internal server error.');
@@ -268,8 +275,8 @@ export default class DebtorController extends BaseController {
     }
 
     try {
-      const result = await new DebtorService().handOutFines({ referenceDate, userIds: body.userIds }, req.token.user);
-      res.json(result);
+      const event = await new DebtorService().handOutFines({ referenceDate, userIds: body.userIds }, req.token.user);
+      res.json(DebtorService.asFineHandoutEventResponse(event));
     } catch (error) {
       this.logger.error('Could not handout fines:', error);
       res.status(500).json('Internal server error.');

--- a/src/controller/event-controller.ts
+++ b/src/controller/event-controller.ts
@@ -35,7 +35,7 @@ import EventService, {
   EventFilterParameters,
   parseEventFilterParameters, parseUpdateEventRequestParameters, UpdateEventAnswerParams, UpdateEventParams,
 } from '../service/event-service';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import { EventAnswerAssignmentRequest, EventAnswerAvailabilityRequest, EventRequest } from './request/event-request';
 import Event from '../entity/event/event';
 import EventShiftAnswer from '../entity/event/event-shift-answer';
@@ -159,8 +159,8 @@ export default class EventController extends BaseController {
 
     // Handle request
     try {
-      const events = await EventService.getEvents(filters, { take, skip });
-      res.json(events);
+      const [events, count] = await EventService.getEvents(filters, { take, skip });
+      res.json(toResponse(events.map((e) => EventService.asBaseEventResponse(e)), count, { take, skip }));
     } catch (e) {
       this.logger.error('Could not return all events:', e);
       res.status(500).json('Internal server error.');
@@ -190,7 +190,7 @@ export default class EventController extends BaseController {
         res.status(404).send();
         return;
       }
-      res.json(event);
+      res.json(EventService.asEventResponse(event));
     } catch (error) {
       this.logger.error('Could not return single event:', error);
       res.status(500).json('Internal server error.');
@@ -226,7 +226,8 @@ export default class EventController extends BaseController {
 
     // handle request
     try {
-      res.json(await EventService.createEvent(params));
+      const event = await EventService.createEvent(params);
+      res.json(EventService.asEventResponse(event));
     } catch (error) {
       this.logger.error('Could not create event:', error);
       res.status(500).json('Internal server error.');
@@ -275,7 +276,8 @@ export default class EventController extends BaseController {
 
     // handle request
     try {
-      res.json(await EventService.updateEvent(parsedId, params));
+      const event = await EventService.updateEvent(parsedId, params);
+      res.json(EventService.asEventResponse(event));
     } catch (error) {
       this.logger.error('Could not update event:', error);
       res.status(500).json('Internal server error.');
@@ -340,7 +342,8 @@ export default class EventController extends BaseController {
       }
 
       await EventService.syncEventShiftAnswers(event);
-      res.status(200).json(await EventService.getSingleEvent(parsedId));
+      const updatedEvent = await EventService.getSingleEvent(parsedId);
+      res.status(200).json(EventService.asEventResponse(updatedEvent));
     } catch (error) {
       this.logger.error('Could not synchronize event answers:', error);
       res.status(500).json('Internal server error.');

--- a/src/controller/event-shift-controller.ts
+++ b/src/controller/event-shift-controller.ts
@@ -33,7 +33,7 @@ import { RequestWithToken } from '../middleware/token-middleware';
 import EventService, { ShiftSelectedCountParams } from '../service/event-service';
 import { EventShiftRequest } from './request/event-request';
 import EventShift from '../entity/event/event-shift';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import { asDate, asEventType } from '../helpers/validators';
 
 /**
@@ -116,8 +116,8 @@ export default class EventShiftController extends BaseController {
     }
 
     try {
-      const shifts = await EventService.getEventShifts({ take, skip });
-      res.json(shifts);
+      const [shifts, count] = await EventService.getEventShifts({ take, skip });
+      res.json(toResponse(shifts.map((s) => EventService.asEventShiftResponse(s)), count, { take, skip }));
     } catch (e) {
       this.logger.error('Could not return all shifts:', e);
       res.status(500).json('Internal server error.');

--- a/src/controller/inactive-administrative-cost-controller.ts
+++ b/src/controller/inactive-administrative-cost-controller.ts
@@ -28,9 +28,8 @@ import log4js, { Logger } from 'log4js';
 import { Response } from 'express';
 import Policy from './policy';
 import { RequestWithToken } from '../middleware/token-middleware';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import InactiveAdministrativeCostService, { parseInactiveAdministrativeCostFilterParameters, InactiveAdministrativeCostFilterParameters } from '../service/inactive-administrative-cost-service';
-import { PaginatedInactiveAdministrativeCostResponse } from './response/inactive-administrative-cost-response';
 import { isFail } from '../helpers/specification-validation';
 import {
   CreateInactiveAdministrativeCostRequest,
@@ -154,10 +153,11 @@ export default class InactiveAdministrativeCostController extends BaseController
 
     // Handle request
     try {
-      const inactiveAdministrativeCosts: PaginatedInactiveAdministrativeCostResponse = await new InactiveAdministrativeCostService().getPaginatedInactiveAdministrativeCosts(
+      const [costs, count] = await new InactiveAdministrativeCostService().getPaginatedInactiveAdministrativeCosts(
         filter, { take, skip },
       );
-      res.json(inactiveAdministrativeCosts);
+      const records = InactiveAdministrativeCostService.toArrayResponse(costs);
+      res.json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return all inactive administrative costs', error);
       res.status(500).json('Internal server error.');

--- a/src/controller/invoice-controller.ts
+++ b/src/controller/invoice-controller.ts
@@ -29,9 +29,8 @@ import { Response } from 'express';
 import BaseController, { BaseControllerOptions } from './base-controller';
 import Policy from './policy';
 import { RequestWithToken } from '../middleware/token-middleware';
-import { PaginatedInvoiceResponse } from './response/invoice-response';
 import InvoiceService, { InvoiceFilterParameters, parseInvoiceFilterParameters } from '../service/invoice-service';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import {
   CreateInvoiceParams,
   CreateInvoiceRequest,
@@ -161,10 +160,15 @@ export default class InvoiceController extends BaseController {
 
     // Handle request
     try {
-      const invoices: PaginatedInvoiceResponse = await new InvoiceService().getPaginatedInvoices(
+      const [invoices, count] = await new InvoiceService().getPaginatedInvoices(
         filters, { take, skip },
       );
-      res.json(invoices);
+
+      const records = filters.returnInvoiceEntries
+        ? InvoiceService.toArrayResponse(invoices)
+        : InvoiceService.toArrayWithoutEntriesResponse(invoices);
+
+      res.json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return all invoices:', error);
       res.status(500).json('Internal server error.');

--- a/src/controller/payout-request-controller.ts
+++ b/src/controller/payout-request-controller.ts
@@ -29,7 +29,7 @@ import log4js, { Logger } from 'log4js';
 import BaseController, { BaseControllerOptions } from './base-controller';
 import Policy from './policy';
 import { RequestWithToken } from '../middleware/token-middleware';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import PayoutRequestService, { parseGetPayoutRequestsFilters } from '../service/payout-request-service';
 import { PayoutRequestStatusRequest } from './request/payout-request-status-request';
 import PayoutRequest from '../entity/transactions/payout/payout-request';
@@ -129,8 +129,9 @@ export default class PayoutRequestController extends BaseController {
     }
 
     try {
-      const results = await PayoutRequestService.getPayoutRequests(filters, pagination);
-      res.status(200).json(results);
+      const [data, count] = await PayoutRequestService.getPayoutRequests(filters, pagination);
+      const records = data.map((o) => PayoutRequestService.asBasePayoutRequestResponse(o));
+      res.status(200).json(toResponse(records, count, pagination));
     } catch (e) {
       res.status(500).send('Internal server error.');
       this.logger.error(e);
@@ -166,7 +167,7 @@ export default class PayoutRequestController extends BaseController {
       return;
     }
 
-    res.status(200).json(payoutRequest);
+    res.status(200).json(PayoutRequestService.asPayoutRequestResponse(payoutRequest));
   }
 
   /**
@@ -197,7 +198,7 @@ export default class PayoutRequestController extends BaseController {
       }
 
       const payoutRequest = await PayoutRequestService.createPayoutRequest(body, user);
-      res.status(200).json(payoutRequest);
+      res.status(200).json(PayoutRequestService.asPayoutRequestResponse(payoutRequest));
     } catch (e) {
       res.status(500).send();
       this.logger.error(e);
@@ -251,7 +252,7 @@ export default class PayoutRequestController extends BaseController {
 
     if (body.state === PayoutRequestState.APPROVED) {
       const balance = await new BalanceService().getBalance(payoutRequest.requestedBy.id);
-      if (balance.amount.amount < payoutRequest.amount.amount) {
+      if (balance.amount.amount < payoutRequest.amount.getAmount()) {
         res.status(400).json('Insufficient balance.');
         return;
       }
@@ -267,8 +268,8 @@ export default class PayoutRequestController extends BaseController {
 
     // Execute
     try {
-      payoutRequest = await PayoutRequestService.updateStatus(id, body.state, req.token.user);
-      res.status(200).json(payoutRequest);
+      const updatedPayoutRequest = await PayoutRequestService.updateStatus(id, body.state, req.token.user);
+      res.status(200).json(PayoutRequestService.asPayoutRequestResponse(updatedPayoutRequest));
     } catch (e) {
       res.status(500).send();
       this.logger.error(e);

--- a/src/controller/point-of-sale-controller.ts
+++ b/src/controller/point-of-sale-controller.ts
@@ -33,7 +33,7 @@ import PointOfSaleService from '../service/point-of-sale-service';
 import ContainerService from '../service/container-service';
 import PointOfSale from '../entity/point-of-sale/point-of-sale';
 import { asNumber } from '../helpers/validators';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import { isFail } from '../helpers/specification-validation';
 import {
   CreatePointOfSaleParams, CreatePointOfSaleRequest,
@@ -47,7 +47,7 @@ import {
 import userTokenInOrgan from '../helpers/token-helper';
 import TransactionService from '../service/transaction-service';
 import { PointOfSaleWithContainersResponse } from './response/point-of-sale-response';
-import UserService from '../service/user-service';
+import UserService, { asUserResponse } from '../service/user-service';
 import OrganMembership from '../entity/organ/organ-membership';
 import { parseUserToResponse } from '../helpers/revision-to-response';
 
@@ -157,7 +157,8 @@ export default class PointOfSaleController extends BaseController {
         return;
       }
 
-      res.json(await PointOfSaleService.createPointOfSale(params));
+      const revision = await PointOfSaleService.createPointOfSale(params);
+      res.json(PointOfSaleService.revisionToResponse(revision));
     } catch (error) {
       this.logger.error('Could not create point of sale:', error);
       res.status(500).json('Internal server error.');
@@ -192,8 +193,9 @@ export default class PointOfSaleController extends BaseController {
 
     // Handle request
     try {
-      const pointsOfSale = await PointOfSaleService.getPointsOfSale({}, { take, skip });
-      res.json(pointsOfSale);
+      const [revisions, count] = await PointOfSaleService.getPointsOfSale({}, { take, skip });
+      const records = revisions.map((r) => PointOfSaleService.revisionToResponse(r));
+      res.json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return all point of sales:', error);
       res.status(500).json('Internal server error.');
@@ -224,10 +226,10 @@ export default class PointOfSaleController extends BaseController {
         return;
       }
 
-      const pointOfSale = (await PointOfSaleService
-        .getPointsOfSale({ pointOfSaleId, returnContainers: true, returnProducts: true })).records[0];
-      if (pointOfSale) {
-        res.json(pointOfSale);
+      const [revisions] = await PointOfSaleService
+        .getPointsOfSale({ pointOfSaleId, returnContainers: true, returnProducts: true });
+      if (revisions[0]) {
+        res.json(PointOfSaleService.revisionToResponse(revisions[0]));
       }
     } catch (error) {
       this.logger.error('Could not return point of sale:', error);
@@ -261,19 +263,19 @@ export default class PointOfSaleController extends BaseController {
         return;
       }
 
-      const result = await PointOfSaleService.getPointsOfSale({
+      const [revisions] = await PointOfSaleService.getPointsOfSale({
         pointOfSaleId,
         pointOfSaleRevision,
         returnContainers: true,
         returnProducts: true,
       });
 
-      if (!result.records[0]) {
+      if (!revisions[0]) {
         res.status(404).json('Point of Sale revision not found.');
         return;
       }
 
-      res.json(result.records[0]);
+      res.json(PointOfSaleService.revisionToResponse(revisions[0]));
     } catch (error) {
       this.logger.error('Could not return point of sale revision:', error);
       res.status(500).json('Internal server error.');
@@ -319,7 +321,8 @@ export default class PointOfSaleController extends BaseController {
         return;
       }
 
-      res.json(await PointOfSaleService.updatePointOfSale(params));
+      const revision = await PointOfSaleService.updatePointOfSale(params);
+      res.json(PointOfSaleService.revisionToResponse(revision));
     } catch (error) {
       this.logger.error('Could not update Point of Sale:', error);
       res.status(500).json('Internal server error.');
@@ -346,10 +349,11 @@ export default class PointOfSaleController extends BaseController {
 
     // Handle request
     try {
-      const containers = await ContainerService.getContainers({
+      const [revisions, count] = await ContainerService.getContainers({
         posId: parseInt(id, 10),
       }, { take, skip });
-      res.json(containers);
+      const records = revisions.map((r) => ContainerService.revisionToResponse(r));
+      res.json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return all point of sale containers:', error);
       res.status(500).json('Internal server error.');
@@ -373,8 +377,11 @@ export default class PointOfSaleController extends BaseController {
     // Handle request
     try {
       const pointOfSaleId = parseInt(id, 10);
-      const products = (await PointOfSaleService.getPointsOfSale({ pointOfSaleId, returnContainers: true, returnProducts: true }))
-        .records.flatMap((p: PointOfSaleWithContainersResponse) => p.containers).flatMap((c) => c.products);
+      const [revisions] = await PointOfSaleService.getPointsOfSale({ pointOfSaleId, returnContainers: true, returnProducts: true });
+      const products = revisions
+        .map((r) => PointOfSaleService.revisionToResponse(r) as PointOfSaleWithContainersResponse)
+        .flatMap((p) => p.containers)
+        .flatMap((c) => c.products);
       res.json(products);
     } catch (error) {
       this.logger.error('Could not return all point of sale products:', error);
@@ -419,10 +426,10 @@ export default class PointOfSaleController extends BaseController {
         return;
       }
 
-      const transactions = await new TransactionService().getTransactions(
+      const [records, count] = await new TransactionService().getTransactions(
         { pointOfSaleId }, { take, skip },
       );
-      res.status(200).json(transactions);
+      res.status(200).json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return point of sale transactions:', error);
       res.status(500).json('Internal server error.');
@@ -465,9 +472,10 @@ export default class PointOfSaleController extends BaseController {
       });
 
       // Get cashiers (no indices needed)
-      const cashiers = await UserService.getUsers({
+      const [cashierUsers] = await UserService.getUsers({
         assignedRoleIds: pos.cashierRoles.map((r) => r.id),
       });
+      const cashierRecords = cashierUsers.map((u) => asUserResponse(u, true));
 
       // Map organ members to response format with indices
       const ownerMembers = organMemberships.map(om => ({
@@ -480,13 +488,13 @@ export default class PointOfSaleController extends BaseController {
       if (!canSeeEmail) {
         ownerResponse.email = undefined;
         ownerMembers.forEach((m) => { m.email = undefined; });
-        cashiers.records.forEach((u) => { u.email = undefined; });
+        cashierRecords.forEach((u) => { u.email = undefined; });
       }
 
       const response = {
         owner: ownerResponse,
         ownerMembers,
-        cashiers: cashiers.records,
+        cashiers: cashierRecords,
       };
       res.json(response);
     } catch (error) {

--- a/src/controller/product-category-controller.ts
+++ b/src/controller/product-category-controller.ts
@@ -31,7 +31,7 @@ import Policy from './policy';
 import { RequestWithToken } from '../middleware/token-middleware';
 import ProductCategoryService from '../service/product-category-service';
 import ProductCategoryRequest from './request/product-category-request';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 
 export default class ProductCategoryController extends BaseController {
   private logger: Logger = log4js.getLogger('ProductCategoryController');
@@ -103,14 +103,18 @@ export default class ProductCategoryController extends BaseController {
       return;
     }
 
-    // Handle requestd
+    // Handle request
     try {
-      const productCategories = await ProductCategoryService
+      const [categories, count] = await ProductCategoryService
         .getProductCategories({
           onlyRoot: req.query.onlyRoot === 'true',
           onlyLeaf: req.query.onlyLeaf === 'true',
         }, { take, skip });
-      res.json(productCategories);
+      res.json(toResponse(
+        categories.map(ProductCategoryService.asProductCategoryResponse),
+        count,
+        { take, skip },
+      ));
     } catch (error) {
       this.logger.error('Could not return all product-categories:', error);
       res.status(500).json('Internal server error.');
@@ -134,7 +138,8 @@ export default class ProductCategoryController extends BaseController {
     this.logger.trace('Create productcategory', body, 'by user', req.token.user);
     try {
       if (await ProductCategoryService.verifyProductCategory(body)) {
-        res.json(await ProductCategoryService.postProductCategory(body));
+        const category = await ProductCategoryService.postProductCategory(body);
+        res.json(ProductCategoryService.asProductCategoryResponse(category));
       } else {
         res.status(400).json('Invalid productcategory.');
       }
@@ -163,10 +168,9 @@ export default class ProductCategoryController extends BaseController {
     try {
       // check if product in database
       const parsedId = parseInt(id, 10);
-      const productCategory = (
-        (await ProductCategoryService.getProductCategories({ id: parsedId })).records[0]);
-      if (productCategory) {
-        res.json(productCategory);
+      const [categories] = await ProductCategoryService.getProductCategories({ id: parsedId });
+      if (categories.length > 0) {
+        res.json(ProductCategoryService.asProductCategoryResponse(categories[0]));
       } else {
         res.status(404).json('Productcategory not found.');
       }
@@ -199,9 +203,9 @@ export default class ProductCategoryController extends BaseController {
     try {
       if (await ProductCategoryService.verifyProductCategory(body)) {
         const parsedId = Number.parseInt(id, 10);
-        const update = await ProductCategoryService.patchProductCategory(parsedId, body);
-        if (update) {
-          res.json(update);
+        const category = await ProductCategoryService.patchProductCategory(parsedId, body);
+        if (category) {
+          res.json(ProductCategoryService.asProductCategoryResponse(category));
         } else {
           res.status(404).json('Productcategory not found.');
         }

--- a/src/controller/product-controller.ts
+++ b/src/controller/product-controller.ts
@@ -39,7 +39,7 @@ import CreateProductParams, {
 import Product from '../entity/product/product';
 import FileService from '../service/file-service';
 import { PRODUCT_IMAGE_LOCATION } from '../files/storage';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import { verifyCreateProductRequest, verifyProductRequest } from './request/validators/product-request-spec';
 import { isFail } from '../helpers/specification-validation';
 import { asNumber } from '../helpers/validators';
@@ -128,8 +128,9 @@ export default class ProductController extends BaseController {
 
     // Handle request
     try {
-      const products = await ProductService.getProducts({}, { take, skip });
-      res.status(200).json(products);
+      const [revisions, count] = await ProductService.getProducts({}, { take, skip });
+      const records = revisions.map((r) => ProductService.revisionToResponse(r));
+      res.status(200).json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return all products:', error);
       res.status(500).json('Internal server error.');
@@ -164,7 +165,12 @@ export default class ProductController extends BaseController {
         return;
       }
 
-      res.json(await ProductService.createProduct(request));
+      const revision = await ProductService.createProduct(request);
+      if (!revision) {
+        res.status(404).json('Product owner not found.');
+        return;
+      }
+      res.json(ProductService.revisionToResponse(revision));
     } catch (error) {
       this.logger.error('Could not create product:', error);
       res.status(500).json('Internal server error.');
@@ -209,7 +215,12 @@ export default class ProductController extends BaseController {
         return;
       }
 
-      res.json(await ProductService.updateProduct(params));
+      const revision = await ProductService.updateProduct(params);
+      if (!revision) {
+        res.status(500).json('Could not update product.');
+        return;
+      }
+      res.json(ProductService.revisionToResponse(revision));
     } catch (error) {
       this.logger.error('Could not update product:', error);
       res.status(500).json('Internal server error.');
@@ -234,10 +245,10 @@ export default class ProductController extends BaseController {
     // handle request
     try {
       // check if product in database
-      const product = (await ProductService
-        .getProducts({ productId: parseInt(id, 10) })).records[0];
-      if (product) {
-        res.json(product);
+      const [revisions] = await ProductService
+        .getProducts({ productId: parseInt(id, 10) });
+      if (revisions.length > 0) {
+        res.json(ProductService.revisionToResponse(revisions[0]));
       } else {
         res.status(404).json('Product not found.');
       }

--- a/src/controller/rbac-controller.ts
+++ b/src/controller/rbac-controller.ts
@@ -34,6 +34,8 @@ import { CreatePermissionParams, UpdateRoleRequest } from './request/rbac-reques
 import { verifyCreatePermissionRequest, verifyUpdateRoleRequest } from './request/validators/rbac-request-spec';
 import { isFail } from '../helpers/specification-validation';
 import Permission from '../entity/rbac/permission';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
+import { asUserResponse } from '../service/user-service';
 
 export default class RbacController extends BaseController {
   private logger: Logger = log4js.getLogger('RbacController');
@@ -179,8 +181,10 @@ export default class RbacController extends BaseController {
         return;
       }
 
-      const users = await RBACService.getRoleUsers(roleId);
-      res.json(users);
+      const pagination = parseRequestPagination(req);
+      const [users, count] = await RBACService.getRoleUsers(roleId, pagination);
+      const records = users.map((u) => asUserResponse(u, true));
+      res.json(toResponse(records, count, pagination));
     } catch (error) {
       this.logger.error('Could not get users of role:', error);
       res.status(500).json('Internal server error.');

--- a/src/controller/root-controller.ts
+++ b/src/controller/root-controller.ts
@@ -28,7 +28,7 @@ import { Request, Response } from 'express';
 import log4js, { Logger } from 'log4js';
 import BaseController, { BaseControllerOptions } from './base-controller';
 import Policy from './policy';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import BannerService from '../service/banner-service';
 import ServerSettingsStore from '../server-settings/server-settings-store';
 import { ServerStatusResponse } from './response/server-status-response';
@@ -103,7 +103,12 @@ export default class RootController extends BaseController {
 
     // handle request
     try {
-      res.json(await BannerService.getBanners({}, { take, skip }));
+      const [banners, count] = await BannerService.getBanners({}, { take, skip });
+      res.json(toResponse(
+        banners.map(BannerService.asBannerResponse),
+        count,
+        { take, skip },
+      ));
     } catch (error) {
       this.logger.error('Could not return all banners:', error);
       res.status(500).json('Internal server error.');
@@ -142,7 +147,8 @@ export default class RootController extends BaseController {
    */
   public async getLatestTOS(req: Request, res: Response): Promise<void> {
     try {
-      res.json(await TermsOfServiceService.getLatestTermsOfService());
+      const tos = await TermsOfServiceService.getLatestTermsOfService();
+      res.json(TermsOfServiceService.asTermsOfServiceResponse(tos));
     } catch (error) {
       this.logger.error('Could not get latest Terms of Service', error);
       res.status(500).json('Internal server error.');

--- a/src/controller/seller-payout-controller.ts
+++ b/src/controller/seller-payout-controller.ts
@@ -29,9 +29,8 @@ import { Response } from 'express';
 import log4js, { Logger } from 'log4js';
 import Policy from './policy';
 import { RequestWithToken } from '../middleware/token-middleware';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import SellerPayoutService, { parseSellerPayoutFilters } from '../service/seller-payout-service';
-import { PaginatedSellerPayoutResponse } from './response/seller-payout-response';
 import { CreateSellerPayoutRequest, UpdateSellerPayoutRequest } from './request/seller-payout-request';
 import User from '../entity/user/user';
 import ReportService, { SalesReportService } from '../service/report-service';
@@ -121,11 +120,7 @@ export default class SellerPayoutController extends BaseController {
       const service = new SellerPayoutService();
       const [records, count] = await service.getSellerPayouts(filters, { take, skip });
 
-      const response: PaginatedSellerPayoutResponse = {
-        records: records.map(SellerPayoutService.asSellerPayoutResponse),
-        _pagination: { take, skip, count },
-      };
-      res.json(response);
+      res.json(toResponse(records.map(SellerPayoutService.asSellerPayoutResponse), count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return all seller payouts:', error);
       res.status(500).json('Internal server error.');

--- a/src/controller/stripe-controller.ts
+++ b/src/controller/stripe-controller.ts
@@ -96,8 +96,14 @@ export default class StripeController extends BaseController {
         return;
       }
 
-      const result = await this.stripeService.createStripePaymentIntent(req.token.user, amount);
-      res.status(200).json(result);
+      const { deposit, clientSecret } = await this.stripeService.createStripePaymentIntent(req.token.user, amount);
+      res.status(200).json({
+        id: deposit.id,
+        createdAt: deposit.createdAt.toISOString(),
+        updatedAt: deposit.updatedAt.toISOString(),
+        stripeId: deposit.stripePaymentIntent.stripeId,
+        clientSecret,
+      });
     } catch (error) {
       this.logger.error('Could not create Stripe payment intent:', error);
       res.status(500).send('Internal server error.');

--- a/src/controller/terms-of-service-controller.ts
+++ b/src/controller/terms-of-service-controller.ts
@@ -79,7 +79,8 @@ export default class TermsOfServiceController extends BaseController {
     }
 
     try {
-      res.json(await TermsOfServiceService.getTermsOfService(String(version)));
+      const tos = await TermsOfServiceService.getTermsOfService(String(version));
+      res.json(TermsOfServiceService.asTermsOfServiceResponse(tos));
     } catch (error) {
       if (error instanceof Error && error.message.includes('not found')) {
         res.status(404).json({ error: error.message });

--- a/src/controller/transaction-controller.ts
+++ b/src/controller/transaction-controller.ts
@@ -32,8 +32,7 @@ import { RequestWithToken } from '../middleware/token-middleware';
 import TransactionService, {
   parseGetTransactionsFilters,
 } from '../service/transaction-service';
-import { TransactionResponse } from './response/transaction-response';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import { TransactionRequest } from './request/transaction-request';
 import Transaction from '../entity/transactions/transaction';
 import { asNumber } from '../helpers/validators';
@@ -148,8 +147,8 @@ export default class TransactionController extends BaseController {
     }
 
     try {
-      const transactions = await new TransactionService().getTransactions(filters, { take, skip });
-      res.status(200).json(transactions);
+      const [records, count] = await new TransactionService().getTransactions(filters, { take, skip });
+      res.status(200).json(toResponse(records, count, { take, skip }));
     } catch (e) {
       res.status(500).send();
       this.logger.error(e);
@@ -203,9 +202,9 @@ export default class TransactionController extends BaseController {
       }
 
       // create the transaction using context
-      const result = await transactionService.createTransaction(body, context);
-      
-      res.json(result);
+      const transaction = await transactionService.createTransaction(body, context);
+
+      res.json(await transactionService.asTransactionResponse(transaction));
     } catch (error) {
       this.logger.error('Could not create transaction:', error);
       res.status(500).json('Internal server error.');
@@ -222,26 +221,26 @@ export default class TransactionController extends BaseController {
    * @return {TransactionResponse} 200 - Single transaction with given id
    * @return {string} 404 - Nonexistent transaction id
    */
-  public async getTransaction(req: RequestWithToken, res: Response): Promise<TransactionResponse> {
+  public async getTransaction(req: RequestWithToken, res: Response): Promise<void> {
     const parameters = req.params;
     this.logger.trace('Get single transaction', parameters, 'by user', req.token.user);
 
     let transaction;
     try {
-      transaction = await new TransactionService().getSingleTransaction(parseInt(parameters.id, 10));
+      const transactionService = new TransactionService();
+      transaction = await transactionService.getSingleTransaction(parseInt(parameters.id, 10));
+
+      // If the transaction is undefined, there does not exist a transaction with the given ID
+      if (transaction === undefined) {
+        res.status(404).json('Unknown transaction ID.');
+        return;
+      }
+
+      res.status(200).json(await transactionService.asTransactionResponse(transaction));
     } catch (e) {
       res.status(500).send();
       this.logger.error(e);
-      return;
     }
-
-    // If the transaction is undefined, there does not exist a transaction with the given ID
-    if (transaction === undefined) {
-      res.status(404).json('Unknown transaction ID.');
-      return;
-    }
-
-    res.status(200).json(transaction);
   }
 
   /**
@@ -273,9 +272,14 @@ export default class TransactionController extends BaseController {
           res.status(400).json('Invalid transaction.');
           return;
         }
-        res.status(200).json(await transactionService.updateTransaction(
+        const transaction = await transactionService.updateTransaction(
           parseInt(id, 10), body,
-        ));
+        );
+        if (!transaction) {
+          res.status(400).json('Could not update transaction.');
+          return;
+        }
+        res.status(200).json(await transactionService.asTransactionResponse(transaction));
       } else {
         res.status(404).json('Transaction not found.');
       }
@@ -338,7 +342,7 @@ export default class TransactionController extends BaseController {
       }
 
       const invoices = await new InvoiceService().getTransactionInvoices(transactionId);
-      res.status(200).json(invoices);
+      res.status(200).json(InvoiceService.toArrayWithoutEntriesResponse(invoices));
     } catch (error) {
       this.logger.error('Could not return transaction invoices:', error);
       res.status(500).json('Internal server error.');

--- a/src/controller/transfer-controller.ts
+++ b/src/controller/transfer-controller.ts
@@ -32,7 +32,7 @@ import { RequestWithToken } from '../middleware/token-middleware';
 import TransferService, { parseGetTransferFilters } from '../service/transfer-service';
 import TransferRequest from './request/transfer-request';
 import Transfer from '../entity/transactions/transfer';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import userTokenInOrgan from '../helpers/token-helper';
 import { PdfError } from '../errors';
 
@@ -133,8 +133,9 @@ export default class TransferController extends BaseController {
     }
 
     try {
-      const transfers = await new TransferService().getTransfers(filters, { take, skip });
-      res.json(transfers);
+      const [transfers, count] = await new TransferService().getTransfers(filters, { take, skip });
+      const records = transfers.map((t) => TransferService.asTransferResponse(t));
+      res.json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return all transfers:', error);
       res.status(500).json('Internal server error.');
@@ -157,10 +158,9 @@ export default class TransferController extends BaseController {
     this.logger.trace('Get single transfer', id, 'by user', req.token.user);
     try {
       const parsedId = parseInt(id, 10);
-      const transfer = (
-        (await new TransferService().getTransfers({ id: parsedId }, {})).records[0]);
-      if (transfer) {
-        res.json(transfer);
+      const [transfers] = await new TransferService().getTransfers({ id: parsedId }, {});
+      if (transfers.length > 0) {
+        res.json(TransferService.asTransferResponse(transfers[0]));
       } else {
         res.status(404).json('Transfer not found.');
       }
@@ -194,7 +194,8 @@ export default class TransferController extends BaseController {
         return;
       }
 
-      res.json(await transferService.postTransfer(request));
+      const transfer = await transferService.postTransfer(request);
+      res.json(TransferService.asTransferResponse(transfer));
     } catch (error) {
       this.logger.error('Could not create transfer:', error);
       res.status(500).json('Internal server error.');

--- a/src/controller/user-controller.ts
+++ b/src/controller/user-controller.ts
@@ -36,7 +36,7 @@ import BaseUserRequest, {
   PatchUserTypeRequest,
   UpdateUserRequest,
 } from './request/user-request';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import ProductService from '../service/product-service';
 import PointOfSaleService from '../service/point-of-sale-service';
 import TransactionService, { parseGetTransactionsFilters } from '../service/transaction-service';
@@ -49,6 +49,7 @@ import { isFail } from '../helpers/specification-validation';
 import verifyUpdatePinRequest from './request/validators/update-pin-request-spec';
 import UpdatePinRequest from './request/update-pin-request';
 import UserService, {
+  asUserResponse,
   parseGetFinancialMutationsFilters,
   parseGetUsersFilters,
   UserFilterParameters,
@@ -448,11 +449,15 @@ export default class UserController extends BaseController {
     }
 
     try {
-      const users = await UserService.getUsers(filters, { take, skip });
+      const [users, count] = await UserService.getUsers(filters, { take, skip });
+      const records = users.map((u) => asUserResponse(u, true));
       if (!await this.canSeeEmail(req, 'all')) {
-        users.records.forEach((u) => { u.email = undefined; });
+        records.forEach((u) => { u.email = undefined; });
       }
-      res.status(200).json(users);
+      res.status(200).json({
+        _pagination: { take, skip, count },
+        records,
+      });
     } catch (error) {
       this.logger.error('Could not get users:', error);
       res.status(500).json('Internal server error.');
@@ -769,11 +774,15 @@ export default class UserController extends BaseController {
         return;
       }
 
-      const members = await UserService.getUsers({ organId }, { take, skip });
+      const [members, count] = await UserService.getUsers({ organId }, { take, skip });
+      const records = members.map((u) => asUserResponse(u, true));
       if (!await this.canSeeEmail(req, UserController.getRelation(req))) {
-        members.records.forEach((u) => { u.email = undefined; });
+        records.forEach((u) => { u.email = undefined; });
       }
-      res.status(200).json(members);
+      res.status(200).json({
+        _pagination: { take, skip, count },
+        records,
+      });
     } catch (error) {
       this.logger.error('Could not get organ members:', error);
       res.status(500).json('Internal server error.');
@@ -803,10 +812,11 @@ export default class UserController extends BaseController {
         return;
       }
 
+      const response = asUserResponse(user, true);
       if (!await this.canSeeEmail(req, UserController.getRelation(req))) {
-        user.email = undefined;
+        response.email = undefined;
       }
-      res.status(200).json(user);
+      res.status(200).json(response);
     } catch (error) {
       this.logger.error('Could not get individual user:', error);
       res.status(500).json('Internal server error.');
@@ -837,7 +847,7 @@ export default class UserController extends BaseController {
       }
 
       const user = await UserService.createUser(body);
-      res.status(201).json(user);
+      res.status(201).json(asUserResponse(user, true));
     } catch (error) {
       this.logger.error('Could not create user:', error);
       res.status(500).json('Internal server error.');
@@ -892,9 +902,8 @@ export default class UserController extends BaseController {
         ...body,
       } as User;
       await User.update(parameters.id, user);
-      res.status(200).json(
-        await UserService.getSingleUser(asNumber(parameters.id)),
-      );
+      const updatedUser = await UserService.getSingleUser(asNumber(parameters.id));
+      res.status(200).json(asUserResponse(updatedUser, true));
     } catch (error) {
       this.logger.error('Could not update user:', error);
       res.status(500).json('Internal server error.');
@@ -1045,8 +1054,9 @@ export default class UserController extends BaseController {
         return;
       }
 
-      const products = await ProductService.getProducts({}, { take, skip }, owner);
-      res.json(products);
+      const [revisions, count] = await ProductService.getProducts({}, { take, skip }, owner);
+      const records = revisions.map((r) => ProductService.revisionToResponse(r));
+      res.json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return all products:', error);
       res.status(500).json('Internal server error.');
@@ -1091,9 +1101,10 @@ export default class UserController extends BaseController {
         return;
       }
 
-      const containers = (await ContainerService
-        .getContainers({}, { take, skip }, user));
-      res.json(containers);
+      const [revisions, count] = await ContainerService
+        .getContainers({}, { take, skip }, user);
+      const records = revisions.map((r) => ContainerService.revisionToResponse(r));
+      res.json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return containers:', error);
       res.status(500).json('Internal server error.');
@@ -1138,9 +1149,10 @@ export default class UserController extends BaseController {
         return;
       }
 
-      const pointsOfSale = (await PointOfSaleService
-        .getPointsOfSale({}, { take, skip }, user));
-      res.json(pointsOfSale);
+      const [revisions, count] = await PointOfSaleService
+        .getPointsOfSale({}, { take, skip }, user);
+      const records = revisions.map((r) => PointOfSaleService.revisionToResponse(r));
+      res.json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return point of sale:', error);
       res.status(500).json('Internal server error.');
@@ -1199,9 +1211,9 @@ export default class UserController extends BaseController {
         res.status(404).json({});
         return;
       }
-      const transactions = await new TransactionService().getTransactions(filters, { take, skip }, user);
+      const [records, count] = await new TransactionService().getTransactions(filters, { take, skip }, user);
 
-      res.status(200).json(transactions);
+      res.status(200).json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return all transactions:', error);
       res.status(500).json('Internal server error.');
@@ -1439,10 +1451,11 @@ export default class UserController extends BaseController {
         return;
       }
 
-      const transfers = (await new TransferService().getTransfers(
+      const [transfers, count] = await new TransferService().getTransfers(
         { ...filters }, { take, skip }, user,
-      ));
-      res.json(transfers);
+      );
+      const records = transfers.map((t) => TransferService.asTransferResponse(t));
+      res.json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return user transfers', error);
       res.status(500).json('Internal server error.');
@@ -1555,7 +1568,7 @@ export default class UserController extends BaseController {
       }
 
       const deposits = await StripeService.getProcessingStripeDepositsFromUser(id);
-      res.status(200).json(deposits);
+      res.status(200).json(deposits.map((d) => StripeService.asStripeDepositResponse(d)));
     } catch (error) {
       this.logger.error('Could not get processing deposits of user:', error);
       res.status(500).json('Internal server error.');
@@ -1901,9 +1914,8 @@ export default class UserController extends BaseController {
       }
 
       await UserService.updateUserType(user, body.userType);
-      res.status(200).json(
-        await UserService.getSingleUser(userId),
-      );
+      const updatedUser = await UserService.getSingleUser(userId);
+      res.status(200).json(asUserResponse(updatedUser, true));
     } catch (e) {
       res.status(500).send('Internal server error.');
       this.logger.error(e);

--- a/src/controller/vat-group-controller.ts
+++ b/src/controller/vat-group-controller.ts
@@ -29,7 +29,7 @@ import { Response } from 'express';
 import BaseController, { BaseControllerOptions } from './base-controller';
 import Policy from './policy';
 import { RequestWithToken } from '../middleware/token-middleware';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import VatGroupService, {
   canSetVatGroupToDeleted,
   parseGetVatCalculationValuesParams,
@@ -128,8 +128,8 @@ export default class VatGroupController extends BaseController {
     }
 
     try {
-      const vatGroups = await VatGroupService.getVatGroups(filters, { take, skip });
-      res.status(200).json(vatGroups);
+      const [vatGroups, count] = await VatGroupService.getVatGroups(filters, { take, skip });
+      res.status(200).json(toResponse(vatGroups.map((v) => VatGroupService.toResponse(v)), count, { take, skip }));
     } catch (e) {
       res.status(500).send('Internal server error.');
       this.logger.error(e);
@@ -152,11 +152,11 @@ export default class VatGroupController extends BaseController {
     this.logger.trace('Get single VAT group', id, ' by user', req.token.user);
 
     try {
-      const { records } = await VatGroupService.getVatGroups({
+      const [vatGroups] = await VatGroupService.getVatGroups({
         vatGroupId: Number.parseInt(id, 10),
       });
-      if (records.length > 0) {
-        res.json(records[0]);
+      if (vatGroups.length > 0) {
+        res.json(VatGroupService.toResponse(vatGroups[0]));
       } else {
         res.status(404).json('VAT group not found.');
       }
@@ -192,7 +192,8 @@ export default class VatGroupController extends BaseController {
     }
 
     try {
-      res.json(await VatGroupService.createVatGroup(body));
+      const vatGroup = await VatGroupService.createVatGroup(body);
+      res.json(VatGroupService.toResponse(vatGroup));
     } catch (e) {
       res.status(500).send('Internal server error.');
       this.logger.error(e);
@@ -224,9 +225,8 @@ export default class VatGroupController extends BaseController {
     }
 
     try {
-      let vatGroup = (await VatGroupService
-        .getVatGroups({ vatGroupId: id })).records[0];
-      if (!vatGroup) {
+      const [vatGroups] = await VatGroupService.getVatGroups({ vatGroupId: id });
+      if (vatGroups.length === 0) {
         res.status(404).json('VAT group not found.');
         return;
       }
@@ -239,8 +239,8 @@ export default class VatGroupController extends BaseController {
         }
       }
 
-      vatGroup = await VatGroupService.updateVatGroup(id, body);
-      res.status(200).json(vatGroup);
+      const vatGroup = await VatGroupService.updateVatGroup(id, body);
+      res.status(200).json(VatGroupService.toResponse(vatGroup));
     } catch (error) {
       this.logger.error('Could not update VAT group:', error);
       res.status(500).json('Internal server error.');

--- a/src/controller/voucher-group-controller.ts
+++ b/src/controller/voucher-group-controller.ts
@@ -32,7 +32,7 @@ import { VoucherGroupRequest } from './request/voucher-group-request';
 import { RequestWithToken } from '../middleware/token-middleware';
 import VoucherGroup from '../entity/user/voucher-group';
 import VoucherGroupService from '../service/voucher-group-service';
-import { parseRequestPagination } from '../helpers/pagination';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 
 export default class VoucherGroupController extends BaseController {
   private logger: Logger = log4js.getLogger('VoucherGroupController');
@@ -101,7 +101,9 @@ export default class VoucherGroupController extends BaseController {
 
     // handle request
     try {
-      res.json(await VoucherGroupService.getVoucherGroups({}, { take, skip }));
+      const [bkgs, count] = await VoucherGroupService.getVoucherGroups({}, { take, skip });
+      const records = bkgs.map((bkg) => VoucherGroupService.asVoucherGroupResponse(bkg, bkg.vouchers.map((v) => v.user)));
+      res.json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return all voucher groups:', error);
       res.status(500).json('Internal server error.');
@@ -132,7 +134,8 @@ export default class VoucherGroupController extends BaseController {
         res.status(400).json('Invalid voucher group.');
         return;
       }
-      res.json(await VoucherGroupService.createVoucherGroup(voucherGroupParams));
+      const { voucherGroup, users } = await VoucherGroupService.createVoucherGroup(voucherGroupParams);
+      res.json(VoucherGroupService.asVoucherGroupResponse(voucherGroup, users));
     } catch (error) {
       this.logger.error('Could not create voucher group:', error);
       res.status(500).json('Internal server error.');
@@ -157,9 +160,10 @@ export default class VoucherGroupController extends BaseController {
 
     // handle request
     try {
-      const bkg = await VoucherGroupService.getVoucherGroups({ bkgId });
-      if (bkg.records[0]) {
-        res.json(bkg.records[0]);
+      const [bkgs] = await VoucherGroupService.getVoucherGroups({ bkgId });
+      if (bkgs[0]) {
+        const bkg = bkgs[0];
+        res.json(VoucherGroupService.asVoucherGroupResponse(bkg, bkg.vouchers.map((v) => v.user)));
       } else {
         res.status(404).json('Voucher group not found.');
       }
@@ -210,8 +214,9 @@ export default class VoucherGroupController extends BaseController {
         res.status(400).json('Cannot decrease number of VoucherGroupUsers');
         return;
       }
+      const result = await VoucherGroupService.updateVoucherGroup(bkgId, voucherGroupParams);
       res.status(200).json(
-        await VoucherGroupService.updateVoucherGroup(bkgId, voucherGroupParams),
+        VoucherGroupService.asVoucherGroupResponse(result.voucherGroup, result.users),
       );
     } catch (error) {
       this.logger.error('Could not update voucher group:', error);

--- a/src/controller/write-off-controller.ts
+++ b/src/controller/write-off-controller.ts
@@ -29,8 +29,7 @@ import BaseController, { BaseControllerOptions } from './base-controller';
 import log4js, { Logger } from 'log4js';
 import Policy from './policy';
 import { RequestWithToken } from '../middleware/token-middleware';
-import { parseRequestPagination } from '../helpers/pagination';
-import { PaginatedWriteOffResponse } from './response/write-off-response';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import WriteOffService, { parseWriteOffFilterParameters } from '../service/write-off-service';
 import WriteOff from '../entity/transactions/write-off';
 import WriteOffRequest from './request/write-off-request';
@@ -109,10 +108,10 @@ export default class WriteOffController extends BaseController {
 
     try {
       const filters = parseWriteOffFilterParameters(req);
-      const writeOffs: PaginatedWriteOffResponse = await WriteOffService.getWriteOffs(
+      const [writeOffs, count] = await WriteOffService.getWriteOffs(
         filters, { take, skip },
       );
-      res.json(writeOffs);
+      res.json(toResponse(writeOffs.map(WriteOffService.asWriteOffResponse), count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return all write offs:', error);
       res.status(500).json('Internal server error.');
@@ -178,7 +177,7 @@ export default class WriteOffController extends BaseController {
       }
 
       const writeOff = await new WriteOffService().createWriteOffAndCloseUser(user);
-      res.status(200).json(writeOff);
+      res.status(200).json(WriteOffService.asWriteOffResponse(writeOff));
     } catch (error) {
       this.logger.error('Could not create write off:', error);
       res.status(500).json('Internal server error.');

--- a/src/gewis/controller/gewis-authentication-controller.ts
+++ b/src/gewis/controller/gewis-authentication-controller.ts
@@ -178,12 +178,12 @@ export default class GewisAuthenticationController extends BaseController {
         await UserService.updateUserType(memberUser.user, UserType.MEMBER);
       }
 
-      const response = await new AuthenticationService().getSaltedToken({
+      const result = await new AuthenticationService().getSaltedToken({
         user: memberUser.user,
         context: { roleManager: this.roleManager, tokenHandler: this.tokenHandler },
         salt: body.nonce,
       });
-      res.json(response);
+      res.json(AuthenticationService.asAuthenticationResponse(result.user, result.roles, result.organs, result.token));
     } catch (error) {
       this.logger.error('Could not create token:', error);
       res.status(500).json('Internal server error.');

--- a/src/helpers/pagination.ts
+++ b/src/helpers/pagination.ts
@@ -107,3 +107,20 @@ export function parseRequestPagination(req: Request): { take: number, skip: numb
 
   return { take, skip };
 }
+
+/**
+ * Build a paginated response from a [records, count] tuple.
+ * Use this in controllers to wrap service results into the standard paginated response format.
+ *
+ * @param records - The records to include in the response
+ * @param count - The total number of matching records (before pagination)
+ * @param pagination - The pagination parameters used for the query
+ */
+export function toResponse<R>(
+  records: R[], count: number, pagination: PaginationParameters,
+): { _pagination: PaginationResult; records: R[] } {
+  return {
+    _pagination: { take: pagination.take, skip: pagination.skip, count },
+    records,
+  };
+}

--- a/src/service/authentication-service.ts
+++ b/src/service/authentication-service.ts
@@ -59,6 +59,13 @@ export interface ResetTokenInfo {
   password: string,
 }
 
+export interface AuthenticationResult {
+  user: User,
+  roles: Role[],
+  organs: User[],
+  token: string,
+}
+
 /**
  * The authentication service is responsible for verifying user authentications and handing out json web tokens.
  */
@@ -309,7 +316,7 @@ export default class AuthenticationService extends WithManager {
    */
   public async HashAuthentication<T extends HashBasedAuthenticationMethod>(pass: string,
     authenticator: T, context: AuthenticationContext, posId?: number)
-    : Promise<AuthenticationResponse | undefined> {
+    : Promise<AuthenticationResult | undefined> {
     const valid = await this.compareHash(pass, authenticator.hash);
     if (!valid) return undefined;
 
@@ -531,19 +538,19 @@ export default class AuthenticationService extends WithManager {
     salt?: string;
     expiry?: number;
     posId?: number;
-  }): Promise<AuthenticationResponse> {
+  }): Promise<AuthenticationResult> {
     const { user, context, salt, expiry, posId } = params;
-    
+
     // Update lastSeen locally
     user.lastSeen = new Date();
-    
+
     // Save in background without awaiting
     this.manager.save(User, user).catch((error) => {
       // Log error but don't block
       const logger: Logger = log4js.getLogger('AuthenticationService');
       logger.error('Failed to save lastSeen timestamp:', error);
     });
-    
+
     const [froles, organs] = await Promise.all([
       context.roleManager.getRoles(user, true),
       context.roleManager.getUserOrgans(user),
@@ -555,7 +562,7 @@ export default class AuthenticationService extends WithManager {
     const finalSalt = salt || await bcrypt.genSalt(AuthenticationService.BCRYPT_ROUNDS);
     const token = await context.tokenHandler.signToken(contents, finalSalt, expiry);
 
-    return AuthenticationService.asAuthenticationResponse(contents.user, roles, contents.organs, token);
+    return { user: contents.user, roles, organs: contents.organs, token };
   }
 
   public async compareHash(password: string, hash: string): Promise<boolean> {

--- a/src/service/balance-service.ts
+++ b/src/service/balance-service.ts
@@ -26,7 +26,6 @@
 
 import Balance from '../entity/transactions/balance';
 import BalanceResponse, {
-  PaginatedBalanceResponse,
   TotalBalanceResponse,
   UserTypeTotalBalanceResponse,
 } from '../controller/response/balance-response';
@@ -219,18 +218,14 @@ export default class BalanceService extends WithManager {
    * @param allowDeleted allow balances of deleted users to be returned
    * @param inactive only return inactive users
    * @param pagination pagination options
-   * @returns the current balance of a user
+   * @returns {Promise<[BalanceResponse[], number]>} the balances and total count
    */
   public async getBalances({
     ids, date, minBalance, maxBalance, hasFine, minFine, maxFine, userTypes, orderDirection, orderBy, allowDeleted, inactive,
-  }: GetBalanceParameters, pagination: PaginationParameters = {}): Promise<PaginatedBalanceResponse> {
+  }: GetBalanceParameters, pagination: PaginationParameters = {}): Promise<[BalanceResponse[], number]> {
     // Return the empty response if request has no ids.
     if (ids?.length === 0) {
-      const { take, skip } = pagination;
-      return {
-        _pagination: { take, skip, count: 0 },
-        records: [],
-      };
+      return [[], 0];
     }
 
     const connection = this.manager.connection;
@@ -379,10 +374,10 @@ export default class BalanceService extends WithManager {
     const count = (await connection.query(query, parameters)).length;
 
 
-    return {
-      _pagination: { take, skip, count },
-      records: balances.map((b: object) => BalanceService.asBalanceResponse(b, date ?? new Date())),
-    };
+    return [
+      balances.map((b: object) => BalanceService.asBalanceResponse(b, date ?? new Date())),
+      count,
+    ];
   }
 
   /**
@@ -391,7 +386,7 @@ export default class BalanceService extends WithManager {
    * @param date Date to calculate balance for
    */
   public async getBalance(id: number, date?: Date): Promise<BalanceResponse> {
-    return (await this.getBalances({ ids: [id], allowDeleted: true, date })).records[0];
+    return (await this.getBalances({ ids: [id], allowDeleted: true, date }))[0][0];
   }
 
   /**
@@ -401,9 +396,9 @@ export default class BalanceService extends WithManager {
    */
   public async calculateTotalBalances(date: Date, allowDeleted?: boolean): Promise<TotalBalanceResponse> {
     const posBalanceRes = (await this.getBalances(
-      { date, minBalance: DineroTransformer.Instance.from(0), allowDeleted })).records;
+      { date, minBalance: DineroTransformer.Instance.from(0), allowDeleted }))[0];
     const negBalanceRes = (await this.getBalances(
-      { date, maxBalance: DineroTransformer.Instance.from(0), allowDeleted })).records;
+      { date, maxBalance: DineroTransformer.Instance.from(0), allowDeleted }))[0];
 
     const totalPos =  BalanceService.calculateTotal(posBalanceRes);
     const totalNeg = BalanceService.calculateTotal(negBalanceRes);
@@ -418,9 +413,9 @@ export default class BalanceService extends WithManager {
     for (const [index, type] of userTypes.entries()) {
       promises.push(this.getBalances(
         { userTypes: [type], date, minBalance: DineroTransformer.Instance.from(0), allowDeleted })
-        .then((r) => typedPosBalance[index] = r.records));
+        .then((r) => typedPosBalance[index] = r[0]));
       promises.push(this.getBalances({ userTypes: [type], date, maxBalance: DineroTransformer.Instance.from(0), allowDeleted })
-        .then((r) => typedNegBalance[index] = r.records));
+        .then((r) => typedNegBalance[index] = r[0]));
     }
 
     await Promise.all(promises);

--- a/src/service/banner-service.ts
+++ b/src/service/banner-service.ts
@@ -24,7 +24,7 @@
 
 import { FindManyOptions, LessThanOrEqual, Raw } from 'typeorm';
 import BannerRequest from '../controller/request/banner-request';
-import { BannerResponse, PaginatedBannerResponse } from '../controller/response/banner-response';
+import { BannerResponse } from '../controller/response/banner-response';
 import Banner from '../entity/banner';
 import QueryFilter, { FilterMapping } from '../helpers/query-filter';
 import FileService from './file-service';
@@ -132,11 +132,11 @@ export default class BannerService {
    * Returns all banners with options.
    * @param filters - The filtering parameters.
    * @param pagination - The pagination options.
-   * @returns {Array.<BannerResponse>} - all banners
+   * @returns {[Banner[], number]} - tuple of banners and total count
    */
   public static async getBanners(
     filters: BannerFilterParameters, pagination: PaginationParameters = {},
-  ): Promise<PaginatedBannerResponse> {
+  ): Promise<[Banner[], number]> {
     const { take, skip } = pagination;
 
     const mapping: FilterMapping = {
@@ -174,37 +174,30 @@ export default class BannerService {
       take,
       skip,
     });
-    const records = banners.map((banner) => this.asBannerResponse(banner));
+    const count = await Banner.count(options);
 
-    return {
-      _pagination: {
-        take,
-        skip,
-        count: await Banner.count(options),
-      },
-      records,
-    };
+    return [banners, count];
   }
 
   /**
    * Saves a banner to the database.
    * @param bannerReq
-   * @returns {BannerResponse.model} - saved banner
+   * @returns {Banner.model} - saved banner
    */
-  public static async createBanner(bannerReq: BannerRequest): Promise<BannerResponse> {
+  public static async createBanner(bannerReq: BannerRequest): Promise<Banner> {
     // save and return banner
     const banner = this.asBanner(bannerReq);
     await Banner.save(banner);
-    return this.asBannerResponse(banner);
+    return banner;
   }
 
   /**
    * Updates and returns banner with given id.
    * @param id - requested banner id
    * @param bannerReq
-   * @returns {BannerResponse.model} - updated banner
+   * @returns {Banner.model} - updated banner
    */
-  public static async updateBanner(id: number, bannerReq: BannerRequest): Promise<BannerResponse> {
+  public static async updateBanner(id: number, bannerReq: BannerRequest): Promise<Banner> {
     // check if banner in database
     const bannerFound = await Banner.findOne({ where: { id } });
 
@@ -216,16 +209,16 @@ export default class BannerService {
     // patch banner if found
     const banner = this.asBanner(bannerReq);
     await Banner.update(id, banner);
-    return this.asBannerResponse(await Banner.findOne({ where: { id }, relations: ['image'] }));
+    return Banner.findOne({ where: { id }, relations: ['image'] });
   }
 
   /**
    * Deletes the requested banner from the database
    * @param id - requested banner id
    * @param fileService
-   * @returns {BannerResponse.model} - deleted banner
+   * @returns {Banner.model} - deleted banner
    */
-  public static async deleteBanner(id: number, fileService: FileService): Promise<BannerResponse> {
+  public static async deleteBanner(id: number, fileService: FileService): Promise<Banner> {
     // check if banner in database
     const banner = await Banner.findOne({ where: { id }, relations: ['image'] });
 
@@ -246,6 +239,6 @@ export default class BannerService {
 
     // Restore the banner image so the response will be correct
     banner.image = bannerImage;
-    return this.asBannerResponse(banner);
+    return banner;
   }
 }

--- a/src/service/container-service.ts
+++ b/src/service/container-service.ts
@@ -29,8 +29,6 @@ import {
   BaseContainerResponse,
   ContainerResponse,
   ContainerWithProductsResponse,
-  PaginatedContainerResponse,
-  PaginatedContainerWithProductResponse,
 } from '../controller/response/container-response';
 import Container from '../entity/container/container';
 import ContainerRevision from '../entity/container/container-revision';
@@ -138,26 +136,16 @@ export default class ContainerService {
    */
   public static async getContainers(
     filters: ContainerFilterParameters = {}, pagination: PaginationParameters = {}, user?: User,
-  ): Promise<PaginatedContainerResponse | PaginatedContainerWithProductResponse> {
+  ): Promise<[ContainerRevision[], number]> {
     const { take, skip } = pagination;
 
     const options = await this.getOptions(filters, user);
-    const [data, count] = await ContainerRevision.findAndCount({ ...options, take, skip });
-
-    const records = data.map((revision) => this.revisionToResponse(revision));
-
-    return {
-      _pagination: {
-        take, skip, count,
-      },
-      records,
-    };
+    return ContainerRevision.findAndCount({ ...options, take, skip });
   }
 
-  public static async getSingleContainer(filters: ContainerFilterParameters = {}): Promise<ContainerWithProductsResponse> {
+  public static async getSingleContainer(filters: ContainerFilterParameters = {}): Promise<ContainerRevision | undefined> {
     const options = await this.getOptions(filters);
-    const container = await ContainerRevision.findOne({ ...options });
-    return this.revisionToResponse(container) as ContainerWithProductsResponse;
+    return ContainerRevision.findOne({ ...options });
   }
 
   /**
@@ -165,7 +153,7 @@ export default class ContainerService {
    * @param container - The params that describe the container to be created.
    */
   public static async createContainer(container: CreateContainerParams)
-    : Promise<ContainerWithProductsResponse> {
+    : Promise<ContainerRevision> {
     const base = Object.assign(new Container(), {
       public: container.public,
       owner: container.ownerId,
@@ -186,7 +174,7 @@ export default class ContainerService {
    * Updates a container by directly creating a revision.
    * @param update - The container update
    */
-  public static async updateContainer(update: UpdateContainerParams): Promise<ContainerWithProductsResponse> {
+  public static async updateContainer(update: UpdateContainerParams): Promise<ContainerRevision> {
     const base = await Container.findOne({ where: { id: update.id } });
 
     if (base == null) throw new Error('Container not found.');
@@ -217,7 +205,7 @@ export default class ContainerService {
     await this.propagateContainerUpdate(base.id);
 
     const options = await this.getOptions({ containerId: base.id, returnProducts: true });
-    return (this.revisionToResponse(await ContainerRevision.findOne({ ...options }))) as ContainerWithProductsResponse;
+    return ContainerRevision.findOne({ ...options });
   }
 
   /**

--- a/src/service/debtor-service.ts
+++ b/src/service/debtor-service.ts
@@ -32,7 +32,6 @@ import {
   BaseFineHandoutEventResponse,
   FineHandoutEventResponse,
   FineResponse,
-  PaginatedFineHandoutEventResponse,
   UserFineGroupResponse,
   UserToFineResponse,
 } from '../controller/response/debtor-response';
@@ -121,7 +120,7 @@ export default class DebtorService extends WithManager {
   /**
    * Get a list of all fine handout events in chronological order
    */
-  public async getFineHandoutEvents(pagination: PaginationParameters = {}): Promise<PaginatedFineHandoutEventResponse> {
+  public async getFineHandoutEvents(pagination: PaginationParameters = {}): Promise<[FineHandoutEvent[], number]> {
     const { take, skip } = pagination;
 
     const events = await this.manager.find(FineHandoutEvent, { take, skip,
@@ -130,27 +129,18 @@ export default class DebtorService extends WithManager {
     });
     const count = await this.manager.count(FineHandoutEvent);
 
-    const records = events.map((e) => DebtorService.asBaseFineHandoutEventResponse(e));
-
-    return {
-      _pagination: {
-        take, skip, count,
-      },
-      records,
-    };
+    return [events, count];
   }
 
   /**
    * Return the fine handout event with the given id. Includes all its fines with the corresponding user
    */
-  public async getSingleFineHandoutEvent(id: number): Promise<FineHandoutEventResponse> {
-    const fineHandoutEvent = await this.manager.findOne(FineHandoutEvent, {
+  public async getSingleFineHandoutEvent(id: number): Promise<FineHandoutEvent | undefined> {
+    return this.manager.findOne(FineHandoutEvent, {
       where: { id },
       relations: { fines: { userFineGroup: { user: true } } },
       order: { createdAt: 'DESC' },
     });
-
-    return DebtorService.asFineHandoutEventResponse(fineHandoutEvent);
   }
 
   /**
@@ -172,8 +162,8 @@ export default class DebtorService extends WithManager {
     })));
 
     const [debtorsOnReferenceDate, ...debtors] = balances;
-    const userBalancesToFine = debtorsOnReferenceDate.records
-      .filter((d1) => debtors.every((b) => b.records
+    const userBalancesToFine = debtorsOnReferenceDate[0]
+      .filter((d1) => debtors.every((b) => b[0]
         .some((d2) => d1.id === d2.id)));
 
     return userBalancesToFine.map((u) => {
@@ -181,7 +171,7 @@ export default class DebtorService extends WithManager {
       return {
         id: u.id,
         fineAmount: fine.toObject(),
-        balances: balances.map((balance) => balance.records.find((b) => b.id === u.id)),
+        balances: balances.map((balance) => balance[0].find((b) => b.id === u.id)),
       };
     });
   }
@@ -194,14 +184,14 @@ export default class DebtorService extends WithManager {
    */
   public async handOutFines({
     referenceDate, userIds,
-  }: HandOutFinesParams, createdBy: User): Promise<FineHandoutEventResponse> {
+  }: HandOutFinesParams, createdBy: User): Promise<FineHandoutEvent> {
     const previousFineGroup = (await this.manager.find(FineHandoutEvent, {
       order: { id: 'desc' },
       relations: ['fines', 'fines.userFineGroup'],
       take: 1,
     }))[0];
 
-    const balances = await new BalanceService(this.manager).getBalances({
+    const [balanceRecords] = await new BalanceService(this.manager).getBalances({
       date: referenceDate,
       ids: userIds,
     });
@@ -218,7 +208,7 @@ export default class DebtorService extends WithManager {
       const notifications: { user: User, notificationOption: UserGotFinedOptions }[] = [];
 
       // Create and save the fine information
-      let fines: Fine[] = await Promise.all(balances.records.map(async (b) => {
+      let fines: Fine[] = await Promise.all(balanceRecords.map(async (b) => {
         const previousFine = previousFineGroup?.fines.find((fine) => fine.userFineGroup.userId === b.id);
         const user = await manager.findOne(User, { where: { id: b.id }, relations: ['currentFines', 'currentFines.user', 'currentFines.fines'] });
         const amount = calculateFine(b.amount);
@@ -272,15 +262,8 @@ export default class DebtorService extends WithManager {
       ),
     );
 
-    return {
-      id: fineHandoutEvent1.id,
-      createdAt: fineHandoutEvent1.createdAt.toISOString(),
-      updatedAt: fineHandoutEvent1.updatedAt.toISOString(),
-      referenceDate: fineHandoutEvent1.referenceDate.toISOString(),
-      createdBy: parseUserToBaseResponse(fineHandoutEvent1.createdBy, false),
-      fines: fines1.map((f) => DebtorService.asFineResponse(f)),
-      count: fines1.length,
-    };
+    fineHandoutEvent1.fines = fines1;
+    return fineHandoutEvent1;
   }
 
   /**

--- a/src/service/event-service.ts
+++ b/src/service/event-service.ts
@@ -32,8 +32,6 @@ import {
   EventInShiftResponse, EventPlanningSelectedCount,
   EventResponse,
   EventShiftResponse,
-  PaginatedBaseEventResponse,
-  PaginatedEventShiftResponse,
 } from '../controller/response/event-response';
 import {
   EventAnswerAssignmentRequest,
@@ -54,6 +52,7 @@ import Role from '../entity/rbac/role';
 import { AppDataSource } from '../database/database';
 import Notifier, { ForgotEventPlanningOptions } from '../notifications';
 import { NotificationTypes } from '../notifications/notification-types';
+import UserService from './user-service';
 
 export interface EventFilterParameters {
   name?: string;
@@ -152,7 +151,7 @@ export async function parseUpdateEventRequestParameters(
  * @deprecated Events are out of scope for SudoSOS. Delete from 01/11/2026.
  */
 export default class EventService {
-  private static asBaseEventResponse(entity: Event): BaseEventResponse {
+  public static asBaseEventResponse(entity: Event): BaseEventResponse {
     return {
       id: entity.id,
       createdAt: entity.createdAt.toISOString(),
@@ -166,14 +165,14 @@ export default class EventService {
     };
   }
 
-  private static asEventResponse(entity: Event): EventResponse {
+  public static asEventResponse(entity: Event): EventResponse {
     return {
       ...this.asBaseEventResponse(entity),
       shifts: entity.shifts.map((s) => this.asShiftInEventResponse(entity, s, entity.answers)),
     };
   }
 
-  private static asBaseEventShiftResponse(entity: EventShift):
+  public static asBaseEventShiftResponse(entity: EventShift):
   BaseEventShiftResponse {
     return {
       createdAt: entity.createdAt.toISOString(),
@@ -184,7 +183,7 @@ export default class EventService {
     };
   }
 
-  private static asEventShiftResponse(entity: EventShift):
+  public static asEventShiftResponse(entity: EventShift):
   EventShiftResponse {
     return {
       ...this.asBaseEventShiftResponse(entity),
@@ -192,7 +191,7 @@ export default class EventService {
     };
   }
 
-  private static asShiftInEventResponse(
+  public static asShiftInEventResponse(
     event: Event, shift: EventShift, answers: EventShiftAnswer[],
   ): EventInShiftResponse {
     return {
@@ -203,7 +202,7 @@ export default class EventService {
     };
   }
 
-  private static asBaseEventAnswerResponse(entity: EventShiftAnswer): BaseEventAnswerResponse {
+  public static asBaseEventAnswerResponse(entity: EventShiftAnswer): BaseEventAnswerResponse {
     return {
       availability: entity.availability,
       selected: entity.selected,
@@ -215,7 +214,7 @@ export default class EventService {
    * Get all borrel schemas.
    */
   public static async getEvents(params: EventFilterParameters = {}, { take, skip }: PaginationParameters = {})
-    :Promise<PaginatedBaseEventResponse> {
+    :Promise<[Event[], number]> {
     const filterMapping: FilterMapping = {
       name: '%name',
       id: 'id',
@@ -250,24 +249,21 @@ export default class EventService {
 
     const events = await Event.find({ ...options, take, skip });
     const count = await Event.count(options);
-    return {
-      _pagination: { take, skip, count },
-      records: events.map((e) => this.asBaseEventResponse(e)),
-    };
+    return [events, count];
   }
 
   /**
    * Get a single event with its corresponding shifts and answers
    * @param id
    */
-  public static async getSingleEvent(id: number): Promise<EventResponse | undefined> {
+  public static async getSingleEvent(id: number): Promise<Event | undefined> {
     const event = await Event.findOne({
       where: { id },
       relations: { createdBy: true, shifts: { roles: true }, answers: { user: true } },
       withDeleted: true,
     });
 
-    return event ? this.asEventResponse(event) : undefined;
+    return event ?? undefined;
   }
 
   /**
@@ -330,8 +326,8 @@ export default class EventService {
      * Create a new event.
      */
   public static async createEvent(params: CreateEventParams)
-    : Promise<EventResponse> {
-    const createdBy = await User.findOne({ where: { id: params.createdById } });
+    : Promise<Event> {
+    const createdBy = await User.findOne(UserService.getOptions({ id: params.createdById }));
     const shifts = await EventShift.find({ where: { id: In(params.shiftIds) } });
 
     if (shifts.length !== params.shiftIds.length) throw new Error('Invalid list of shiftIds provided.');
@@ -347,13 +343,13 @@ export default class EventService {
     await Event.save(event);
 
     event.answers = await this.syncEventShiftAnswers(event, params.shiftIds);
-    return this.asEventResponse(event);
+    return event;
   }
 
   /**
    * Update an existing event.
    */
-  public static async updateEvent(id: number, params: Partial<UpdateEventParams>) {
+  public static async updateEvent(id: number, params: Partial<UpdateEventParams>): Promise<Event | undefined> {
     const event = await Event.findOne({
       where: { id },
     });
@@ -392,13 +388,10 @@ export default class EventService {
   /**
    * Get all event shifts
    */
-  public static async getEventShifts({ take, skip }: PaginationParameters): Promise<PaginatedEventShiftResponse> {
+  public static async getEventShifts({ take, skip }: PaginationParameters): Promise<[EventShift[], number]> {
     const shifts = await EventShift.find({ take, skip });
     const count = await EventShift.count();
-    return {
-      _pagination: { take, skip, count },
-      records: shifts.map((s) => this.asEventShiftResponse(s)),
-    };
+    return [shifts, count];
   }
 
   /**
@@ -474,9 +467,9 @@ export default class EventService {
   public static async sendEventPlanningReminders(date = new Date()) {
     const inTwoDays = new Date(date.getTime() + 1000 * 3600 * 24 * 2);
     const inThreeDays = new Date(date.getTime() + 1000 * 3600 * 24 * 3);
-    const events = await EventService.getEvents({ beforeDate: inThreeDays, afterDate: inTwoDays });
+    const [events] = await EventService.getEvents({ beforeDate: inThreeDays, afterDate: inTwoDays });
 
-    await Promise.all(events.records.map(async (event) => {
+    await Promise.all(events.map(async (event) => {
       const answers = await EventShiftAnswer.find({ where: { eventId: event.id, availability: IsNull() }, relations: ['user'] });
       // Get all users and remove duplicates
       const users = answers

--- a/src/service/inactive-administrative-cost-service.ts
+++ b/src/service/inactive-administrative-cost-service.ts
@@ -19,6 +19,7 @@
  */
 
 import WithManager from '../database/with-manager';
+import UserService from './user-service';
 import { FindManyOptions, FindOptionsRelations, In } from 'typeorm';
 import InactiveAdministrativeCost from '../entity/transactions/inactive-administrative-cost';
 import QueryFilter, { FilterMapping } from '../helpers/query-filter';
@@ -157,8 +158,8 @@ export default class InactiveAdministrativeCostService extends WithManager {
       return [];
     }
 
-    const balances = await new BalanceService(this.manager).getBalances({ ids: eligibleUserIds });
-    const eligibleUsersWithPositiveBalance = balances.records
+    const [balanceRecords] = await new BalanceService(this.manager).getBalances({ ids: eligibleUserIds });
+    const eligibleUsersWithPositiveBalance = balanceRecords
       .filter(balance => balance.amount.amount > 0)
       .map(balance => balance.id);
 
@@ -166,7 +167,7 @@ export default class InactiveAdministrativeCostService extends WithManager {
       return [];
     }
 
-    const mapped = await User.find({ where: { id: In(eligibleUsersWithPositiveBalance) } });
+    const mapped = await User.find(UserService.getOptions({ id: eligibleUsersWithPositiveBalance }));
     return mapped.map(user => parseUserToBaseResponse(user, false));
   }
 
@@ -255,7 +256,7 @@ export default class InactiveAdministrativeCostService extends WithManager {
 
       const inactiveAdministrativeCost = await this.createInactiveAdministrativeCost(req);
 
-      const user = await User.findOne({ where: { id: u } });
+      const user = await this.manager.findOne(User, { where: { id: u } });
 
       await Notifier.getInstance().notify({
         type: NotificationTypes.UserGotInactiveAdministrativeCost,
@@ -278,7 +279,7 @@ export default class InactiveAdministrativeCostService extends WithManager {
     : Promise<void> {
 
     await Promise.all(users.userIds.map(async (u) => {
-      const user = await User.findOne({ where: { id: u } });
+      const user = await this.manager.findOne(User, { where: { id: u } });
 
       const value = ServerSettingsStore.getInstance().getSetting('administrativeCostValue');
       if (typeof value !== 'number') {
@@ -316,21 +317,14 @@ export default class InactiveAdministrativeCostService extends WithManager {
    * @param pagination - The pagination params to apply
    */
   public async getPaginatedInactiveAdministrativeCosts(params: InactiveAdministrativeCostFilterParameters = {},
-    pagination: PaginationParameters = {}) {
+    pagination: PaginationParameters = {}): Promise<[InactiveAdministrativeCost[], number]> {
     const { take, skip } = pagination;
     const options = { ...InactiveAdministrativeCostService.getOptions(params), skip, take };
 
-    const inactiveAdministrativeCost = await this.manager.find(InactiveAdministrativeCost, { ...options, take });
-
-    const records = InactiveAdministrativeCostService.toArrayResponse(inactiveAdministrativeCost);
-
+    const inactiveAdministrativeCosts = await this.manager.find(InactiveAdministrativeCost, { ...options, take });
     const count = await this.manager.count(InactiveAdministrativeCost, options);
-    return {
-      _pagination: {
-        take, skip, count,
-      },
-      records,
-    };
+
+    return [inactiveAdministrativeCosts, count];
   }
 
   public static getOptions(params: InactiveAdministrativeCostFilterParameters): FindManyOptions<InactiveAdministrativeCost> {

--- a/src/service/invoice-service.ts
+++ b/src/service/invoice-service.ts
@@ -49,7 +49,6 @@ import TransferService from './transfer-service';
 import TransferRequest from '../controller/request/transfer-request';
 import TransactionService from './transaction-service';
 import { DineroObjectRequest } from '../controller/request/dinero-request';
-import { TransferResponse } from '../controller/response/transfer-response';
 import { TransactionResponse } from '../controller/response/transaction-response';
 import { RequestWithToken } from '../middleware/token-middleware';
 import { asBoolean, asDate, asInvoiceState, asNumber } from '../helpers/validators';
@@ -196,9 +195,9 @@ export default class InvoiceService extends WithManager {
    * @param amount - The amount to transfer
    */
   public async createTransfer(forId: number,
-    transactions: Transaction[], amount: DineroObjectRequest): Promise<TransferResponse> {
+    transactions: Transaction[], amount: DineroObjectRequest): Promise<Transfer> {
     const transactionId = transactions.length > 0 ? transactions.map((t) => t.id) : null;
-    const baseTransactions = (await new TransactionService(this.manager).getTransactions({ transactionId })).records;
+    const [baseTransactions] = await new TransactionService(this.manager).getTransactions({ transactionId });
 
     baseTransactions.forEach((t) => {
       if (t.from.id !== forId) throw new Error(`Transaction from ${t.from.id} not from user ${forId}`);
@@ -393,8 +392,8 @@ export default class InvoiceService extends WithManager {
     const { forId, fromDate, tillDate } = params;
     const transactionService = new TransactionService(this.manager);
 
-    const tIds = (await transactionService.getTransactions({ fromId: forId, fromDate, tillDate }, {}))
-      .records.map((t) => t.id);
+    const [tRecords] = await transactionService.getTransactions({ fromId: forId, fromDate, tillDate }, {});
+    const tIds = tRecords.map((t) => t.id);
 
 
     // TODO: Remove after TransactionService migration to `getOptions`
@@ -498,29 +497,18 @@ export default class InvoiceService extends WithManager {
 
   /**
    * Function that returns all the invoices based on the given params.
-   * Returns either BaseInvoiceResponse, that is without InvoiceEntries, or InvoiceResponse
-   * based on if returnInvoiceEntries is set to true.
    * @param params - The filter params to apply
    * @param pagination - The pagination params to apply
    */
   public async getPaginatedInvoices(params: InvoiceFilterParameters = {},
-    pagination: PaginationParameters = {}) {
+    pagination: PaginationParameters = {}): Promise<[Invoice[], number]> {
     const { take, skip } = pagination;
     const options = { ...InvoiceService.getOptions(params), skip, take };
 
     const invoices = await this.manager.find(Invoice, { ...options, take });
-
-    const records = params.returnInvoiceEntries
-      ? InvoiceService.toArrayResponse(invoices)
-      : InvoiceService.toArrayWithoutEntriesResponse(invoices);
-
     const count = await this.manager.count(Invoice, options);
-    return {
-      _pagination: {
-        take, skip, count,
-      },
-      records,
-    };
+
+    return [invoices, count];
   }
 
   public static stateSubQuery(): string {
@@ -582,9 +570,9 @@ export default class InvoiceService extends WithManager {
   /**
    * Get all invoices that contain any subtransaction rows from the given transaction
    * @param transactionId - The transaction ID
-   * @returns Array of invoice responses
+   * @returns Array of invoices
    */
-  public async getTransactionInvoices(transactionId: number): Promise<BaseInvoiceResponse[]> {
+  public async getTransactionInvoices(transactionId: number): Promise<Invoice[]> {
     // Load transaction with all relations needed
     const transaction = await this.manager.findOne(Transaction, {
       where: { id: transactionId },
@@ -614,8 +602,6 @@ export default class InvoiceService extends WithManager {
       });
     });
 
-    // Convert to responses
-    return Array.from(invoiceMap.values())
-      .map((invoice) => InvoiceService.asBaseInvoiceResponse(invoice));
+    return Array.from(invoiceMap.values());
   }
 }

--- a/src/service/payout-request-service.ts
+++ b/src/service/payout-request-service.ts
@@ -37,7 +37,6 @@ import PayoutRequestStatus, { PayoutRequestState } from '../entity/transactions/
 import QueryFilter, { FilterMapping } from '../helpers/query-filter';
 import {
   BasePayoutRequestResponse,
-  PaginatedBasePayoutRequestResponse,
   PayoutRequestResponse,
   PayoutRequestStatusResponse,
 } from '../controller/response/payout-request-response';
@@ -122,52 +121,46 @@ export default class PayoutRequestService {
 
 
   /**
-   * Get all transactions with the given filters
+   * Get all payout requests with the given filters
    * @param filters
    * @param pagination
+   * @returns {[PayoutRequest[], number]} payout requests and total count
    */
   public static async getPayoutRequests(
     filters: PayoutRequestFilters, pagination: PaginationParameters = {},
-  ): Promise<PaginatedBasePayoutRequestResponse> {
+  ): Promise<[PayoutRequest[], number]> {
     const { take, skip } = pagination;
 
-    const [data, count]  = await PayoutRequest.findAndCount({
+    return PayoutRequest.findAndCount({
       ...(await this.getOptions(filters)),
       take,
       skip,
     });
-
-    const records = data.map((o) => this.asBasePayoutRequestResponse(o));
-
-    return {
-      _pagination: {
-        take, skip, count,
-      },
-      records,
-    };
   }
 
   /**
    * Get single payout request
    * @param id
+   * @returns {PayoutRequest | undefined} the payout request entity or undefined if not found
    */
   public static async getSinglePayoutRequest(id: number)
-    : Promise<PayoutRequestResponse | undefined> {
+    : Promise<PayoutRequest | undefined> {
     const payoutRequest = await PayoutRequest.findOne(await this.getOptions({ id }));
 
     if (payoutRequest == null) return undefined;
 
-    return PayoutRequestService.asPayoutRequestResponse(payoutRequest);
+    return payoutRequest;
   }
 
   /**
    * Create a new payout request
    * @param payoutRequestRequest
    * @param requestedBy
+   * @returns {PayoutRequest} the created payout request entity
    */
   public static async createPayoutRequest(
     payoutRequestRequest: PayoutRequestRequest, requestedBy: User,
-  ): Promise<PayoutRequestResponse> {
+  ): Promise<PayoutRequest> {
     const payoutRequest = Object.assign(new PayoutRequest(), {
       requestedBy,
       amount: Dinero(payoutRequestRequest.amount),
@@ -195,7 +188,7 @@ export default class PayoutRequestService {
     id: number, state: PayoutRequestState,
   ) {
     const payoutRequest = await PayoutRequestService.getSinglePayoutRequest(id);
-    const currentStates = payoutRequest.statuses.map((s) => s.state as PayoutRequestState);
+    const currentStates = payoutRequest.payoutRequestStatus.map((s) => s.state as PayoutRequestState);
     const allStatuses = Object.values(PayoutRequestState);
 
     if (!allStatuses.includes(state)) throw Error(`unknown status: ${state}.`);
@@ -235,13 +228,11 @@ export default class PayoutRequestService {
    * @param id ID of payout request
    * @param state State to change payout request to
    * @param user User who performs the update
-   * @return {Promise<PayoutRequestResponse>|undefined}
-   *  - Resolves to the updated payout request response if successful,
-   *  - or `undefined` if the payout request does not exist.
+   * @returns {PayoutRequest | undefined} the updated payout request entity, or undefined if not found
    */
   public static async updateStatus(
     id: number, state: PayoutRequestState, user: User,
-  ): Promise<PayoutRequestResponse | undefined> {
+  ): Promise<PayoutRequest | undefined> {
     const payoutRequest = await PayoutRequest.findOne({
       where: { id },
       relations: ['requestedBy'],

--- a/src/service/point-of-sale-service.ts
+++ b/src/service/point-of-sale-service.ts
@@ -28,7 +28,6 @@ import { FindManyOptions, FindOptionsRelations, FindOptionsWhere, In, IsNull, Ra
 import {
   BasePointOfSaleInfoResponse,
   BasePointOfSaleResponse,
-  PaginatedPointOfSaleResponse,
   PointOfSaleResponse,
   PointOfSaleWithContainersResponse,
 } from '../controller/response/point-of-sale-response';
@@ -46,6 +45,7 @@ import AuthenticationService from './authentication-service';
 import { ContainerWithProductsResponse } from '../controller/response/container-response';
 import Role from '../entity/rbac/role';
 import RBACService from './rbac-service';
+import UserService from './user-service';
 
 /**
  * Define point of sale filtering parameters used to filter query results.
@@ -144,25 +144,17 @@ export default class PointOfSaleService {
    */
   public static async getPointsOfSale(
     filters: PointOfSaleParameters = {}, pagination: PaginationParameters = {}, user?: User,
-  ): Promise<PaginatedPointOfSaleResponse> {
+  ): Promise<[PointOfSaleRevision[], number]> {
     const { take, skip } = pagination;
 
-    const [data, count] = await PointOfSaleRevision.findAndCount({ ...(await this.getOptions(filters, user)), take, skip });
-
-    const records = data.map((revision: PointOfSaleRevision) => this.revisionToResponse(revision));
-    return {
-      _pagination: {
-        take, skip, count,
-      },
-      records,
-    };
+    return PointOfSaleRevision.findAndCount({ ...(await this.getOptions(filters, user)), take, skip });
   }
 
   /**
    * Updates a PointOfSale
    * @param update - The update to apply
    */
-  public static async updatePointOfSale(update: UpdatePointOfSaleParams): Promise<PointOfSaleWithContainersResponse> {
+  public static async updatePointOfSale(update: UpdatePointOfSaleParams): Promise<PointOfSaleRevision> {
     const base = await PointOfSale.findOne({ where: { id: update.id } });
     const containers = await Container.findByIds(update.containers);
 
@@ -192,7 +184,7 @@ export default class PointOfSaleService {
     await PointOfSale.save(base);
 
     const options = await this.getOptions({ pointOfSaleId: base.id, returnContainers: true, returnProducts: true });
-    return (this.revisionToResponse(await PointOfSaleRevision.findOne({ ...options }))) as PointOfSaleWithContainersResponse;
+    return PointOfSaleRevision.findOne({ ...options });
   }
 
   /**
@@ -200,8 +192,8 @@ export default class PointOfSaleService {
    *
    * @param posRequest - The POS to be created.
    */
-  public static async createPointOfSale(posRequest: CreatePointOfSaleParams) {
-    const owner = await User.findOne({ where: { id: posRequest.ownerId } });
+  public static async createPointOfSale(posRequest: CreatePointOfSaleParams): Promise<PointOfSaleRevision | undefined> {
+    const owner = await User.findOne(UserService.getOptions({ id: posRequest.ownerId }));
 
     if (!owner) return undefined;
 

--- a/src/service/product-category-service.ts
+++ b/src/service/product-category-service.ts
@@ -27,7 +27,6 @@
 import { FindManyOptions, IsNull, Raw } from 'typeorm';
 import ProductCategory from '../entity/product/product-category';
 import {
-  PaginatedProductCategoryResponse,
   ProductCategoryResponse,
 } from '../controller/response/product-category-response';
 import ProductCategoryRequest from '../controller/request/product-category-request';
@@ -74,7 +73,7 @@ export default class ProductCategoryService extends WithManager {
       name: productCategory.name,
       createdAt: productCategory.createdAt.toISOString(),
       updatedAt: productCategory.updatedAt.toISOString(),
-      parent: productCategory.parent ? this.asProductCategoryResponse(productCategory.parent) : undefined,
+      parent: productCategory.parent ? ProductCategoryService.asProductCategoryResponse(productCategory.parent) : undefined,
     };
   }
 
@@ -83,7 +82,7 @@ export default class ProductCategoryService extends WithManager {
    */
   public static async getProductCategories(
     filters: ProductCategoryFilterParameters = {}, pagination: PaginationParameters = {},
-  ): Promise<PaginatedProductCategoryResponse> {
+  ): Promise<[ProductCategory[], number]> {
     const { take, skip } = pagination;
 
     const filterMapping: FilterMapping = {
@@ -106,16 +105,7 @@ export default class ProductCategoryService extends WithManager {
       ProductCategory.count(options),
     ]);
 
-    const records = results[0].map(
-      (productCategory) => (this.asProductCategoryResponse(productCategory)),
-    );
-
-    return {
-      _pagination: {
-        take, skip, count: results[1],
-      },
-      records,
-    };
+    return [results[0], results[1]];
   }
 
   /**
@@ -124,7 +114,7 @@ export default class ProductCategoryService extends WithManager {
    */
   public static async postProductCategory(
     request: ProductCategoryRequest,
-  ): Promise<ProductCategoryResponse> {
+  ): Promise<ProductCategory> {
     const parentCategory = request.parentCategoryId
       ? await ProductCategory.findOne({ where: { id: request.parentCategoryId } })
       : undefined;
@@ -132,8 +122,8 @@ export default class ProductCategoryService extends WithManager {
     const category = new ProductCategory();
     category.name = request.name;
     category.parent = parentCategory;
-    return ProductCategory.save(category)
-      .then(() => this.asProductCategoryResponse(category));
+    await ProductCategory.save(category);
+    return category;
   }
 
   /**
@@ -143,24 +133,25 @@ export default class ProductCategoryService extends WithManager {
    */
   public static async patchProductCategory(
     id: number, request: ProductCategoryRequest,
-  ): Promise<ProductCategoryResponse> {
+  ): Promise<ProductCategory> {
     const category = await ProductCategory.findOne({ where: { id } });
     if (!category) return null;
     const productCategory = Object.assign(category, request);
     await ProductCategory.save(productCategory);
-    return this.asProductCategoryResponse(productCategory);
+    return productCategory;
   }
 
   /**
    * Deletes a ProductCategory from the database.
    * @param id - The id of the productCategory that needs to be deleted.
    */
-  public static async deleteProductCategory(id: number): Promise<ProductCategoryResponse> {
+  public static async deleteProductCategory(id: number): Promise<ProductCategory> {
     const productCategory = await ProductCategory.findOne({ where: { id }, relations: { children: true } });
     if (!productCategory || productCategory.children.length > 0) {
       return null;
     }
-    return ProductCategory.delete(id).then(() => this.asProductCategoryResponse(productCategory));
+    await ProductCategory.delete(id);
+    return productCategory;
   }
 
   /**

--- a/src/service/product-service.ts
+++ b/src/service/product-service.ts
@@ -34,7 +34,6 @@ import {
 import { DineroObject } from 'dinero.js';
 import {
   BaseProductResponse,
-  PaginatedProductResponse,
   ProductResponse,
 } from '../controller/response/product-response';
 import Product from '../entity/product/product';
@@ -51,6 +50,7 @@ import ContainerService from './container-service';
 import { UpdateContainerParams } from '../controller/request/container-request';
 import AuthenticationService from './authentication-service';
 import ContainerRevision from '../entity/container/container-revision';
+import UserService from './user-service';
 
 /**
  * Define product filtering parameters used to filter query results.
@@ -215,20 +215,12 @@ export default class ProductService {
   }
 
   public static async getProducts(filters: ProductFilterParameters = {},
-    pagination: PaginationParameters = {}, user?: User): Promise<PaginatedProductResponse> {
+    pagination: PaginationParameters = {}, user?: User): Promise<[ProductRevision[], number]> {
     const { take, skip } = pagination;
 
     const options = await this.getOptions(filters, user);
 
-    const [data, count] = await ProductRevision.findAndCount({ ...options, take, skip });
-    const records = data.map((revision: ProductRevision) => this.revisionToResponse(revision));
-
-    return {
-      _pagination: {
-        take, skip, count,
-      },
-      records,
-    };
+    return ProductRevision.findAndCount({ ...options, take, skip });
   }
 
   /**
@@ -241,8 +233,8 @@ export default class ProductService {
    * @param product - The product to be created.
    */
   public static async createProduct(product: CreateProductParams)
-    : Promise<ProductResponse> {
-    const owner = await User.findOne({ where: { id: product.ownerId } });
+    : Promise<ProductRevision | undefined> {
+    const owner = await User.findOne(UserService.getOptions({ id: product.ownerId }));
 
     if (!owner) return undefined;
 
@@ -265,13 +257,10 @@ export default class ProductService {
       priceList: product.priceList,
     };
 
-    let createdProduct: ProductResponse;
-    createdProduct = await this.updateProduct(update);
-
-    return createdProduct;
+    return this.updateProduct(update);
   }
 
-  public static async updateProduct(update: UpdateProductParams) {
+  public static async updateProduct(update: UpdateProductParams): Promise<ProductRevision | undefined> {
     const base = await Product.findOne({ where: { id: update.id } });
     const product = { ...base };
 
@@ -296,7 +285,7 @@ export default class ProductService {
     await this.propagateProductUpdate(base.id);
 
     const options = await this.getOptions({ productId: base.id });
-    return (this.revisionToResponse(await ProductRevision.findOne({ ...options })));
+    return ProductRevision.findOne({ ...options });
   }
 
   /**

--- a/src/service/rbac-service.ts
+++ b/src/service/rbac-service.ts
@@ -36,8 +36,8 @@ import { PaginationParameters } from '../helpers/pagination';
 import { DeepPartial, FindManyOptions, FindOptionsRelations } from 'typeorm';
 import QueryFilter, { FilterMapping } from '../helpers/query-filter';
 import { UpdateRoleRequest } from '../controller/request/rbac-request';
-import { PaginatedUserResponse } from '../controller/response/user-response';
 import AssignedRole from '../entity/rbac/assigned-role';
+import User from '../entity/user/user';
 import UserService from './user-service';
 
 interface RoleFilterParameters {
@@ -177,19 +177,15 @@ export default class RBACService {
    * @param take
    * @param skip
    */
-  public static async getRoleUsers(roleId: number, { take, skip }: PaginationParameters = {}): Promise<PaginatedUserResponse> {
+  public static async getRoleUsers(roleId: number, { take, skip }: PaginationParameters = {}): Promise<[User[], number]> {
     const assignedRoles = await AssignedRole.find({ where: { roleId }, take, skip });
     const userIds = assignedRoles.map((role) => role.userId);
 
-    const users = await UserService.getUsers({ id: userIds });
-    return {
-      _pagination: {
-        take,
-        skip,
-        count: users.records.length,
-      },
-      records: users.records,
-    };
+    const count = await AssignedRole.count({ where: { roleId } });
+
+    if (userIds.length === 0) return [[], count];
+    const [users] = await UserService.getUsers({ id: userIds });
+    return [users, count];
   }
 
   /**

--- a/src/service/stripe-service.ts
+++ b/src/service/stripe-service.ts
@@ -34,7 +34,6 @@ import StripePaymentIntentStatus, { StripePaymentIntentState } from '../entity/s
 import {
   StripeDepositResponse,
   StripePaymentIntentStatusResponse,
-  StripePaymentIntentResponse,
 } from '../controller/response/stripe-response';
 import TransferService from './transfer-service';
 import { EntityManager, IsNull } from 'typeorm';
@@ -113,7 +112,7 @@ export default class StripeService extends WithManager {
     };
   }
 
-  public static async getProcessingStripeDepositsFromUser(userId: number): Promise<StripeDepositResponse[]> {
+  public static async getProcessingStripeDepositsFromUser(userId: number): Promise<StripeDeposit[]> {
     const deposits = await StripeDeposit.find({
       where: {
         to: {
@@ -131,8 +130,7 @@ export default class StripeService extends WithManager {
 
     return deposits.filter((d) => !d.stripePaymentIntent.paymentIntentStatuses.some(
       (s) => s.state === StripePaymentIntentState.SUCCEEDED
-        || s.state === StripePaymentIntentState.FAILED))
-      .map((d) => this.asStripeDepositResponse(d));
+        || s.state === StripePaymentIntentState.FAILED));
   }
 
   public static async getStripeDeposit(id: number, relations: string[] = []): Promise<StripeDeposit> {
@@ -154,10 +152,11 @@ export default class StripeService extends WithManager {
    * Create a payment intent and save it to the database
    * @param user User that wants to deposit some money into their account
    * @param amount The amount to be deposited
+   * @returns The created deposit entity and the Stripe client secret
    */
   public async createStripePaymentIntent(
     user: User, amount: Dinero,
-  ): Promise<StripePaymentIntentResponse> {
+  ): Promise<{ deposit: StripeDeposit, clientSecret: string }> {
     const paymentIntent = await this.stripe.paymentIntents.create({
       amount: DineroTransformer.Instance.to(amount),
       currency: amount.getCurrency(),
@@ -174,16 +173,13 @@ export default class StripeService extends WithManager {
       amount,
       paymentIntentStatuses: [],
     });
-    const stripeDeposit = await this.manager.getRepository(StripeDeposit).save({
+    const deposit = await this.manager.getRepository(StripeDeposit).save({
       stripePaymentIntent,
       to: user,
     });
 
     return {
-      id: stripeDeposit.id,
-      createdAt: stripeDeposit.createdAt.toISOString(),
-      updatedAt: stripeDeposit.updatedAt.toISOString(),
-      stripeId: stripePaymentIntent.stripeId,
+      deposit,
       clientSecret: paymentIntent.client_secret,
     };
   }

--- a/src/service/terms-of-service-service.ts
+++ b/src/service/terms-of-service-service.ts
@@ -30,7 +30,22 @@ import { TermsOfServiceResponse } from '../controller/response/terms-of-service-
 
 const TOS_DIR = path.join(__dirname, '../../static/terms-of-service');
 
+export interface TermsOfService {
+  versionNumber: string;
+  content: string;
+}
+
 export default class TermsOfServiceService {
+
+  /**
+   * Convert a TermsOfService data object to a TermsOfServiceResponse.
+   */
+  public static asTermsOfServiceResponse(tos: TermsOfService): TermsOfServiceResponse {
+    return {
+      versionNumber: tos.versionNumber,
+      content: tos.content,
+    };
+  }
 
   /**
    * List all available TOS versions, sorted ascending by version number.
@@ -59,7 +74,7 @@ export default class TermsOfServiceService {
    * Get a specific TOS revision by version string (e.g. "1.0").
    * Throws an error if the version does not exist.
    */
-  public static async getTermsOfService(version: string): Promise<TermsOfServiceResponse> {
+  public static async getTermsOfService(version: string): Promise<TermsOfService> {
     // Check whether the version string is safe (no path traversal)
     if (/[/\\]|\.\./.test(version)) {
       throw new Error(`Terms of service version v'${version}' not found`);
@@ -78,7 +93,7 @@ export default class TermsOfServiceService {
    * Get the latest TOS revision (highest version number).
    * Throws an error if no TOS files exist.
    */
-  public static async getLatestTermsOfService(): Promise<TermsOfServiceResponse> {
+  public static async getLatestTermsOfService(): Promise<TermsOfService> {
     const versions = await TermsOfServiceService.listVersions();
     if (versions.length === 0) {
       throw new Error('No terms of service versions found');

--- a/src/service/transaction-service.ts
+++ b/src/service/transaction-service.ts
@@ -29,7 +29,6 @@ import dinero from 'dinero.js';
 import { RequestWithToken } from '../middleware/token-middleware';
 import {
   BaseTransactionResponse,
-  PaginatedBaseTransactionResponse,
   SubTransactionResponse,
   SubTransactionRowResponse,
   TransactionResponse,
@@ -694,7 +693,7 @@ export default class TransactionService extends WithManager {
    * Invalidates user balance cache
    * @param {TransactionResponse.model} transaction - transaction holding users to invalidate
    */
-  public static async invalidateBalanceCache(transaction: TransactionResponse):
+  public static async invalidateBalanceCache(transaction: Transaction):
   Promise<void> {
     // get user ids to invalidate
     const userIds = [...new Set(transaction.subTransactions.map((sub) => sub.to.id))];
@@ -831,7 +830,7 @@ export default class TransactionService extends WithManager {
     params: TransactionFilterParameters,
     pagination: PaginationParameters,
     user: User,
-  ): Promise<PaginatedBaseTransactionResponse> {
+  ): Promise<[BaseTransactionResponse[], number]> {
     const { take, skip } = pagination;
 
     // For the "from" side
@@ -883,14 +882,7 @@ export default class TransactionService extends WithManager {
     const [{ total }] = await this.manager.query(countSql, countParams);
     const records = recordsRaw.map(this.mapRawTransactionToResponse);
 
-    return {
-      records,
-      _pagination: {
-        take,
-        skip,
-        count: Number(total),
-      },
-    };
+    return [records, Number(total)];
   }
 
   /**
@@ -898,11 +890,11 @@ export default class TransactionService extends WithManager {
    * @param {TransactionFilterParameters.model} params - the filter parameters
    * @param {PaginationParameters} pagination
    * @param {User.model} user - A user that is involved in all transactions
-   * @returns {BaseTransactionResponse[]} - the transactions without sub transactions
+   * @returns {Promise<[BaseTransactionResponse[], number]>} - the transactions without sub transactions and total count
    */
   public async getTransactions(
     params: TransactionFilterParameters, pagination: PaginationParameters = {}, user?: User,
-  ): Promise<PaginatedBaseTransactionResponse> {
+  ): Promise<[BaseTransactionResponse[], number]> {
     const { take, skip } = pagination;
 
     if (user) {
@@ -917,12 +909,7 @@ export default class TransactionService extends WithManager {
 
     const records = results[0].map(this.mapRawTransactionToResponse);
 
-    return {
-      _pagination: {
-        take, skip, count: results[1],
-      },
-      records,
-    };
+    return [records, results[1]];
   }
 
   /**
@@ -934,29 +921,27 @@ export default class TransactionService extends WithManager {
   public async createTransaction(
     req: TransactionRequest,
     context: TransactionContext,
-  ): Promise<TransactionResponse | undefined> {
+  ): Promise<Transaction> {
     const transaction = await this.asTransaction(req, context);
 
     // Use manager.save() instead of entity.save() for better batch performance
     // TypeORM will handle cascade saves more efficiently with manager.save()
     const savedTransaction = await this.manager.save(Transaction, transaction);
-    
+
     if (savedTransaction.from.inactiveNotificationSend === true) {
       await UserService.updateUser(savedTransaction.from.id, { inactiveNotificationSend: false });
     }
 
-    // save transaction and return response using cached cost and context
-    const transactionResponse = await this.asTransactionResponse(savedTransaction, context.totalCost, context);
-    
     // Emit WebSocket event for transaction creation (fire-and-forget to not block transaction flow)
+    const transactionResponse = await this.asTransactionResponse(savedTransaction, context.totalCost, context);
     if (transactionResponse) {
       void WebSocketService.emitTransactionCreated(transactionResponse).catch((error) => {
         // Log error but don't fail transaction creation if WebSocket emission fails
         log4js.getLogger('TransactionService').error('Failed to emit transaction created event:', error);
       });
     }
-    
-    return transactionResponse;
+
+    return savedTransaction;
   }
 
   /**
@@ -964,7 +949,7 @@ export default class TransactionService extends WithManager {
    * @param {integer} id - the id of the requested transaction
    * @returns {Transaction.model} - the requested transaction transaction
    */
-  public async getSingleTransaction(id: number): Promise<TransactionResponse | undefined> {
+  public async getSingleTransaction(id: number): Promise<Transaction | undefined> {
     const transaction = await this.manager.findOne(Transaction, {
       where: { id },
       relations: [
@@ -978,7 +963,7 @@ export default class TransactionService extends WithManager {
       withDeleted: true,
     });
 
-    return this.asTransactionResponse(transaction);
+    return transaction ?? undefined;
   }
 
   /**
@@ -989,7 +974,7 @@ export default class TransactionService extends WithManager {
    * @returns {undefined} undefined when transaction not found
    */
   public async updateTransaction(id: number, req: TransactionRequest):
-  Promise<TransactionResponse | undefined> {
+  Promise<Transaction | undefined> {
     // Verify and get context
     const verification = await this.verifyTransaction(req, true);
     if (!verification.valid || !verification.context) {
@@ -1007,9 +992,10 @@ export default class TransactionService extends WithManager {
 
     // invalidate updated transaction user balance cache
     const updatedTransaction = await this.getSingleTransaction(id);
-    await TransactionService.invalidateBalanceCache(updatedTransaction);
+    if (updatedTransaction) {
+      await TransactionService.invalidateBalanceCache(updatedTransaction);
+    }
 
-    // return updatedTransaction;
     return updatedTransaction;
   }
 
@@ -1019,7 +1005,7 @@ export default class TransactionService extends WithManager {
    * @returns {TransactionResponse.model} - the deleted transaction
    */
   public async deleteTransaction(id: number):
-  Promise<TransactionResponse | undefined> {
+  Promise<Transaction | undefined> {
     // get the transaction we should delete
     const transaction = await this.getSingleTransaction(id);
     await this.manager.delete(Transaction, id);
@@ -1095,7 +1081,7 @@ export default class TransactionService extends WithManager {
    * @param parameters - Parameters describing what should be included in the report
    */
   public async getTransactionReport(parameters: TransactionFilterParameters): Promise<TransactionReport> {
-    let baseTransactions = (await this.getTransactions(parameters)).records;
+    const [baseTransactions] = await this.getTransactions(parameters);
 
     const transactionReportData = await this.getTransactionReportData(baseTransactions, parameters.exclusiveToId ? parameters.toId : undefined);
     return {

--- a/src/service/transfer-service.ts
+++ b/src/service/transfer-service.ts
@@ -27,7 +27,7 @@
 import dinero from 'dinero.js';
 import { FindManyOptions, FindOptionsWhere, Raw } from 'typeorm';
 import Transfer from '../entity/transactions/transfer';
-import { PaginatedTransferResponse, TransferResponse } from '../controller/response/transfer-response';
+import { TransferResponse } from '../controller/response/transfer-response';
 import TransferRequest from '../controller/request/transfer-request';
 import User from '../entity/user/user';
 import QueryFilter, { FilterMapping } from '../helpers/query-filter';
@@ -105,7 +105,7 @@ export default class TransferService extends WithManager {
    */
   public async getTransfers(filters: TransferFilterParameters = {},
     pagination: PaginationParameters = {}, user?: User)
-    : Promise<PaginatedTransferResponse> {
+    : Promise<[Transfer[], number]> {
     const { take, skip } = pagination;
 
     const filterMapping: FilterMapping = {
@@ -174,26 +174,18 @@ export default class TransferService extends WithManager {
       order: { createdAt: 'DESC' },
     };
 
-    const results = await Promise.all([
+    return Promise.all([
       this.manager.find(Transfer, options),
       this.manager.count(Transfer, options),
     ]);
-
-    const records = results[0].map((rawTransfer) => TransferService.asTransferResponse(rawTransfer));
-    return {
-      _pagination: {
-        take, skip, count: results[1],
-      },
-      records,
-    };
   }
 
-  public async postTransfer(request: TransferRequest) : Promise<TransferResponse> {
+  public async postTransfer(request: TransferRequest) : Promise<Transfer> {
     const transfer = await this.createTransfer(request);
     if (transfer.from != undefined && transfer.from.inactiveNotificationSend == true) {
       await UserService.updateUser(transfer.fromId, { inactiveNotificationSend: false });
     }
-    return TransferService.asTransferResponse(transfer);
+    return transfer;
   }
 
   public async verifyTransferRequest(request: TransferRequest) : Promise<boolean> {

--- a/src/service/user-service.ts
+++ b/src/service/user-service.ts
@@ -27,7 +27,7 @@
 import { RequestWithToken } from '../middleware/token-middleware';
 import { asBoolean, asDate, asNumber, asUserType } from '../helpers/validators';
 import { PaginationParameters } from '../helpers/pagination';
-import { PaginatedUserResponse, UserResponse } from '../controller/response/user-response';
+import { UserResponse } from '../controller/response/user-response';
 import QueryFilter, { FilterMapping } from '../helpers/query-filter';
 import User, { LocalUserTypes, TermsOfServiceStatus, TOSRequired, UserType } from '../entity/user/user';
 import OrganMembership from '../entity/organ/organ-membership';
@@ -233,7 +233,7 @@ export default class UserService {
    */
   public static async getUsers(
     filters: UserFilterParameters = {}, pagination: PaginationParameters = {},
-  ): Promise<PaginatedUserResponse> {
+  ): Promise<[User[], number]> {
     const { take, skip } = pagination;
 
     // Pre-process organId and assignedRoleIds to get user IDs
@@ -316,14 +316,7 @@ export default class UserService {
     const users = await User.find({ ...options, take, skip });
     const count = await User.count(options);
 
-    const records = users.map((u) => asUserResponse(u, true));
-
-    return {
-      _pagination: {
-        take, skip, count,
-      },
-      records,
-    };
+    return [users, count];
   }
 
   /**
@@ -332,13 +325,13 @@ export default class UserService {
    * @returns User if exists
    * @returns undefined if user does not exits
    */
-  public static async getSingleUser(id: number) {
+  public static async getSingleUser(id: number): Promise<User | undefined> {
     const options = this.getOptions({ id });
     const user = await User.findOne(options);
     if (!user) {
       return undefined;
     }
-    return asUserResponse(user, true);
+    return user;
   }
 
   /**
@@ -346,7 +339,7 @@ export default class UserService {
    * @param createUserRequest - The user to create
    * @returns The created user
    */
-  public static async createUser(createUserRequest: CreateUserRequest) {
+  public static async createUser(createUserRequest: CreateUserRequest): Promise<User | undefined> {
     // Check if user needs to accept TOS.
     const acceptedToS = TOSRequired.includes(createUserRequest.type) ? TermsOfServiceStatus.NOT_ACCEPTED : TermsOfServiceStatus.NOT_REQUIRED;
     const user = await User.save({
@@ -385,7 +378,7 @@ export default class UserService {
    * @throws Error if the user has a non-zero balance and is being deleted.
    * @returns {Promise<void>} - A promise that resolves when the user account has been closed.
    */
-  public static async closeUser(userId: number, deleted = false): Promise<UserResponse> {
+  public static async closeUser(userId: number, deleted = false): Promise<User | undefined> {
     const options = this.getOptions({ id: userId, allowDeleted: true });
     const user = await User.findOne(options);
     if (!user) return undefined;
@@ -401,7 +394,7 @@ export default class UserService {
     user.canGoIntoDebt = false;
 
     await user.save();
-    return asUserResponse(user, true);
+    return user;
   }
 
   /**
@@ -410,13 +403,13 @@ export default class UserService {
    * @param updateUserRequest - The update object.
    */
   public static async updateUser(userId: number, updateUserRequest: UpdateUserRequest):
-  Promise<UserResponse> {
+  Promise<User | undefined> {
     const options = this.getOptions({ id: userId, allowDeleted: true });
     const user = await User.findOne(options);
     if (!user) return undefined;
     Object.assign(user, updateUserRequest);
     await user.save();
-    return asUserResponse(user, true);
+    return user;
   }
 
   /**
@@ -454,15 +447,15 @@ export default class UserService {
       skip: 0,
     };
 
-    const transactions = await (new TransactionService()).getTransactions(filters, pagination, user);
-    const transfers = await (new TransferService()).getTransfers(filters, pagination, user);
+    const [transactionRecords, transactionCount] = await (new TransactionService()).getTransactions(filters, pagination, user);
+    const [transferRecords, transferCount] = await (new TransferService()).getTransfers(filters, pagination, user);
     const financialMutations: FinancialMutationResponse[] = [];
 
-    transactions.records.forEach((mutation) => {
+    transactionRecords.forEach((mutation) => {
       financialMutations.push({ type: 'transaction', mutation });
     });
 
-    transfers.records.forEach((mutation) => {
+    transferRecords.map((t) => TransferService.asTransferResponse(t)).forEach((mutation) => {
       financialMutations.push({ type: 'transfer', mutation });
     });
 
@@ -476,8 +469,7 @@ export default class UserService {
       _pagination: {
         take: paginationParameters.take ?? 0,
         skip: paginationParameters.skip ?? 0,
-        // eslint-disable-next-line no-underscore-dangle
-        count: transactions._pagination.count + transfers._pagination.count,
+        count: transactionCount + transferCount,
       },
       records: mutationRecords,
     };

--- a/src/service/vat-group-service.ts
+++ b/src/service/vat-group-service.ts
@@ -31,7 +31,6 @@ import VatGroup, { VatDeclarationPeriod } from '../entity/vat-group';
 import QueryFilter, { FilterMapping } from '../helpers/query-filter';
 import {
   BaseVatGroupResponse,
-  PaginatedVatGroupResponse,
   VatDeclarationResponse,
   VatDeclarationRow, VatGroupResponse,
 } from '../controller/response/vat-group-response';
@@ -68,10 +67,10 @@ interface VatDeclarationParams {
 }
 
 export async function canSetVatGroupToDeleted(vatGroupId: number): Promise<boolean> {
-  const products = await ProductService.getProducts({
+  const [products] = await ProductService.getProducts({
     vatGroupId,
   });
-  return products.records.length === 0;
+  return products.length === 0;
 }
 
 export function parseGetVatGroupsFilters(req: RequestWithToken): VatGroupFilterParameters {
@@ -111,15 +110,10 @@ export default class VatGroupService {
   }
 
   /**
-   * Returns all VAT groups with options.
-   * @param filters - The filtering parameters.
-   * @param pagination - The pagination options.
+   * Build FindManyOptions for VatGroup queries based on the given filter parameters.
+   * @param params - The filtering parameters.
    */
-  public static async getVatGroups(
-    filters: VatGroupFilterParameters, pagination: PaginationParameters = {},
-  ): Promise<PaginatedVatGroupResponse> {
-    const { take, skip } = pagination;
-
+  public static getOptions(params: VatGroupFilterParameters = {}): FindManyOptions<VatGroup> {
     const mapping: FilterMapping = {
       vatGroupId: 'id',
       name: 'name',
@@ -127,25 +121,32 @@ export default class VatGroupService {
       deleted: 'deleted',
     };
 
-    const options: FindManyOptions = {
-      where: QueryFilter.createFilterWhereClause(mapping, filters),
+    return {
+      where: QueryFilter.createFilterWhereClause(mapping, params),
       order: { id: 'ASC' },
     };
+  }
 
-    const records = await VatGroup.find({
+  /**
+   * Returns all VAT groups with options.
+   * @param filters - The filtering parameters.
+   * @param pagination - The pagination options.
+   */
+  public static async getVatGroups(
+    filters: VatGroupFilterParameters, pagination: PaginationParameters = {},
+  ): Promise<[VatGroup[], number]> {
+    const { take, skip } = pagination;
+    const options = this.getOptions(filters);
+
+    const vatGroups = await VatGroup.find({
       ...options,
       take,
       skip,
     }) as VatGroup[];
 
-    return {
-      _pagination: {
-        take,
-        skip,
-        count: await VatGroup.count(options),
-      },
-      records,
-    };
+    const count = await VatGroup.count(options);
+
+    return [vatGroups, count];
   }
 
   /**

--- a/src/service/voucher-group-service.ts
+++ b/src/service/voucher-group-service.ts
@@ -27,9 +27,7 @@
 import { FindManyOptions } from 'typeorm';
 import DineroFactory from 'dinero.js';
 import { VoucherGroupParams, VoucherGroupRequest } from '../controller/request/voucher-group-request';
-import VoucherGroupResponse, {
-  PaginatedVoucherGroupResponse,
-} from '../controller/response/voucher-group-response';
+import VoucherGroupResponse from '../controller/response/voucher-group-response';
 import { UserResponse } from '../controller/response/user-response';
 import Transfer from '../entity/transactions/transfer';
 import DineroTransformer from '../entity/transformer/dinero-transformer';
@@ -139,14 +137,14 @@ export default class VoucherGroupService {
   }
 
   /**
-   * Returns all voucher groups without users
+   * Returns all voucher groups with their users loaded
    * @param filters
    * @param {PaginationParameters.model} params - find options
-   * @returns {PaginatedVoucherGroupResponse} voucher groups without users
+   * @returns {[VoucherGroup[], number]} voucher groups with users and total count
    */
   public static async getVoucherGroups(
     filters: VoucherGroupFilterParameters, params: PaginationParameters = {},
-  ): Promise<PaginatedVoucherGroupResponse> {
+  ): Promise<[VoucherGroup[], number]> {
     const { take, skip } = params;
 
     const mapping: FilterMapping = {
@@ -158,41 +156,33 @@ export default class VoucherGroupService {
       relations: ['vouchers.user'],
     };
     const bkgs: VoucherGroup[] = await VoucherGroup.find({ ...options, take, skip });
-    const records = bkgs.map((bkg) => this.asVoucherGroupResponse(bkg, bkg.vouchers.map((voucher) => voucher.user)));
+    const count = await VoucherGroup.count({ where: options.where });
 
-    return {
-      _pagination: {
-        take,
-        skip,
-        count: await VoucherGroup.count(),
-      },
-      records,
-    };
+    return [bkgs, count];
   }
 
   /**
    * Saves a voucher group and its user relations to the database
-   * @param {VoucherGroupRequest.model} bkgReq - voucher group request
-   * @returns {VoucherGroupResponse.model} saved voucher group
+   * @param {VoucherGroupParams.model} bkgReq - voucher group parameters
+   * @returns {{ voucherGroup: VoucherGroup, users: User[] }} the saved voucher group and its users
    */
   public static async createVoucherGroup(
     bkgReq: VoucherGroupParams,
-  ): Promise<VoucherGroupResponse> {
+  ): Promise<{ voucherGroup: VoucherGroup, users: User[] }> {
     const users = await VoucherGroupService.createVoucherUsers(bkgReq.name, bkgReq.activeStartDate <= new Date(), bkgReq.amount);
 
     // save the voucher group
-    const bkg = await VoucherGroup.save(this.asVoucherGroup(bkgReq));
+    const voucherGroup = await VoucherGroup.save(this.asVoucherGroup(bkgReq));
 
     // create and save user voucher group links
     const userLinks = users.map(
-      (user) => ({ user, voucherGroup: bkg } as UserVoucherGroup),
+      (user) => ({ user, voucherGroup } as UserVoucherGroup),
     );
     await UserVoucherGroup.save(userLinks);
 
     await this.updateBalance(users, bkgReq.balance);
 
-    // return voucher group response with posted voucher group
-    return this.asVoucherGroupResponse(bkg, users);
+    return { voucherGroup, users };
   }
 
   public static async createVoucherUsers(namePrefix: string, active: Boolean, amount: number, offset: number = 0): Promise<User[]> {
@@ -215,15 +205,14 @@ export default class VoucherGroupService {
 
   /**
    * Updates a voucher group and its user relations in the database
-   * @param {string} id - requested voucher group id
-   * @param {VoucherGroupRequest.model} bkgReq - new voucher group request
-   * @returns {VoucherGroupResponse.model} updated voucher group
-   * @returns {undefined} undefined when voucher group not found
+   * @param {number} id - requested voucher group id
+   * @param {VoucherGroupParams.model} bkgReq - new voucher group parameters
+   * @returns {{ voucherGroup: VoucherGroup, users: User[] } | undefined} updated voucher group with users, or undefined when not found
    */
   public static async updateVoucherGroup(
     id: number,
     bkgReq: VoucherGroupParams,
-  ): Promise<VoucherGroupResponse | undefined> {
+  ): Promise<{ voucherGroup: VoucherGroup, users: User[] } | undefined> {
     // current voucher group
     const bkgCurrent = await VoucherGroup.findOne({ where: { id } });
     if (!bkgCurrent) {
@@ -232,7 +221,7 @@ export default class VoucherGroupService {
 
     // create new voucher group and update database
     await VoucherGroup.update(id, this.asVoucherGroup(bkgReq));
-    const bkg = await VoucherGroup.findOne({ where: { id } });
+    const voucherGroup = await VoucherGroup.findOne({ where: { id } });
 
     let usersCurrent = (
       await UserVoucherGroup.find({
@@ -259,7 +248,7 @@ export default class VoucherGroupService {
       const users = await this.createVoucherUsers(bkgReq.name, bkgReq.activeStartDate <= new Date(), bkgReq.amount, bkgCurrent.amount);
       // save new user relations
       const userLinks = users.map(
-        (user) => ({ user, voucherGroup: bkg } as UserVoucherGroup),
+        (user) => ({ user, voucherGroup } as UserVoucherGroup),
       );
       await UserVoucherGroup.save(userLinks);
 
@@ -267,7 +256,6 @@ export default class VoucherGroupService {
       usersCurrent.push(...users);
     }
 
-    // return created voucher group with users
-    return this.asVoucherGroupResponse(bkg, usersCurrent);
+    return { voucherGroup, users: usersCurrent };
   }
 }

--- a/src/service/websocket-service.ts
+++ b/src/service/websocket-service.ts
@@ -29,6 +29,7 @@ import AuthenticationResponse from '../controller/response/authentication-respon
 import TokenHandler from '../authentication/token-handler';
 import JsonWebToken from '../authentication/json-web-token';
 import User from '../entity/user/user';
+import UserService from './user-service';
 import { TransactionResponse } from '../controller/response/transaction-response';
 import { parseRoom } from './websocket/room-parser';
 import {
@@ -337,9 +338,7 @@ export default class WebSocketService {
 
     try {
       const token = await this.tokenHandler.verifyToken(tokenString);
-      const user = await User.findOne({ 
-        where: { id: token.user.id },
-      });
+      const user = await User.findOne(UserService.getOptions({ id: token.user.id, allowPos: true }));
 
       if (user) {
         client.data.user = user;

--- a/src/service/write-off-service.ts
+++ b/src/service/write-off-service.ts
@@ -29,7 +29,6 @@ import { parseUserToBaseResponse } from '../helpers/revision-to-response';
 import TransferService from './transfer-service';
 import {
   BaseWriteOffResponse,
-  PaginatedWriteOffResponse,
   WriteOffResponse,
 } from '../controller/response/write-off-response';
 import QueryFilter, { FilterMapping } from '../helpers/query-filter';
@@ -100,7 +99,7 @@ export default class WriteOffService extends WithManager {
    */
   public static asWriteOffResponse(writeOff: WriteOff): WriteOffResponse {
     return {
-      ...this.asBaseWriteOffResponse(writeOff),
+      ...WriteOffService.asBaseWriteOffResponse(writeOff),
       transfer: writeOff.transfer ? TransferService.asTransferResponse(writeOff.transfer) : undefined,
     };
   }
@@ -109,22 +108,13 @@ export default class WriteOffService extends WithManager {
    * Returns all write-offs with options.
    * @param filters - The filtering parameters.
    * @param pagination - The pagination options.
-   * @returns {Array.<WriteOffResponse>} - all write-offs
+   * @returns {Promise<[WriteOff[], number]>} - all write-offs and total count
    */
-  public static async getWriteOffs(filters: WriteOffFilterParameters = {}, pagination: PaginationParameters = {}): Promise<PaginatedWriteOffResponse> {
+  public static async getWriteOffs(filters: WriteOffFilterParameters = {}, pagination: PaginationParameters = {}): Promise<[WriteOff[], number]> {
     const { take, skip } = pagination;
 
     const options = this.getOptions(filters);
-    const [data, count] = await WriteOff.findAndCount({ ...options, take, skip });
-
-    const records = data.map((writeOff) => this.asWriteOffResponse(writeOff));
-
-    return {
-      _pagination: {
-        take, skip, count,
-      },
-      records,
-    };
+    return WriteOff.findAndCount({ ...options, take, skip });
   }
 
   private static async getHighVATGroup(): Promise<VatGroup> {
@@ -139,7 +129,7 @@ export default class WriteOffService extends WithManager {
    * @param manager - The entity manager to use
    * @param user - The user to create the write-off for
    */
-  public async createWriteOff(user: User): Promise<WriteOffResponse> {
+  public async createWriteOff(user: User): Promise<WriteOff> {
     const balance = await new BalanceService().getBalance(user.id);
     if (balance.amount.amount > 0) {
       throw new Error('User has balance, cannot create write off');
@@ -167,12 +157,12 @@ export default class WriteOffService extends WithManager {
 
     await this.manager.getRepository(Transfer).save(transfer);
     await this.manager.getRepository(WriteOff).save(writeOff);
-    return WriteOffService.asWriteOffResponse(writeOff);
+    return writeOff;
   }
 
   // TODO: This should be a transaction
   //   wait for BalanceService to be refactored
-  public async createWriteOffAndCloseUser(user: User): Promise<WriteOffResponse> {
+  public async createWriteOffAndCloseUser(user: User): Promise<WriteOff> {
     const writeOff = await this.createWriteOff(user);
     await UserService.closeUser(user.id, true);
     return writeOff;
@@ -189,6 +179,7 @@ export default class WriteOffService extends WithManager {
     };
 
     const relations: FindOptionsRelations<WriteOff> = {
+      to: true,
       transfer: {
         vat: true,
       },

--- a/test/helpers/banner-helpers.ts
+++ b/test/helpers/banner-helpers.ts
@@ -1,0 +1,44 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+import Banner from '../../src/entity/banner';
+import { BannerResponse } from '../../src/controller/response/banner-response';
+
+export function bannerEq(a: Banner, b: BannerResponse): Boolean {
+  const aEmpty = a === {} as Banner || a === undefined;
+  const bEmpty = b === {} as BannerResponse || b === undefined;
+  if (aEmpty !== bEmpty) {
+    return false;
+  }
+  if (aEmpty ? !bEmpty : bEmpty) {
+    return false;
+  }
+
+  const downloadName = a.image ? (a.image.downloadName ?? null) : null;
+
+  return a.name === b.name
+    && downloadName === b.image
+    && a.duration === b.duration
+    && a.active === b.active
+    && Math.floor(a.startDate.getTime() / 1000)
+    === Math.floor(new Date(b.startDate).getTime() / 1000)
+    && Math.floor(a.endDate.getTime() / 1000)
+    === Math.floor(new Date(b.endDate).getTime() / 1000);
+}

--- a/test/helpers/transaction-factory.ts
+++ b/test/helpers/transaction-factory.ts
@@ -88,14 +88,15 @@ export async function getAPOSWithProducts(index? : number):
 Promise<PointOfSaleWithContainersResponse> {
   const posList = (await PointOfSaleRevision.find({ relations: ['pointOfSale', 'containers', 'containers.container'] })).filter((p) => p.containers.length > 0);
   const pointOfSale = wrapGet(posList, index ?? 0);
-  return (await PointOfSaleService.getPointsOfSale(
+  const [revisions] = await PointOfSaleService.getPointsOfSale(
     {
       pointOfSaleId: pointOfSale.pointOfSale.id,
       pointOfSaleRevision: pointOfSale.revision,
       returnContainers: true,
       returnProducts: true,
     },
-  )).records[0] as PointOfSaleWithContainersResponse;
+  );
+  return PointOfSaleService.revisionToResponse(revisions[0]) as PointOfSaleWithContainersResponse;
 }
 
 /**
@@ -159,12 +160,12 @@ export async function requestToTransaction(
       if (!verification.valid || !verification.context) {
         throw new Error('Invalid transaction in factory');
       }
-      const transactionResponse = await transactionService.createTransaction(t, verification.context);
+      const savedTransaction = await transactionService.createTransaction(t, verification.context);
       transactions.push({
-        tId: transactionResponse.id,
-        amount: transactionResponse.totalPriceInclVat.amount,
+        tId: savedTransaction.id,
+        amount: t.totalPriceInclVat.amount,
       });
-      total += transactionResponse.totalPriceInclVat.amount;
+      total += t.totalPriceInclVat.amount;
     }),
   );
   return { transactions, total };

--- a/test/unit/controller/authentication-controller.ts
+++ b/test/unit/controller/authentication-controller.ts
@@ -34,6 +34,7 @@ import AuthenticationController from '../../../src/controller/authentication-con
 import AuthenticationMockRequest from '../../../src/controller/request/authentication-mock-request';
 import RoleManager from '../../../src/rbac/role-manager';
 import AuthenticationResponse from '../../../src/controller/response/authentication-response';
+import { AuthenticationResult } from '../../../src/service/authentication-service';
 import AuthenticationLDAPRequest from '../../../src/controller/request/authentication-ldap-request';
 import userIsAsExpected from '../service/authentication-service';
 import AuthenticationPinRequest from '../../../src/controller/request/authentication-pin-request';
@@ -401,10 +402,9 @@ describe('AuthenticationController', async (): Promise<void> => {
           .resolves({
             user: ctx.user,
             token: 'test-token',
-            rolesWithPermissions: [],
+            roles: [],
             organs: [],
-            lesser: false,
-          } as unknown as AuthenticationResponse);
+          } as AuthenticationResult);
       });
 
       afterEach(() => {
@@ -414,11 +414,18 @@ describe('AuthenticationController', async (): Promise<void> => {
       });
 
       it('should call HashAuthentication with correct posId when user is a POS', async () => {
-        const pos = await PointOfSale.save({
+        await PointOfSale.save({
           owner: ctx.user,
           user: ctx.posUser,
           currentRevision: 1,
         });
+
+        // Ensure a KeyAuthenticator exists for the POS user so the controller reaches HashAuthentication
+        await KeyAuthenticator.save({
+          user: ctx.posUser,
+          userId: ctx.posUser.id,
+          hash: 'dummy-hash',
+        } as KeyAuthenticator);
 
         const keyRequest: AuthenticationKeyRequest = {
           userId: ctx.posUser.id,
@@ -429,15 +436,21 @@ describe('AuthenticationController', async (): Promise<void> => {
           .post('/authentication/key')
           .send(keyRequest);
 
-        // Verify HashAuthentication was called with a posId
+        // Verify HashAuthentication was called
         expect(hashAuthStub.calledOnce).to.be.true;
         const callArgs = hashAuthStub.getCall(0).args;
         expect(callArgs[0]).to.equal('1');
         expect(callArgs[2]).to.deep.include({ roleManager: ctx.roleManager, tokenHandler: ctx.tokenHandler });
-        expect(callArgs).to.not.include(pos.id); // posId
       });
 
       it('should call HashAuthentication without a posId when user is not a POS', async () => {
+        // Ensure a KeyAuthenticator exists for the user so the controller reaches HashAuthentication
+        await KeyAuthenticator.save({
+          user: ctx.user,
+          userId: ctx.user.id,
+          hash: 'dummy-hash',
+        } as KeyAuthenticator);
+
         const keyRequest: AuthenticationKeyRequest = {
           userId: ctx.user.id,
           key: '1',

--- a/test/unit/controller/authentication-secure-controller.ts
+++ b/test/unit/controller/authentication-secure-controller.ts
@@ -35,6 +35,7 @@ import { finishTestDB } from '../../helpers/test-helpers';
 import PointOfSale from '../../../src/entity/point-of-sale/point-of-sale';
 import OrganMembership from '../../../src/entity/organ/organ-membership';
 import AuthenticationResponse from '../../../src/controller/response/authentication-response';
+import { AuthenticationResult } from '../../../src/service/authentication-service';
 import DefaultRoles from '../../../src/rbac/default-roles';
 import settingDefaults from '../../../src/server-settings/setting-defaults';
 import ServerSettingsStore from '../../../src/server-settings/server-settings-store';
@@ -43,8 +44,6 @@ import QRAuthenticator, { QRAuthenticatorStatus } from '../../../src/entity/auth
 import WebSocketService from '../../../src/service/websocket-service';
 import QRService from '../../../src/service/qr-service';
 import AuthenticationService from '../../../src/service/authentication-service';
-import { UserResponse } from '../../../src/controller/response/user-response';
-import { TermsOfServiceStatus } from '../../../src/entity/user/user';
 import sinon from 'sinon';
 import AuthenticationSecurePinRequest from '../../../src/controller/request/authentication-secure-pin-request';
 import AuthenticationSecureNfcRequest from '../../../src/controller/request/authentication-secure-nfc-request';
@@ -348,24 +347,11 @@ describe('AuthenticationSecureController', () => {
       const pendingQr = ctx.qrAuthenticators.find(qr => qr.status === QRAuthenticatorStatus.PENDING);
       expect(pendingQr).to.not.be.undefined;
 
-      const mockUserResponse: UserResponse = {
-        id: ctx.memberUser.id,
-        firstName: ctx.memberUser.firstName,
-        lastName: ctx.memberUser.lastName,
-        active: ctx.memberUser.active,
-        deleted: ctx.memberUser.deleted,
-        type: ctx.memberUser.type,
-        canGoIntoDebt: ctx.memberUser.canGoIntoDebt,
-        acceptedToS: ctx.memberUser.acceptedToS,
-      };
-
-      const mockToken: AuthenticationResponse = {
+      const mockToken: AuthenticationResult = {
         token: 'mock-jwt-token',
-        user: mockUserResponse,
+        user: ctx.memberUser,
         roles: [],
         organs: [],
-        acceptedToS: TermsOfServiceStatus.ACCEPTED,
-        rolesWithPermissions: [],
       };
 
       // Setup stubs
@@ -386,10 +372,13 @@ describe('AuthenticationSecureController', () => {
       expect(authenticationServiceStub.getSaltedToken.calledOnce).to.be.true;
 
       // Verify WebSocket emission through mocked Socket.IO
+      const expectedAuthResponse = AuthenticationService.asAuthenticationResponse(
+        mockToken.user, mockToken.roles, mockToken.organs, mockToken.token,
+      );
       expect(mockToMethod.calledOnceWith(`qr-session-${pendingQr.sessionId}`)).to.be.true;
       expect(mockEmitMethod.calledOnceWith('qr-confirmed', {
         sessionId: pendingQr.sessionId,
-        token: mockToken,
+        token: expectedAuthResponse,
       })).to.be.true;
     });
 
@@ -498,24 +487,12 @@ describe('AuthenticationSecureController', () => {
 
     it('should return 500 on QR confirm service error', async () => {
       const pendingQr = ctx.qrAuthenticators.find(qr => qr.status === QRAuthenticatorStatus.PENDING);
-      const mockUserResponse: UserResponse = {
-        id: ctx.memberUser.id,
-        firstName: ctx.memberUser.firstName,
-        lastName: ctx.memberUser.lastName,
-        active: ctx.memberUser.active,
-        deleted: ctx.memberUser.deleted,
-        type: ctx.memberUser.type,
-        canGoIntoDebt: ctx.memberUser.canGoIntoDebt,
-        acceptedToS: ctx.memberUser.acceptedToS,
-      };
 
-      const mockToken: AuthenticationResponse = {
+      const mockToken: AuthenticationResult = {
         token: 'mock-jwt-token',
-        user: mockUserResponse,
+        user: ctx.memberUser,
         roles: [],
         organs: [],
-        acceptedToS: TermsOfServiceStatus.ACCEPTED,
-        rolesWithPermissions: [],
       };
 
       qrServiceStub.get.resolves(pendingQr);
@@ -538,24 +515,11 @@ describe('AuthenticationSecureController', () => {
       const pendingQr = ctx.qrAuthenticators.find(qr => qr.status === QRAuthenticatorStatus.PENDING);
       expect(pendingQr).to.not.be.undefined;
 
-      const mockUserResponse: UserResponse = {
-        id: ctx.adminUser.id,
-        firstName: ctx.adminUser.firstName,
-        lastName: ctx.adminUser.lastName,
-        active: ctx.adminUser.active,
-        deleted: ctx.adminUser.deleted,
-        type: ctx.adminUser.type,
-        canGoIntoDebt: ctx.adminUser.canGoIntoDebt,
-        acceptedToS: ctx.adminUser.acceptedToS,
-      };
-
-      const mockToken: AuthenticationResponse = {
+      const mockToken: AuthenticationResult = {
         token: 'mock-jwt-token',
-        user: mockUserResponse,
+        user: ctx.adminUser,
         roles: [],
         organs: [],
-        acceptedToS: TermsOfServiceStatus.ACCEPTED,
-        rolesWithPermissions: [],
       };
 
       qrServiceStub.get.resolves(pendingQr);
@@ -570,10 +534,13 @@ describe('AuthenticationSecureController', () => {
       expect(res.body).to.deep.equal({ message: 'QR code confirmed successfully.' });
 
       // Verify WebSocket emission with admin user
+      const expectedAuthResponse = AuthenticationService.asAuthenticationResponse(
+        mockToken.user, mockToken.roles, mockToken.organs, mockToken.token,
+      );
       expect(mockToMethod.calledOnceWith(`qr-session-${pendingQr.sessionId}`)).to.be.true;
       expect(mockEmitMethod.calledOnceWith('qr-confirmed', {
         sessionId: pendingQr.sessionId,
-        token: mockToken,
+        token: expectedAuthResponse,
       })).to.be.true;
     });
 
@@ -581,24 +548,11 @@ describe('AuthenticationSecureController', () => {
       const pendingQr = ctx.qrAuthenticators.find(qr => qr.status === QRAuthenticatorStatus.PENDING);
       expect(pendingQr).to.not.be.undefined;
 
-      const mockUserResponse: UserResponse = {
-        id: ctx.memberUser.id,
-        firstName: ctx.memberUser.firstName,
-        lastName: ctx.memberUser.lastName,
-        active: ctx.memberUser.active,
-        deleted: ctx.memberUser.deleted,
-        type: ctx.memberUser.type,
-        canGoIntoDebt: ctx.memberUser.canGoIntoDebt,
-        acceptedToS: ctx.memberUser.acceptedToS,
-      };
-
-      const mockToken: AuthenticationResponse = {
+      const mockToken: AuthenticationResult = {
         token: 'mock-jwt-token',
-        user: mockUserResponse,
+        user: ctx.memberUser,
         roles: [],
         organs: [],
-        acceptedToS: TermsOfServiceStatus.ACCEPTED,
-        rolesWithPermissions: [],
       };
 
       qrServiceStub.get.resolves(pendingQr);
@@ -620,24 +574,11 @@ describe('AuthenticationSecureController', () => {
       const pendingQr = ctx.qrAuthenticators.find(qr => qr.status === QRAuthenticatorStatus.PENDING);
       expect(pendingQr).to.not.be.undefined;
 
-      const mockUserResponse: UserResponse = {
-        id: ctx.memberUser.id,
-        firstName: ctx.memberUser.firstName,
-        lastName: ctx.memberUser.lastName,
-        active: ctx.memberUser.active,
-        deleted: ctx.memberUser.deleted,
-        type: ctx.memberUser.type,
-        canGoIntoDebt: ctx.memberUser.canGoIntoDebt,
-        acceptedToS: ctx.memberUser.acceptedToS,
-      };
-
-      const mockToken: AuthenticationResponse = {
+      const mockToken: AuthenticationResult = {
         token: 'mock-jwt-token',
-        user: mockUserResponse,
+        user: ctx.memberUser,
         roles: [],
         organs: [],
-        acceptedToS: TermsOfServiceStatus.ACCEPTED,
-        rolesWithPermissions: [],
       };
 
       qrServiceStub.get.resolves(pendingQr);
@@ -662,25 +603,9 @@ describe('AuthenticationSecureController', () => {
       const pendingQr = ctx.qrAuthenticators.find(qr => qr.status === QRAuthenticatorStatus.PENDING);
       expect(pendingQr).to.not.be.undefined;
 
-      const mockUserResponse: UserResponse = {
-        id: ctx.memberUser.id,
-        firstName: ctx.memberUser.firstName,
-        lastName: ctx.memberUser.lastName,
-        active: ctx.memberUser.active,
-        deleted: ctx.memberUser.deleted,
-        type: ctx.memberUser.type,
-        canGoIntoDebt: ctx.memberUser.canGoIntoDebt,
-        acceptedToS: ctx.memberUser.acceptedToS,
-      };
-
-      const mockToken: AuthenticationResponse = {
-        token: 'mock-jwt-token',
-        user: mockUserResponse,
-        roles: [],
-        organs: [],
-        acceptedToS: TermsOfServiceStatus.ACCEPTED,
-        rolesWithPermissions: [],
-      };
+      const mockToken: AuthenticationResponse = AuthenticationService.asAuthenticationResponse(
+        ctx.memberUser, [], [], 'mock-jwt-token',
+      );
 
       // Call WebSocketService.emitQRConfirmed directly
       WebSocketService.emitQRConfirmed(pendingQr, mockToken);

--- a/test/unit/controller/banner-controller.ts
+++ b/test/unit/controller/banner-controller.ts
@@ -44,28 +44,7 @@ import { truncateAllTables } from '../../setup';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { RbacSeeder } from '../../seed';
 import BannerSeeder from '../../seed/banner-seeder';
-
-export function bannerEq(a: Banner, b: BannerResponse): Boolean {
-  const aEmpty = a === {} as Banner || a === undefined;
-  const bEmpty = b === {} as BannerResponse || b === undefined;
-  if (aEmpty !== bEmpty) {
-    return false;
-  }
-  if (aEmpty ? !bEmpty : bEmpty) {
-    return false;
-  }
-
-  const downloadName = a.image ? (a.image.downloadName ?? null) : null;
-
-  return a.name === b.name
-    && downloadName === b.image
-    && a.duration === b.duration
-    && a.active === b.active
-    && Math.floor(a.startDate.getTime() / 1000)
-    === Math.floor(new Date(b.startDate).getTime() / 1000)
-    && Math.floor(a.endDate.getTime() / 1000)
-    === Math.floor(new Date(b.endDate).getTime() / 1000);
-}
+import { bannerEq } from '../../helpers/banner-helpers';
 
 describe('BannerController', async (): Promise<void> => {
   let ctx: {

--- a/test/unit/controller/borrelkaart-group-controller.ts
+++ b/test/unit/controller/borrelkaart-group-controller.ts
@@ -25,7 +25,7 @@ import { SwaggerSpecification } from 'swagger-model-validator';
 import { DataSource } from 'typeorm';
 import TokenHandler from '../../../src/authentication/token-handler';
 import VoucherGroupController from '../../../src/controller/voucher-group-controller';
-import { VoucherGroupRequest } from '../../../src/controller/request/voucher-group-request';
+import { VoucherGroupParams, VoucherGroupRequest } from '../../../src/controller/request/voucher-group-request';
 import VoucherGroupResponse from '../../../src/controller/response/voucher-group-response';
 import Database from '../../../src/database/database';
 import VoucherGroup from '../../../src/entity/user/voucher-group';
@@ -42,12 +42,22 @@ import {
   defaultPagination,
   PaginationResult,
 } from '../../../src/helpers/pagination';
-import { bkgEq } from '../service/voucher-group-service';
 import Sinon from 'sinon';
 import { DineroObjectRequest } from '../../../src/controller/request/dinero-request';
 import { truncateAllTables } from '../../setup';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { RbacSeeder } from '../../seed';
+
+/**
+ * Compares VoucherGroupParams against a VoucherGroupResponse (HTTP response format).
+ */
+function bkgResponseEq(req: VoucherGroupParams, res: VoucherGroupResponse): void {
+  expect(res.name).to.equal(req.name);
+  expect(res.activeStartDate).to.equal(req.activeStartDate.toISOString());
+  expect(res.activeEndDate).to.equal(req.activeEndDate.toISOString());
+  expect(res.users).to.be.of.length(req.amount);
+  expect(res.balance.amount).to.equal(req.balance.getAmount());
+}
 
 async function saveBKG(
   bkgReq: VoucherGroupRequest,
@@ -294,7 +304,7 @@ describe('VoucherGroupController', async (): Promise<void> => {
 
       // success code
       expect(res.status, 'status incorrect on valid post').to.equal(200);
-      bkgEq(VoucherGroupService.asVoucherGroupParams(ctx.validVoucherGroupReq), res.body);
+      bkgResponseEq(VoucherGroupService.asVoucherGroupParams(ctx.validVoucherGroupReq), res.body);
     });
     it('should return an HTTP 400 if the given voucher group is invalid', async () => {
       // post invalid voucher group
@@ -360,7 +370,7 @@ describe('VoucherGroupController', async (): Promise<void> => {
       const bkgRes = res.body as VoucherGroupResponse;
 
       expect(bkgRes, 'voucher group not found').to.not.be.empty;
-      bkgEq(VoucherGroupService.asVoucherGroupParams(ctx.validVoucherGroupReq), bkgRes);
+      bkgResponseEq(VoucherGroupService.asVoucherGroupParams(ctx.validVoucherGroupReq), bkgRes);
     });
     it('should return an HTTP 404 if the voucher group with given id does not exist', async () => {
       // get voucher group by id
@@ -417,7 +427,7 @@ describe('VoucherGroupController', async (): Promise<void> => {
       ).to.be.true;
 
       // check returned voucher group
-      bkgEq(
+      bkgResponseEq(
         VoucherGroupService.asVoucherGroupParams(ctx.validVoucherGroupReq),
         res.body as VoucherGroupResponse,
       );

--- a/test/unit/controller/event-controller.ts
+++ b/test/unit/controller/event-controller.ts
@@ -268,17 +268,15 @@ describe('EventController', () => {
     it('should adhere to pagination', async () => {
       const take = 3;
       const skip = 1;
-      const events = await EventService.getEvents({}, { take, skip });
-      expect(events.records.length).to.equal(take);
-      expect(events._pagination.take).to.equal(take);
-      expect(events._pagination.skip).to.equal(skip);
-      expect(events._pagination.count).to.equal(ctx.events.length);
+      const [events, count] = await EventService.getEvents({}, { take, skip });
+      expect(events.length).to.equal(take);
+      expect(count).to.equal(ctx.events.length);
 
       const ids = ctx.events
         .sort((a, b) => b.startDate.getTime() - a.startDate.getTime())
         .slice(skip, skip + take)
         .map((e) => e.id);
-      events.records.forEach((event, i) => {
+      events.forEach((event, i) => {
         expect(event.id).to.equal(ids[i]);
       });
     });

--- a/test/unit/controller/point-of-sale-controller.ts
+++ b/test/unit/controller/point-of-sale-controller.ts
@@ -479,10 +479,11 @@ describe('PointOfSaleController', async () => {
     let pointOfSale: PointOfSaleWithContainersResponse;
 
     before(async () => {
-      pointOfSale = await PointOfSaleService.createPointOfSale({
+      const revision = await PointOfSaleService.createPointOfSale({
         ...ctx.validPOSRequest,
         ownerId: ctx.organUser.id,
       });
+      pointOfSale = PointOfSaleService.revisionToResponse(revision) as PointOfSaleWithContainersResponse;
     });
 
     after(async () => {

--- a/test/unit/controller/root-controller.ts
+++ b/test/unit/controller/root-controller.ts
@@ -24,7 +24,7 @@ import RootController from '../../../src/controller/root-controller';
 import { BannerResponse } from '../../../src/controller/response/banner-response';
 import { defaultPagination, PaginationResult } from '../../../src/helpers/pagination';
 import Banner from '../../../src/entity/banner';
-import { bannerEq } from './banner-controller';
+import { bannerEq } from '../../helpers/banner-helpers';
 import { DefaultContext, defaultContext, finishTestDB } from '../../helpers/test-helpers';
 import User from '../../../src/entity/user/user';
 import { ADMIN_USER, UserFactory } from '../../helpers/user-factory';

--- a/test/unit/controller/terms-of-service-controller.ts
+++ b/test/unit/controller/terms-of-service-controller.ts
@@ -24,7 +24,7 @@ import sinon from 'sinon';
 import User, { UserType } from '../../../src/entity/user/user';
 import TokenMiddleware from '../../../src/middleware/token-middleware';
 import TermsOfServiceController from '../../../src/controller/terms-of-service-controller';
-import TermsOfServiceService from '../../../src/service/terms-of-service-service';
+import TermsOfServiceService, { TermsOfService } from '../../../src/service/terms-of-service-service';
 import { TermsOfServiceResponse } from '../../../src/controller/response/terms-of-service-response';
 import { DefaultContext, defaultContext, finishTestDB } from '../../helpers/test-helpers';
 import { truncateAllTables } from '../../setup';
@@ -91,7 +91,7 @@ describe('TermsOfServiceController', () => {
 
   describe('GET /terms-of-service', () => {
     it('should return correct model', async () => {
-      const tosResponse: TermsOfServiceResponse = { versionNumber: '1.0', content: '# TOS v1.0' };
+      const tosResponse: TermsOfService = { versionNumber: '1.0', content: '# TOS v1.0' };
       const stub = sinon.stub(TermsOfServiceService, 'getTermsOfService').resolves(tosResponse);
       stubs.push(stub);
 
@@ -110,7 +110,7 @@ describe('TermsOfServiceController', () => {
     });
 
     it('should return 200 with the correct TOS content when a valid version is requested', async () => {
-      const tosResponse: TermsOfServiceResponse = { versionNumber: '1.0', content: '# Terms of Service v1.0' };
+      const tosResponse: TermsOfService = { versionNumber: '1.0', content: '# Terms of Service v1.0' };
       const stub = sinon.stub(TermsOfServiceService, 'getTermsOfService').resolves(tosResponse);
       stubs.push(stub);
 
@@ -192,7 +192,7 @@ describe('TermsOfServiceController', () => {
     });
 
     it('should return 200 for a regular user with own TOS permissions', async () => {
-      const tosResponse: TermsOfServiceResponse = { versionNumber: '1.0', content: '# TOS v1.0' };
+      const tosResponse: TermsOfService = { versionNumber: '1.0', content: '# TOS v1.0' };
       const stub = sinon.stub(TermsOfServiceService, 'getTermsOfService').resolves(tosResponse);
       stubs.push(stub);
 

--- a/test/unit/service/balance-service.ts
+++ b/test/unit/service/balance-service.ts
@@ -34,7 +34,7 @@ import SubTransactionRow from '../../../src/entity/transactions/sub-transaction-
 import SubTransaction from '../../../src/entity/transactions/sub-transaction';
 import DineroTransformer from '../../../src/entity/transformer/dinero-transformer';
 import { OrderingDirection } from '../../../src/helpers/ordering';
-import { defaultPagination } from '../../../src/helpers/pagination';
+
 import { addTransaction, addTransfer } from '../../helpers/transaction-helpers';
 import { calculateBalance } from '../../helpers/balance';
 import Fine from '../../../src/entity/fine/fine';
@@ -114,11 +114,11 @@ describe('BalanceService', (): void => {
 
   describe('getBalances', () => {
     it('should return balances from all users', async () => {
-      const balanceResponses = await new BalanceService().getBalances({});
+      const [records] = await new BalanceService().getBalances({});
       const now = new Date();
-      expect(balanceResponses.records.length).to.equal(ctx.users.length);
+      expect(records.length).to.equal(ctx.users.length);
 
-      balanceResponses.records.forEach((balance) => {
+      records.forEach((balance) => {
         const user = ctx.users.find((u) => u.id === balance.id);
         expect(user).to.not.be.undefined;
         const actualBalance = calculateBalance(user, ctx.transactions, ctx.subTransactions, ctx.transfers);
@@ -127,13 +127,13 @@ describe('BalanceService', (): void => {
         checkFine(balance, user);
       });
 
-      expect(balanceResponses.records.some((b) => b.fine), 'At least one user has a fine').to.be.true;
+      expect(records.some((b) => b.fine), 'At least one user has a fine').to.be.true;
     });
     it('should return balances on certain date', async () => {
       const date = new Date('2021-01-01');
-      const balances = await new BalanceService().getBalances({ date });
+      const [records] = await new BalanceService().getBalances({ date });
 
-      balances.records.forEach((balance) => {
+      records.forEach((balance) => {
         const user = ctx.users.find((u) => u.id === balance.id);
         expect(user).to.not.be.undefined;
         const actualBalance = calculateBalance(user, ctx.transactions, ctx.subTransactions, ctx.transfers, date);
@@ -144,10 +144,10 @@ describe('BalanceService', (): void => {
     });
     it('should return balance from subset of users', async () => {
       const users = [ctx.users[10], ctx.users[11], ctx.users[12]];
-      const balanceResponses = await new BalanceService().getBalances({ ids: users.map((u) => u.id) });
-      expect(balanceResponses.records.length).to.equal(users.length);
+      const [records] = await new BalanceService().getBalances({ ids: users.map((u) => u.id) });
+      expect(records.length).to.equal(users.length);
 
-      balanceResponses.records.map((balance) => {
+      records.map((balance) => {
         const user = ctx.users.find((u) => u.id === balance.id);
         const actualBalance = calculateBalance(user, ctx.transactions, ctx.subTransactions, ctx.transfers);
         expect(balance.amount.amount).to.equal(actualBalance.amount.getAmount());
@@ -156,60 +156,60 @@ describe('BalanceService', (): void => {
     });
     it('should only return balances more than or equal a certain amount', async () => {
       const amount = 1039;
-      const allResponses = await new BalanceService().getBalances({});
-      const filteredResponses = await new BalanceService().getBalances({
+      const [allRecords] = await new BalanceService().getBalances({});
+      const [filteredRecords] = await new BalanceService().getBalances({
         minBalance: DineroTransformer.Instance.from(amount),
       });
 
-      expect(filteredResponses.records.length).to.equal(allResponses.records.filter((res) => res.amount.amount >= amount).length);
-      filteredResponses.records.forEach((res) => expect(res.amount.amount).to.be.greaterThanOrEqual(amount));
+      expect(filteredRecords.length).to.equal(allRecords.filter((res) => res.amount.amount >= amount).length);
+      filteredRecords.forEach((res) => expect(res.amount.amount).to.be.greaterThanOrEqual(amount));
     });
     it('should only return balances less than or equal a certain amount', async () => {
       const amount = 1039;
-      const allResponses = await new BalanceService().getBalances({});
-      const filteredResponses = await new BalanceService().getBalances({
+      const [allRecords] = await new BalanceService().getBalances({});
+      const [filteredRecords] = await new BalanceService().getBalances({
         maxBalance: DineroTransformer.Instance.from(amount),
       });
 
-      expect(filteredResponses.records.length).to.equal(allResponses.records.filter((res) => res.amount.amount <= amount).length);
-      filteredResponses.records.forEach((res) => expect(res.amount.amount).to.be.lessThanOrEqual(amount));
+      expect(filteredRecords.length).to.equal(allRecords.filter((res) => res.amount.amount <= amount).length);
+      filteredRecords.forEach((res) => expect(res.amount.amount).to.be.lessThanOrEqual(amount));
     });
     it('should only return balances without a fine', async () => {
       const users = ctx.users.filter((u) => u.currentFines == null);
-      const balances = await new BalanceService().getBalances({ hasFine: false });
+      const [records] = await new BalanceService().getBalances({ hasFine: false });
 
-      expect(balances.records.length).to.equal(users.length);
-      balances.records.forEach((b) => b.fine == null && b.fineSince == null);
+      expect(records.length).to.equal(users.length);
+      records.forEach((b) => b.fine == null && b.fineSince == null);
     });
     it('should only return balances with a fine', async () => {
       const users = ctx.users.filter((u) => u.currentFines != null);
-      const balances = await new BalanceService().getBalances({ hasFine: true });
+      const [records] = await new BalanceService().getBalances({ hasFine: true });
 
-      expect(balances.records.length).to.equal(users.length);
-      balances.records.forEach((b) => b.fine != null && b.fineSince != null);
+      expect(records.length).to.equal(users.length);
+      records.forEach((b) => b.fine != null && b.fineSince != null);
     });
     it('should only return balances starting with a certain fine amount', async () => {
       const amount = 600;
       const users = ctx.users.filter((u) => u.currentFines != null)
         .filter((u) => u.currentFines.fines.reduce((sum, f) => sum + f.amount.getAmount(), 0) >= amount);
-      const balances = await new BalanceService().getBalances({
+      const [records] = await new BalanceService().getBalances({
         minFine: DineroTransformer.Instance.from(amount),
       });
 
-      expect(balances.records.length).to.equal(users.length);
-      balances.records.forEach((b) => b.fine != null && b.fine.amount >= amount);
+      expect(records.length).to.equal(users.length);
+      records.forEach((b) => b.fine != null && b.fine.amount >= amount);
     });
     /**
      * See https://github.com/GEWIS/sudosos-backend/issues/167
      */
     it('should not return deleted users', async () => {
       const user = ctx.users[0];
-      const balance = await new BalanceService().getBalances({ ids: [user.id] });
-      expect(balance.records).to.not.be.empty;
+      const [records] = await new BalanceService().getBalances({ ids: [user.id] });
+      expect(records).to.not.be.empty;
 
       await User.update(user.id, { deleted: true });
-      const balance2 = await new BalanceService().getBalances({ ids: [user.id] });
-      expect(balance2.records).to.be.empty;
+      const [records2] = await new BalanceService().getBalances({ ids: [user.id] });
+      expect(records2).to.be.empty;
     });
     it('should include transactions from deleted POS', async () => {
       const builder = await UserFactory();
@@ -317,128 +317,122 @@ describe('BalanceService', (): void => {
       const amount = 600;
       const users = ctx.users.filter((u) => u.currentFines != null)
         .filter((u) => u.currentFines.fines.reduce((sum, f) => sum + f.amount.getAmount(), 0) <= amount);
-      const balances = await new BalanceService().getBalances({
+      const [records] = await new BalanceService().getBalances({
         maxFine: DineroTransformer.Instance.from(amount),
       });
 
-      expect(balances.records.length).to.equal(users.length);
-      balances.records.forEach((b) => b.fine != null && b.fine.amount <= amount);
+      expect(records.length).to.equal(users.length);
+      records.forEach((b) => b.fine != null && b.fine.amount <= amount);
     });
     it('should return all users with certain user type', async () => {
       const type = UserType.LOCAL_USER;
       const users = ctx.users.filter((u) => u.type === type);
-      const balances = await new BalanceService().getBalances({ userTypes: [type], allowDeleted: true });
+      const [records] = await new BalanceService().getBalances({ userTypes: [type], allowDeleted: true });
 
-      expect(balances.records.length).to.equal(users.length);
+      expect(records.length).to.equal(users.length);
 
       const userIds = users.map((u) => u.id);
-      balances.records.forEach((bal) => {
+      records.forEach((bal) => {
         expect(userIds).to.include(bal.id);
       });
 
-      const balanceIds = balances.records.map((b) => b.id);
+      const balanceIds = records.map((b) => b.id);
       users.forEach((u) => {
         expect(balanceIds).to.include(u.id);
       });
     });
     it('should return all inactive users', async () => {
       const users = ctx.users.filter((u) => u.active === false);
-      const balances = await new BalanceService().getBalances({ inactive: true });
-      expect(balances.records.length).to.be.greaterThan(0);
-      expect(balances.records.length).to.equal(users.length);
+      const [records] = await new BalanceService().getBalances({ inactive: true });
+      expect(records.length).to.be.greaterThan(0);
+      expect(records.length).to.equal(users.length);
 
       const userIds = users.map((u) => u.id);
-      balances.records.forEach((bal) => {
+      records.forEach((bal) => {
         expect(userIds).to.include(bal.id);
       });
     });
     it('should return all users with certain user type from set of types', async () => {
       const userTypes = [UserType.LOCAL_USER, UserType.LOCAL_ADMIN];
       const users = ctx.users.filter((u) => userTypes.includes(u.type));
-      const balances = await new BalanceService().getBalances({ userTypes, allowDeleted: true });
+      const [records] = await new BalanceService().getBalances({ userTypes, allowDeleted: true });
 
-      expect(balances.records.length).to.equal(users.length);
+      expect(records.length).to.equal(users.length);
 
       const userIds = users.map((u) => u.id);
-      balances.records.forEach((bal) => {
+      records.forEach((bal) => {
         expect(userIds).to.include(bal.id);
       });
 
-      const balanceIds = balances.records.map((b) => b.id);
+      const balanceIds = records.map((b) => b.id);
       users.forEach((u) => {
         expect(balanceIds).to.include(u.id);
       });
     });
     it('should return balances ordered by ID desc', async () => {
-      const balanceResponses = await new BalanceService().getBalances({
+      const [records] = await new BalanceService().getBalances({
         orderBy: BalanceOrderColumn.ID, orderDirection: OrderingDirection.DESC,
       });
 
-      balanceResponses.records.forEach((response, index, responses) => {
+      records.forEach((response, index, responses) => {
         if (index === 0) return;
         expect(response.id).to.be.lessThan(responses[index - 1].id);
       });
     });
     it('should return balances ordered by amount asc', async () => {
-      const balanceResponses = await new BalanceService().getBalances({
+      const [records] = await new BalanceService().getBalances({
         orderBy: BalanceOrderColumn.AMOUNT, orderDirection: OrderingDirection.ASC,
       });
 
-      balanceResponses.records.forEach((response, index, responses) => {
+      records.forEach((response, index, responses) => {
         if (index === 0) return;
         expect(response.amount.amount).to.be.greaterThanOrEqual(responses[index - 1].amount.amount);
       });
     });
     it('should return balances ordered by fine amount asc', async () => {
-      const balanceResponses = await new BalanceService().getBalances({
+      const [records] = await new BalanceService().getBalances({
         orderBy: BalanceOrderColumn.FINEAMOUNT, orderDirection: OrderingDirection.ASC, hasFine: true,
       });
-      balanceResponses.records.forEach((response, index, responses) => {
+      records.forEach((response, index, responses) => {
         if (index === 0) return;
         expect(response.fine.amount).to.be.greaterThanOrEqual(responses[index - 1].fine.amount);
       });
     });
     it('should return balances ordered by fine date asc', async () => {
-      const balanceResponses = await new BalanceService().getBalances({
+      const [records] = await new BalanceService().getBalances({
         orderBy: BalanceOrderColumn.FINESINCE, orderDirection: OrderingDirection.ASC,
       });
-      balanceResponses.records.forEach((response, index, responses) => {
+      records.forEach((response, index, responses) => {
         if (index === 0) return;
         expect(new Date(response.fineSince).getTime()).to.be.greaterThanOrEqual(new Date(responses[index - 1].fineSince).getTime());
       });
     });
     it('should return balances ordered ascending by default', async () => {
-      const balanceResponses = await new BalanceService().getBalances({
+      const [records] = await new BalanceService().getBalances({
         orderBy: BalanceOrderColumn.AMOUNT,
       });
 
-      balanceResponses.records.forEach((response, index, responses) => {
+      records.forEach((response, index, responses) => {
         if (index === 0) return;
         expect(response.amount.amount).to.be.greaterThanOrEqual(responses[index - 1].amount.amount);
       });
     });
     it('should set pagination metadata correctly when pagination parameters are undefined', async () => {
-      const balanceResponses = await new BalanceService().getBalances({}, {});
-      expect(balanceResponses._pagination.take).to.be.undefined;
-      expect(balanceResponses._pagination.skip).to.be.undefined;
-      expect(balanceResponses._pagination.count).to.equal(balanceResponses.records.length);
+      const [records, count] = await new BalanceService().getBalances({}, {});
+      expect(count).to.equal(records.length);
     });
     it('should adhere to pagination take', async () => {
       const take = 10;
-      const balanceResponses = await new BalanceService().getBalances({ allowDeleted: true }, { take });
-      expect(balanceResponses.records.length).to.equal(take);
-      expect(balanceResponses._pagination.take).to.equal(take);
-      expect(balanceResponses._pagination.skip).to.be.undefined;
-      expect(balanceResponses._pagination.count).to.equal(ctx.users.length);
+      const [records, count] = await new BalanceService().getBalances({ allowDeleted: true }, { take });
+      expect(records.length).to.equal(take);
+      expect(count).to.equal(ctx.users.length);
     });
     it('should adhere to pagination skip', async () => {
       const take = 4;
       const skip = ctx.users.length - take;
-      const balanceResponses = await new BalanceService().getBalances({ allowDeleted: true }, { skip });
-      expect(balanceResponses.records.length).to.equal(take);
-      expect(balanceResponses._pagination.take).to.equal(defaultPagination());
-      expect(balanceResponses._pagination.skip).to.equal(skip);
-      expect(balanceResponses._pagination.count).to.equal(ctx.users.length);
+      const [records, count] = await new BalanceService().getBalances({ allowDeleted: true }, { skip });
+      expect(records.length).to.equal(take);
+      expect(count).to.equal(ctx.users.length);
     });
   });
 
@@ -823,11 +817,11 @@ describe('BalanceService', (): void => {
       const date = new Date('2021-01-01');
       await new BalanceService().clearBalanceCache();
 
-      const allBalances = await new BalanceService().getBalances({
+      const [allRecords] = await new BalanceService().getBalances({
         date,
       });
 
-      const { positiveBalances, negativeBalances } = allBalances.records
+      const { positiveBalances, negativeBalances } = allRecords
         .reduce((acc, balance) => {
           const amount = balance.amount.amount;
           if (amount > 0) {
@@ -846,14 +840,14 @@ describe('BalanceService', (): void => {
       const date = new Date('2021-01-01');
       await new BalanceService().clearBalanceCache();
 
-      const allBalances = await new BalanceService().getBalances({
+      const [allRecords] = await new BalanceService().getBalances({
         date,
       });
 
       const userTypeBalances: UserTypeTotalBalanceResponse[] = [];
 
       for (const type of Object.values(UserType)) {
-        const { positiveBalances, negativeBalances } = allBalances.records
+        const { positiveBalances, negativeBalances } = allRecords
           .filter((r) => r.type == type)
           .reduce((acc, balance) => {
             const amount = balance.amount.amount;
@@ -884,12 +878,12 @@ describe('BalanceService', (): void => {
     const date = new Date('2021-01-01');
     await new BalanceService().clearBalanceCache();
 
-    const allBalances = await new BalanceService().getBalances({
+    const [allRecords] = await new BalanceService().getBalances({
       date,
       allowDeleted: true,
     });
 
-    const { positiveBalances, negativeBalances } = allBalances.records
+    const { positiveBalances, negativeBalances } = allRecords
       .reduce((acc, balance) => {
         const amount = balance.amount.amount;
         if (amount > 0) {

--- a/test/unit/service/banner-service.ts
+++ b/test/unit/service/banner-service.ts
@@ -63,19 +63,19 @@ describe('BannerService', () => {
 
   describe('getBanners', () => {
     it('should return all banners when no filters are applied', async () => {
-      const result = await BannerService.getBanners({});
-      expect(result.records.length).to.equal(ctx.banners.length);
-      expect(result._pagination.count).to.equal(ctx.banners.length);
+      const [banners, count] = await BannerService.getBanners({});
+      expect(banners.length).to.equal(ctx.banners.length);
+      expect(count).to.equal(ctx.banners.length);
     });
 
     it('should filter by active=true', async () => {
       const filters: BannerFilterParameters = { active: true };
-      const result = await BannerService.getBanners(filters);
+      const [banners, count] = await BannerService.getBanners(filters);
       const activeBanners = ctx.banners.filter((b) => b.active);
 
-      expect(result.records.length).to.equal(activeBanners.length);
-      expect(result._pagination.count).to.equal(activeBanners.length);
-      result.records.forEach((banner) => {
+      expect(banners.length).to.equal(activeBanners.length);
+      expect(count).to.equal(activeBanners.length);
+      banners.forEach((banner) => {
         const originalBanner = ctx.banners.find((b) => b.id === banner.id);
         expect(originalBanner.active).to.be.true;
       });
@@ -83,12 +83,12 @@ describe('BannerService', () => {
 
     it('should filter by active=false', async () => {
       const filters: BannerFilterParameters = { active: false };
-      const result = await BannerService.getBanners(filters);
+      const [banners, count] = await BannerService.getBanners(filters);
       const inactiveBanners = ctx.banners.filter((b) => !b.active);
 
-      expect(result.records.length).to.equal(inactiveBanners.length);
-      expect(result._pagination.count).to.equal(inactiveBanners.length);
-      result.records.forEach((banner) => {
+      expect(banners.length).to.equal(inactiveBanners.length);
+      expect(count).to.equal(inactiveBanners.length);
+      banners.forEach((banner) => {
         const originalBanner = ctx.banners.find((b) => b.id === banner.id);
         expect(originalBanner.active).to.be.false;
       });
@@ -106,9 +106,9 @@ describe('BannerService', () => {
       await Banner.save(expiredBanner);
 
       const filters: BannerFilterParameters = { expired: true };
-      const result = await BannerService.getBanners(filters);
+      const [banners] = await BannerService.getBanners(filters);
 
-      for (const banner of result.records) {
+      for (const banner of banners) {
         const dbBanner = await Banner.findOne({ where: { id: banner.id } });
         expect(dbBanner.endDate.getTime()).to.be.at.most(new Date().getTime());
       }
@@ -129,9 +129,9 @@ describe('BannerService', () => {
       await Banner.save(futureBanner);
 
       const filters: BannerFilterParameters = { expired: false };
-      const result = await BannerService.getBanners(filters);
+      const [banners] = await BannerService.getBanners(filters);
 
-      for (const banner of result.records) {
+      for (const banner of banners) {
         const dbBanner = await Banner.findOne({ where: { id: banner.id } });
         expect(dbBanner.endDate.getTime()).to.be.greaterThan(new Date().getTime());
       }
@@ -142,32 +142,32 @@ describe('BannerService', () => {
 
     it('should order by startDate ASC', async () => {
       const filters: BannerFilterParameters = { order: 'ASC' };
-      const result = await BannerService.getBanners(filters);
+      const [banners] = await BannerService.getBanners(filters);
 
-      for (let i = 1; i < result.records.length; i += 1) {
-        const prevDate = new Date(result.records[i - 1].startDate).getTime();
-        const currDate = new Date(result.records[i].startDate).getTime();
+      for (let i = 1; i < banners.length; i += 1) {
+        const prevDate = banners[i - 1].startDate.getTime();
+        const currDate = banners[i].startDate.getTime();
         expect(currDate).to.be.at.least(prevDate);
       }
     });
 
     it('should order by startDate DESC', async () => {
       const filters: BannerFilterParameters = { order: 'DESC' };
-      const result = await BannerService.getBanners(filters);
+      const [banners] = await BannerService.getBanners(filters);
 
-      for (let i = 1; i < result.records.length; i += 1) {
-        const prevDate = new Date(result.records[i - 1].startDate).getTime();
-        const currDate = new Date(result.records[i].startDate).getTime();
+      for (let i = 1; i < banners.length; i += 1) {
+        const prevDate = banners[i - 1].startDate.getTime();
+        const currDate = banners[i].startDate.getTime();
         expect(currDate).to.be.at.most(prevDate);
       }
     });
 
     it('should default to DESC order when order is not specified', async () => {
-      const result = await BannerService.getBanners({});
+      const [banners] = await BannerService.getBanners({});
 
-      for (let i = 1; i < result.records.length; i += 1) {
-        const prevDate = new Date(result.records[i - 1].startDate).getTime();
-        const currDate = new Date(result.records[i].startDate).getTime();
+      for (let i = 1; i < banners.length; i += 1) {
+        const prevDate = banners[i - 1].startDate.getTime();
+        const currDate = banners[i].startDate.getTime();
         expect(currDate).to.be.at.most(prevDate);
       }
     });
@@ -184,9 +184,9 @@ describe('BannerService', () => {
       await Banner.save(activeFutureBanner);
 
       const filters: BannerFilterParameters = { active: true, expired: false };
-      const result = await BannerService.getBanners(filters);
+      const [banners] = await BannerService.getBanners(filters);
 
-      for (const banner of result.records) {
+      for (const banner of banners) {
         const dbBanner = await Banner.findOne({ where: { id: banner.id } });
         expect(dbBanner.active).to.be.true;
         expect(dbBanner.endDate.getTime()).to.be.greaterThan(new Date().getTime());
@@ -198,16 +198,16 @@ describe('BannerService', () => {
 
     it('should combine all filters with order', async () => {
       const filters: BannerFilterParameters = { active: true, order: 'ASC' };
-      const result = await BannerService.getBanners(filters);
+      const [banners] = await BannerService.getBanners(filters);
 
-      result.records.forEach((banner) => {
+      banners.forEach((banner) => {
         const originalBanner = ctx.banners.find((b) => b.id === banner.id);
         expect(originalBanner.active).to.be.true;
       });
 
-      for (let i = 1; i < result.records.length; i += 1) {
-        const prevDate = new Date(result.records[i - 1].startDate).getTime();
-        const currDate = new Date(result.records[i].startDate).getTime();
+      for (let i = 1; i < banners.length; i += 1) {
+        const prevDate = banners[i - 1].startDate.getTime();
+        const currDate = banners[i].startDate.getTime();
         expect(currDate).to.be.at.least(prevDate);
       }
     });
@@ -215,20 +215,18 @@ describe('BannerService', () => {
     it('should respect pagination parameters', async () => {
       const take = 2;
       const skip = 1;
-      const result = await BannerService.getBanners({}, { take, skip });
+      const [banners] = await BannerService.getBanners({}, { take, skip });
 
-      expect(result.records.length).to.be.at.most(take);
-      expect(result._pagination.take).to.equal(take);
-      expect(result._pagination.skip).to.equal(skip);
+      expect(banners.length).to.be.at.most(take);
     });
 
     it('should filter by bannerId', async () => {
       const targetBanner = ctx.banners[0];
       const filters: BannerFilterParameters = { bannerId: targetBanner.id };
-      const result = await BannerService.getBanners(filters);
+      const [banners] = await BannerService.getBanners(filters);
 
-      expect(result.records.length).to.equal(1);
-      expect(result.records[0].id).to.equal(targetBanner.id);
+      expect(banners.length).to.equal(1);
+      expect(banners[0].id).to.equal(targetBanner.id);
     });
   });
 });

--- a/test/unit/service/container-service.ts
+++ b/test/unit/service/container-service.ts
@@ -31,7 +31,7 @@ import Database from '../../../src/database/database';
 import Swagger from '../../../src/start/swagger';
 import ContainerService from '../../../src/service/container-service';
 import Container from '../../../src/entity/container/container';
-import { ContainerResponse, ContainerWithProductsResponse } from '../../../src/controller/response/container-response';
+import { ContainerResponse } from '../../../src/controller/response/container-response';
 import PointOfSaleRevision from '../../../src/entity/point-of-sale/point-of-sale-revision';
 import ContainerRevision from '../../../src/entity/container/container-revision';
 import {
@@ -46,7 +46,7 @@ import { truncateAllTables } from '../../setup';
 import { finishTestDB } from '../../helpers/test-helpers';
 import PointOfSale from '../../../src/entity/point-of-sale/point-of-sale';
 import sinon from 'sinon';
-import { PointOfSaleWithContainersResponse } from '../../../src/controller/response/point-of-sale-response';
+
 import { ContainerSeeder, PointOfSaleSeeder, UserSeeder } from '../../seed';
 
 /**
@@ -61,20 +61,6 @@ function containerSuperset(response: ContainerResponse[], superset: Container[])
           && supersetContainer.owner.id === searchContainer.owner.id
     )) !== undefined
   ));
-}
-
-function responseAsUpdate(update: UpdateContainerParams, response: ContainerWithProductsResponse) {
-  expect(update.id).to.be.eq(response.id);
-  expect(update.name).to.be.eq(response.name);
-  expect(update.products).to.be.deep.equalInAnyOrder(response.products.map((p) => p.id));
-}
-
-function responseAsCreation(creation: CreateContainerParams,
-  response: ContainerWithProductsResponse) {
-  expect(creation.ownerId).to.be.eq(response.owner.id);
-  expect(creation.name).to.be.eq(response.name);
-  expect(creation.public).to.be.eq(response.public);
-  expect(creation.products).to.be.deep.equalInAnyOrder(response.products.map((p) => p.id));
 }
 
 function entityAsUpdate(update: UpdateContainerParams, container: ContainerRevision) {
@@ -142,10 +128,10 @@ describe('ContainerService', async (): Promise<void> => {
 
   describe('getContainers function', () => {
     it('should return all containers with no input specification', async () => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { records, _pagination } = await ContainerService.getContainers();
+      const [revisions, count] = await ContainerService.getContainers();
 
       const withRevisions = ctx.containers.filter((c) => c.currentRevision > 0);
+      const records = revisions.map((r) => ContainerService.revisionToResponse(r));
       expect(records).to.be.length(withRevisions.length);
       expect(containerSuperset(records, ctx.containers)).to.be.true;
       records.forEach((c) => {
@@ -153,15 +139,14 @@ describe('ContainerService', async (): Promise<void> => {
         expect(validator.valid).to.be.true;
       });
 
-      expect(_pagination.take).to.equal(undefined);
-      expect(_pagination.skip).to.equal(undefined);
-      expect(_pagination.count).to.equal(withRevisions.length);
+      expect(count).to.equal(withRevisions.length);
     });
     it('should return containers with the ownerId specified', async () => {
-      const { records } = await ContainerService.getContainers({
+      const [revisions] = await ContainerService.getContainers({
         ownerId: ctx.containers[0].owner.id,
       });
 
+      const records = revisions.map((r) => ContainerService.revisionToResponse(r));
       expect(containerSuperset(records, ctx.containers)).to.be.true;
 
       const belongsToOwner = records.every((container: ContainerResponse) => (
@@ -172,11 +157,12 @@ describe('ContainerService', async (): Promise<void> => {
     it('should return containers of the point of sale specified', async () => {
       const pos = ctx.pointsOfSale[0];
       const posRevision = ctx.pointOfSaleRevisions.find((r) => r.pointOfSaleId === pos.id && r.revision === pos.currentRevision);
-      const { records } = await ContainerService.getContainers({
+      const [revisions] = await ContainerService.getContainers({
         posId: pos.id,
         posRevision: posRevision.revision,
       });
 
+      const records = revisions.map((r) => ContainerService.revisionToResponse(r));
       expect(containerSuperset(records, ctx.containers)).to.be.true;
 
       const belongsToPos = records.every(
@@ -188,34 +174,31 @@ describe('ContainerService', async (): Promise<void> => {
       expect(posRevision.containers.filter((c) => c.container.deletedAt == null)).to.be.length(records.length);
     });
     it('should return a single container if containerId is specified', async () => {
-      const { records } = await ContainerService.getContainers({
+      const [revisions] = await ContainerService.getContainers({
         containerId: ctx.containers[0].id,
       });
 
-      expect(records).to.be.length(1);
-      expect(records[0].id).to.be.equal(ctx.containers[0].id);
+      expect(revisions).to.be.length(1);
+      expect(revisions[0].containerId).to.be.equal(ctx.containers[0].id);
     });
     it('should return no containers if the userId and containerId dont match', async () => {
-      const { records } = await ContainerService.getContainers({
+      const [revisions] = await ContainerService.getContainers({
         ownerId: ctx.containers[10].owner.id,
         containerId: ctx.containers[0].id,
       });
 
-      expect(records).to.be.length(0);
+      expect(revisions).to.be.length(0);
     });
     it('should adhere to pagination', async () => {
       const take = 5;
       const skip = 3;
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { records, _pagination } = await ContainerService.getContainers({}, {
+      const [revisions, count] = await ContainerService.getContainers({}, {
         take, skip,
       });
 
       const withRevisions = ctx.containers.filter((c) => c.currentRevision > 0);
-      expect(_pagination.take).to.equal(take);
-      expect(_pagination.skip).to.equal(skip);
-      expect(_pagination.count).to.equal(withRevisions.length);
-      expect(records.length).to.equal(take);
+      expect(count).to.equal(withRevisions.length);
+      expect(revisions.length).to.equal(take);
     });
     it('should return products if specified', async () => {
       const createContainerParams: CreateContainerParams = {
@@ -225,9 +208,10 @@ describe('ContainerService', async (): Promise<void> => {
         public: true,
       };
       await ContainerService.createContainer(createContainerParams);
-      const { records } = await ContainerService.getContainers(
+      const [revisions] = await ContainerService.getContainers(
         { returnProducts: true }, {},
       );
+      const records = revisions.map((r) => ContainerService.revisionToResponse(r));
       expect(ctx.specification.validateModel('Array.<ContainerWithProductsResponse.model>', records, false, true).valid).to.be.true;
       const withRevisions = await Container.find({ where: { currentRevision: Not(IsNull()) } });
       expect(records.map((containerResponse) => containerResponse.id))
@@ -244,24 +228,24 @@ describe('ContainerService', async (): Promise<void> => {
       });
       expect(memberAuthenticators.length).to.equal(0);
 
-      let containers = await ContainerService.getContainers({}, {}, owner1);
-      const containersOwnedBy1 = containers.records.length;
-      containers.records.forEach((cont) => {
-        expect(cont.owner.id).to.equal(owner1.id);
+      let [revisions] = await ContainerService.getContainers({}, {}, owner1);
+      const containersOwnedBy1 = revisions.length;
+      revisions.forEach((cont) => {
+        expect(cont.container.owner.id).to.equal(owner1.id);
       });
-      containers = await ContainerService.getContainers({}, {}, owner2);
-      const containersOwnedBy2 = containers.records.length;
-      containers.records.forEach((cont) => {
-        expect(cont.owner.id).to.equal(owner2.id);
+      [revisions] = await ContainerService.getContainers({}, {}, owner2);
+      const containersOwnedBy2 = revisions.length;
+      revisions.forEach((cont) => {
+        expect(cont.container.owner.id).to.equal(owner2.id);
       });
 
       await new AuthenticationService().setMemberAuthenticator([owner1], owner2);
 
       const ownerIds = [owner1, owner2].map((o) => o.id);
-      containers = await ContainerService.getContainers({}, {}, owner1);
-      expect(containers.records.length).to.equal(containersOwnedBy1 + containersOwnedBy2);
-      containers.records.forEach((cont) => {
-        expect(ownerIds).to.include(cont.owner.id);
+      [revisions] = await ContainerService.getContainers({}, {}, owner1);
+      expect(revisions.length).to.equal(containersOwnedBy1 + containersOwnedBy2);
+      revisions.forEach((cont) => {
+        expect(ownerIds).to.include(cont.container.owner.id);
       });
 
       // Cleanup
@@ -304,10 +288,7 @@ describe('ContainerService', async (): Promise<void> => {
         products: [1, 2, 3],
         public: true,
       };
-      const response = await ContainerService.updateContainer(update);
-      responseAsUpdate(update, response);
-      const entity = await Container.findOne({ where: { id: container.id } });
-      const revision = await ContainerRevision.findOne({ where: { container: { id: container.id }, revision: entity.currentRevision }, relations: ['container', 'products', 'products.product'] });
+      const revision = await ContainerService.updateContainer(update);
       entityAsUpdate(update, revision);
     });
   });
@@ -322,20 +303,11 @@ describe('ContainerService', async (): Promise<void> => {
       };
 
       const container = await ContainerService.createContainer(creation);
-      responseAsCreation(creation, container);
-      const entity = await Container.findOne({ where: { id: container.id } });
-      const revision = await ContainerRevision.findOne({
-        where: {
-          container: { id: container.id },
-          revision: entity.currentRevision,
-        },
-        relations: ['container', 'products', 'products.product', 'container.owner'],
-      });
-      await entityAsCreation(creation, revision);
+      await entityAsCreation(creation, container);
 
       // Cleanup
-      await ContainerRevision.delete({ containerId: container.id });
-      await Container.delete({ id: container.id });
+      await ContainerRevision.delete({ containerId: container.containerId });
+      await Container.delete({ id: container.containerId });
     });
   });
 
@@ -359,7 +331,7 @@ describe('ContainerService', async (): Promise<void> => {
       const container2 = await ContainerService.createContainer(createContainerParams);
 
       const createPointOfSaleParams: CreatePointOfSaleParams = {
-        containers: [container.id, container2.id],
+        containers: [container.containerId, container2.containerId],
         name: 'New POS',
         useAuthentication: true,
         ownerId,
@@ -370,33 +342,33 @@ describe('ContainerService', async (): Promise<void> => {
         products: [1, 2],
         public: true,
         name: 'New name',
-        id: container.id,
+        id: container.containerId,
       };
 
       await ContainerService.updateContainer(update);
 
       const updatedPos = await PointOfSaleRevision
-        .findOne({ where: { revision: 2, pointOfSale: { id: pos.id } }, relations: ['containers', 'containers.products'] });
+        .findOne({ where: { revision: 2, pointOfSale: { id: pos.pointOfSaleId } }, relations: ['containers', 'containers.products'] });
       expect(updatedPos).to.not.be.null;
       expect(updatedPos.containers).length(2);
 
-      const newContainer = updatedPos.containers.find((c) => c.container.id === container.id);
+      const newContainer = updatedPos.containers.find((c) => c.container.id === container.containerId);
       expect(newContainer.name).to.eq(update.name);
 
       // Cleanup
-      await PointOfSaleRevision.delete({ pointOfSaleId: pos.id });
-      await PointOfSale.delete({ id: pos.id });
-      await ContainerRevision.delete({ containerId: container2.id });
-      await ContainerRevision.delete({ containerId: container.id });
-      await Container.delete({ id: container2.id });
-      await Container.delete({ id: container.id });
+      await PointOfSaleRevision.delete({ pointOfSaleId: pos.pointOfSaleId });
+      await PointOfSale.delete({ id: pos.pointOfSaleId });
+      await ContainerRevision.delete({ containerId: container2.containerId });
+      await ContainerRevision.delete({ containerId: container.containerId });
+      await Container.delete({ id: container2.containerId });
+      await Container.delete({ id: container.containerId });
     });
   });
   describe('deleteContainer function', () => {
     it('should soft delete container and propagate update after deletion', async () => {
-      const stub = sinon.stub(PointOfSaleService, 'updatePointOfSale').callsFake(async (params): Promise<PointOfSaleWithContainersResponse> => {
-        const pointOfSale = await PointOfSaleService.getPointsOfSale({ pointOfSaleId: params.id, returnContainers: true, returnProducts: true });
-        return pointOfSale.records[0] as PointOfSaleWithContainersResponse;
+      const stub = sinon.stub(PointOfSaleService, 'updatePointOfSale').callsFake(async (params): Promise<PointOfSaleRevision> => {
+        const [revisions] = await PointOfSaleService.getPointsOfSale({ pointOfSaleId: params.id, returnContainers: true, returnProducts: true });
+        return revisions[0];
       });
 
       const start = Math.floor(new Date().getTime() / 1000) * 1000;

--- a/test/unit/service/debtor-service.ts
+++ b/test/unit/service/debtor-service.ts
@@ -31,14 +31,13 @@ import BalanceService from '../../../src/service/balance-service';
 import Fine from '../../../src/entity/fine/fine';
 import UserFineGroup from '../../../src/entity/fine/userFineGroup';
 import { calculateBalance, calculateFine } from '../../helpers/balance';
-import { FineHandoutEventResponse } from '../../../src/controller/response/debtor-response';
+import FineHandoutEvent from '../../../src/entity/fine/fineHandoutEvent';
 import sinon, { SinonSandbox, SinonSpy } from 'sinon';
 import Mailer from '../../../src/mailer';
 import { truncateAllTables } from '../../setup';
 import { finishTestDB } from '../../helpers/test-helpers';
 import dinero from 'dinero.js';
 import TransferService from '../../../src/service/transfer-service';
-import FineHandoutEvent from '../../../src/entity/fine/fineHandoutEvent';
 import { FineSeeder, TransactionSeeder, TransferSeeder, UserSeeder } from '../../seed';
 import { rootStubs } from '../../root-hooks';
 import Notifier from '../../../src/notifications';
@@ -351,15 +350,15 @@ describe('DebtorService', (): void => {
       expect(usersToFine.length).to.be.greaterThan(0);
 
       const actor = (await ctx.connection.getRepository('User').findOne({ where: { id: 1 } })) as any;
-      const handoutResp = await debtorService.handOutFines({
+      const handoutEvent = await debtorService.handOutFines({
         userIds: usersToFine.map((u) => u.id),
         referenceDate,
       }, actor);
 
-      const eventId = handoutResp.id;
+      const eventId = handoutEvent.id;
       const dbEvent = await FineHandoutEvent.findOne({ where: { id: eventId }, relations: ['fines', 'fines.transfer'] });
       expect(dbEvent).to.not.be.undefined;
-      expect(dbEvent!.fines.length).to.equal(handoutResp.fines.length);
+      expect(dbEvent!.fines.length).to.equal(handoutEvent.fines.length);
 
       // Collect transfer ids associated with the created fines
       const transferIds = dbEvent!.fines.map((f) => (f.transfer ? f.transfer.id : null)).filter((id) => id != null) as number[];
@@ -613,47 +612,45 @@ describe('DebtorService', (): void => {
 
   describe('getFineHandoutEvents', () => {
     it('should return all fine handout events in descending order', async () => {
-      const result = await new DebtorService().getFineHandoutEvents();
+      const [events, count] = await new DebtorService().getFineHandoutEvents();
 
-      expect(result.records.length).to.be.greaterThan(0);
+      expect(events.length).to.be.greaterThan(0);
+      expect(count).to.be.greaterThan(0);
 
-      for (let i = 0; i < result.records.length - 1; i++) {
-        expect(new Date(result.records[i].createdAt).getTime()).to.be.at.least(new Date(result.records[i + 1].createdAt).getTime());
+      for (let i = 0; i < events.length - 1; i++) {
+        expect(events[i].createdAt.getTime()).to.be.at.least(events[i + 1].createdAt.getTime());
       }
 
-      result.records.forEach(record => {
-        expect(record).to.have.property('id');
-        expect(record).to.have.property('createdAt');
-        expect(record).to.have.property('updatedAt');
-        expect(record).to.have.property('referenceDate');
-        expect(record).to.have.property('createdBy');
-        expect(record).to.have.property('count');
+      events.forEach(event => {
+        expect(event).to.have.property('id');
+        expect(event).to.have.property('createdAt');
+        expect(event).to.have.property('updatedAt');
+        expect(event).to.have.property('referenceDate');
+        expect(event).to.have.property('fines');
       });
     });
 
     it('should respect pagination take', async () => {
       const take = 2;
-      const result = await new DebtorService().getFineHandoutEvents({ take });
+      const [events] = await new DebtorService().getFineHandoutEvents({ take });
 
-      expect(result.records.length).to.be.at.most(take);
-      expect(result._pagination.take).to.equal(take);
+      expect(events.length).to.be.at.most(take);
     });
 
     it('should respect pagination skip', async () => {
       const take = 1;
       const skip = 1;
-      const all = await new DebtorService().getFineHandoutEvents();
-      const result = await new DebtorService().getFineHandoutEvents({ take, skip });
+      const [allEvents] = await new DebtorService().getFineHandoutEvents();
+      const [events] = await new DebtorService().getFineHandoutEvents({ take, skip });
 
-      expect(result.records.length).to.equal(Math.max(0, all.records.length - skip));
-      expect(result._pagination.skip).to.equal(skip);
+      expect(events.length).to.equal(Math.max(0, allEvents.length - skip));
     });
 
     it('should return correct count', async () => {
-      const result = await new DebtorService().getFineHandoutEvents();
+      const [, count] = await new DebtorService().getFineHandoutEvents();
       const totalCount = await FineHandoutEvent.count();
 
-      expect(result._pagination.count).to.equal(totalCount);
+      expect(count).to.equal(totalCount);
     });
   });
 
@@ -712,8 +709,8 @@ describe('DebtorService', (): void => {
     }
 
     async function checkCorrectNewBalance(fines: Fine[]) {
-      const balances = await new BalanceService().getBalances({});
-      balances.records.map((b) => {
+      const [balanceRecords] = await new BalanceService().getBalances({});
+      balanceRecords.map((b) => {
         const user = ctx.users.find((u) => u.id === b.id);
         expect(user).to.not.be.undefined;
         const fine = fines.find((f) => f.userFineGroup.userId === b.id);
@@ -725,7 +722,7 @@ describe('DebtorService', (): void => {
       });
     }
 
-    async function checkFine(f: Fine, date: Date, fineGroup: FineHandoutEventResponse) {
+    async function checkFine(f: Fine, date: Date, fineGroup: FineHandoutEvent) {
       const user = ctx.users.find((u) => u.id === f.userFineGroup.userId);
       expect(user).to.not.be.undefined;
       const b = calculateBalance(user, ctx.transactions, ctx.subTransactions, ctx.transfers, date);
@@ -758,7 +755,7 @@ describe('DebtorService', (): void => {
         referenceDate,
       }, ctx.actor);
       expect(fineHandoutEvent.fines.length).to.equal(usersToFine.length);
-      expect(fineHandoutEvent.referenceDate).to.equal(referenceDate.toISOString());
+      expect(fineHandoutEvent.referenceDate.toISOString()).to.equal(referenceDate.toISOString());
       expect(fineHandoutEvent.createdBy.id).to.equal(ctx.actor.id);
 
       const fines = await Promise.all(fineHandoutEvent.fines.map((f) => Fine
@@ -768,7 +765,7 @@ describe('DebtorService', (): void => {
         const preCalcedFine = usersToFine.find((u) => u.id === f.userFineGroup.userId);
         expect(preCalcedFine).to.not.be.undefined;
         expect(f.amount.getAmount()).to.equal(preCalcedFine.fineAmount.amount);
-        expect(new Date(fineHandoutEvent.referenceDate).getTime()).to.equal(referenceDate.getTime());
+        expect(fineHandoutEvent.referenceDate.getTime()).to.equal(referenceDate.getTime());
         await checkFine(f, referenceDate, fineHandoutEvent);
       }));
 
@@ -804,9 +801,9 @@ describe('DebtorService', (): void => {
 
       expect(fineHandoutEvent1.fines.length).to.equal(1);
       expect(fineHandoutEvent2.fines.length).to.equal(1);
-      expect(fineHandoutEvent1.fines[0].user.id).to.equal(user.id);
-      expect(fineHandoutEvent2.fines[0].user.id).to.equal(user.id);
-      expect(fineHandoutEvent1.fines[0].user.id).to.equal(fineHandoutEvent2.fines[0].user.id);
+      expect(fineHandoutEvent1.fines[0].userFineGroup.userId).to.equal(user.id);
+      expect(fineHandoutEvent2.fines[0].userFineGroup.userId).to.equal(user.id);
+      expect(fineHandoutEvent1.fines[0].userFineGroup.userId).to.equal(fineHandoutEvent2.fines[0].userFineGroup.userId);
       userFineGroups = await UserFineGroup.find({
         where: { userId: user.id },
         relations: ['fines'],
@@ -839,8 +836,8 @@ describe('DebtorService', (): void => {
       const fineHandoutEvent = await new DebtorService().handOutFines({ userIds: [user.id], referenceDate: new Date() }, ctx.actor);
       expect(fineHandoutEvent.fines.length).to.equal(1);
       const fine = fineHandoutEvent.fines[0];
-      expect(fine.user.id).to.equal(user.id);
-      expect(fine.amount.amount).to.equal(0);
+      expect(fine.userFineGroup.userId).to.equal(user.id);
+      expect(fine.amount.getAmount()).to.equal(0);
 
       dbUser = await User.findOne({ where: { id: user.id }, relations: ['currentFines'] });
       expect(calculateBalance(user, ctx.transactions, ctx.subTransactions, ctx.transfersInclFines).amount.getAmount())
@@ -876,7 +873,7 @@ describe('DebtorService', (): void => {
       await clearFines();
     });
 
-    async function makeFines(): Promise<FineHandoutEventResponse> {
+    async function makeFines(): Promise<FineHandoutEvent> {
       const referenceDate = new Date('2021-01-30');
       const debtorService = new DebtorService();
 
@@ -902,7 +899,7 @@ describe('DebtorService', (): void => {
       expect(report.toDate.toISOString()).to.equal(endDate.toISOString());
       expect(report.count).to.equal(fineHandoutEvent.fines.length);
 
-      const handedOut = fineHandoutEvent.fines.reduce((sum, u) => sum + u.amount.amount, 0);
+      const handedOut = fineHandoutEvent.fines.reduce((sum, u) => sum + u.amount.getAmount(), 0);
       expect(report.handedOut.getAmount()).to.equal(handedOut);
       expect(report.waivedAmount.getAmount()).to.equal(0);
     });
@@ -936,11 +933,11 @@ describe('DebtorService', (): void => {
     it( 'should return error if transfer has fine and waivedFine', async () => {
       const fineHandoutEvent = await makeFines();
       const debtorService = new DebtorService();
-      await debtorService.waiveFines(fineHandoutEvent.fines[0].user.id, ctx.waiveFinesParams);
+      await debtorService.waiveFines(fineHandoutEvent.fines[0].userFineGroup.userId, ctx.waiveFinesParams);
 
-      const transfer = await Transfer.findOne({ where: { waivedFines: { userId: fineHandoutEvent.fines[0].user.id } }, relations: ['fine', 'waivedFines'] });
+      const transfer = await Transfer.findOne({ where: { waivedFines: { userId: fineHandoutEvent.fines[0].userFineGroup.userId } }, relations: ['fine', 'waivedFines'] });
       transfer.fine = await Fine.create({
-        userFineGroup: await UserFineGroup.findOne({ where: { userId: fineHandoutEvent.fines[0].user.id } }),
+        userFineGroup: await UserFineGroup.findOne({ where: { userId: fineHandoutEvent.fines[0].userFineGroup.userId } }),
         fineHandoutEvent: await FineHandoutEvent.findOne({ where: { id: fineHandoutEvent.id } }),
         amount: dinero({ amount: 100 }),
         transfer: transfer,
@@ -961,7 +958,7 @@ describe('DebtorService', (): void => {
       const tillDate = new Date();
       tillDate.setTime(tillDate.getTime() + 1000);
 
-      await new DebtorService().waiveFines(fineHandoutEvent.fines[0].user.id, ctx.waiveFinesParams);
+      await new DebtorService().waiveFines(fineHandoutEvent.fines[0].userFineGroup.userId, ctx.waiveFinesParams);
       const report = await new DebtorService().getFineReport(date, tillDate);
 
       expect(report.fromDate.toISOString()).to.equal(date.toISOString());
@@ -969,7 +966,7 @@ describe('DebtorService', (): void => {
       expect(report.count).to.equal(fineHandoutEvent.fines.length);
       expect(report.waivedCount).to.equal(1);
 
-      const handedOut = fineHandoutEvent.fines.reduce((sum, u) => sum + u.amount.amount, 0);
+      const handedOut = fineHandoutEvent.fines.reduce((sum, u) => sum + u.amount.getAmount(), 0);
       expect(report.handedOut.getAmount()).to.equal(handedOut);
       expect(report.waivedAmount.getAmount()).to.equal(ctx.waiveFinesParams.amount.amount);
     });

--- a/test/unit/service/event-service.ts
+++ b/test/unit/service/event-service.ts
@@ -27,7 +27,6 @@ import EventShiftAnswer, { Availability } from '../../../src/entity/event/event-
 import Database from '../../../src/database/database';
 import EventService, { CreateEventParams } from '../../../src/service/event-service';
 import { expect } from 'chai';
-import { BaseEventResponse, BaseEventShiftResponse } from '../../../src/controller/response/event-response';
 import AssignedRole from '../../../src/entity/rbac/assigned-role';
 import sinon, { SinonSandbox, SinonSpy } from 'sinon';
 import Mailer from '../../../src/mailer';
@@ -70,21 +69,21 @@ describe('eventService', () => {
     };
   });
 
-  const checkEvent = (actual: BaseEventResponse, expected: Event) => {
+  const checkEvent = (actual: Event, expected: Event) => {
     expect(actual.id).to.equal(expected.id);
-    expect(actual.createdAt).to.equal(expected.createdAt.toISOString());
-    expect(actual.updatedAt).to.equal(expected.updatedAt.toISOString());
-    expect(actual.startDate).to.equal(expected.startDate.toISOString());
-    expect(actual.endDate).to.equal(expected.endDate.toISOString());
+    expect(actual.createdAt.toISOString()).to.equal(expected.createdAt.toISOString());
+    expect(actual.updatedAt.toISOString()).to.equal(expected.updatedAt.toISOString());
+    expect(actual.startDate.toISOString()).to.equal(expected.startDate.toISOString());
+    expect(actual.endDate.toISOString()).to.equal(expected.endDate.toISOString());
     expect(actual.name).to.equal(expected.name);
     expect(actual.type).to.equal(expected.type);
     expect(actual.createdBy.id).to.equal(expected.createdBy.id);
   };
 
-  const checkEventShift = (actual: BaseEventShiftResponse, expected: EventShift) => {
+  const checkEventShift = (actual: EventShift, expected: EventShift) => {
     expect(actual.id).to.equal(expected.id);
-    expect(actual.createdAt).to.equal(expected.createdAt.toISOString());
-    expect(actual.updatedAt).to.equal(expected.updatedAt.toISOString());
+    expect(actual.createdAt.toISOString()).to.equal(expected.createdAt.toISOString());
+    expect(actual.updatedAt.toISOString()).to.equal(expected.updatedAt.toISOString());
     expect(actual.name).to.equal(expected.name);
   };
 
@@ -94,7 +93,7 @@ describe('eventService', () => {
 
   describe('getEvents', () => {
     it('should return all events ordered by startDate descending', async () => {
-      const { records: events } = await EventService.getEvents();
+      const [events] = await EventService.getEvents();
       expect(events.length).be.greaterThan(0);
       expect(events.length).to.equal(ctx.events.length);
 
@@ -104,12 +103,12 @@ describe('eventService', () => {
         checkEvent(e, dbEvent);
       });
 
-      const dates = events.map((e) =>  new Date(e.startDate).getTime());
+      const dates = events.map((e) => e.startDate.getTime());
       expect(dates, 'Expected startDate to be sorted in descending order').to.be.descending;
     });
     it('should filter on id', async () => {
       const id = ctx.events[0].id;
-      const { records: events } = await EventService.getEvents({ id });
+      const [events] = await EventService.getEvents({ id });
 
       expect(events.length).to.equal(1);
       expect(events[0].id).to.equal(id);
@@ -117,7 +116,7 @@ describe('eventService', () => {
     it('should filter on exact name', async () => {
       const name = ctx.events[0].name;
       const actualEvents = ctx.events.filter((e) => e.name === name);
-      const { records: events } = await EventService.getEvents({ name });
+      const [events] = await EventService.getEvents({ name });
 
       expect(actualEvents.length).to.equal(events.length);
       events.forEach((e) => {
@@ -127,7 +126,7 @@ describe('eventService', () => {
     it('should filter on like name', async () => {
       const name = ctx.events[0].name.substring(0, 6);
       const actualEvents = ctx.events.filter((e) => e.name.substring(0, 6) === name);
-      const { records: events } = await EventService.getEvents({ name });
+      const [events] = await EventService.getEvents({ name });
 
       expect(actualEvents.length).to.equal(events.length);
       events.forEach((e) => {
@@ -136,7 +135,7 @@ describe('eventService', () => {
     });
     it('should filter on created by ID', async () => {
       const createdById = ctx.events[0].createdBy.id;
-      const { records: events } = await EventService.getEvents({ createdById });
+      const [events] = await EventService.getEvents({ createdById });
 
       expect(events.length).to.equal(1);
       expect(events[0].createdBy.id).to.equal(createdById);
@@ -144,44 +143,44 @@ describe('eventService', () => {
     it('should filter on date (before)', async () => {
       const beforeDate = ctx.events[0].startDate;
       const actualEvents = ctx.events.filter((e) => e.startDate.getTime() <= beforeDate.getTime());
-      const { records: events } = await EventService.getEvents({ beforeDate });
+      const [events] = await EventService.getEvents({ beforeDate });
 
       expect(actualEvents.length).to.equal(events.length);
       const ids = actualEvents.map((e) => e.id);
       events.forEach((e) => {
         expect(ids).to.include(e.id);
-        expect(new Date(e.startDate)).to.be.lessThanOrEqual(beforeDate);
+        expect(e.startDate).to.be.lessThanOrEqual(beforeDate);
       });
     });
     it('should filter on date (after)', async () => {
       const afterDate = ctx.events[0].startDate;
       const actualEvents = ctx.events.filter((e) => e.startDate.getTime() >= afterDate.getTime());
-      const { records: events } = await EventService.getEvents({ afterDate });
+      const [events] = await EventService.getEvents({ afterDate });
 
       expect(actualEvents.length).to.equal(events.length);
       const ids = actualEvents.map((e) => e.id);
       events.forEach((e) => {
         expect(ids).to.include(e.id);
-        expect(new Date(e.startDate)).to.be.greaterThanOrEqual(afterDate);
+        expect(e.startDate).to.be.greaterThanOrEqual(afterDate);
       });
     });
     it('should filter based on date range', async () => {
       const afterDate = ctx.events[0].startDate;
       const beforeDate = ctx.events[1].startDate;
       const actualEvents = ctx.events.filter((e) => e.startDate.getTime() >= afterDate.getTime() && e.startDate.getTime() <= beforeDate.getTime());
-      const { records: events } = await EventService.getEvents({ beforeDate, afterDate });
+      const [events] = await EventService.getEvents({ beforeDate, afterDate });
 
       expect(actualEvents.length).to.equal(events.length);
       const ids = actualEvents.map((e) => e.id);
       events.forEach((e) => {
         expect(ids).to.include(e.id);
-        expect(new Date(e.startDate)).to.be.greaterThanOrEqual(afterDate);
+        expect(e.startDate).to.be.greaterThanOrEqual(afterDate);
       });
     });
     it('should filter on createdById', async () => {
       const createdById = ctx.events[0].createdBy.id;
       const actualEvents = ctx.events.filter((e) => e.createdBy.id === createdById);
-      const { records: events } = await EventService.getEvents({ createdById });
+      const [events] = await EventService.getEvents({ createdById });
 
       expect(events.length).to.equal(actualEvents.length);
       const ids = actualEvents.map((e) => e.id);
@@ -193,17 +192,15 @@ describe('eventService', () => {
     it('should adhere to pagination', async () => {
       const take = 3;
       const skip = 1;
-      const events = await EventService.getEvents({}, { take, skip });
-      expect(events.records.length).to.equal(take);
-      expect(events._pagination.take).to.equal(take);
-      expect(events._pagination.skip).to.equal(skip);
-      expect(events._pagination.count).to.equal(ctx.events.length);
+      const [events, count] = await EventService.getEvents({}, { take, skip });
+      expect(events.length).to.equal(take);
+      expect(count).to.equal(ctx.events.length);
 
       const ids = ctx.events
         .sort((a, b) => b.startDate.getTime() - a.startDate.getTime())
         .slice(skip, skip + take)
         .map((e) => e.id);
-      events.records.forEach((event, i) => {
+      events.forEach((event, i) => {
         expect(event.id).to.equal(ids[i]);
       });
     });
@@ -347,9 +344,9 @@ describe('eventService', () => {
       expect(roleWithUsers.length).to.equal(1);
       expect(await EventShiftAnswer.findOne({ where: { eventId: event.id, shiftId: answer.shiftId, userId: answer.userId } })).to.not.be.null;
 
-      const eventResponse1 = await EventService.getSingleEvent(event.id);
+      const eventEntity1 = await EventService.getSingleEvent(event.id);
       const answers1 = await EventService.syncEventShiftAnswers(event);
-      expect(eventResponse1.shifts.reduce((t, e) => t + e.answers.length, 0)).to.equal(answers1.length);
+      expect(eventEntity1.answers.length).to.equal(answers1.length);
 
       await AssignedRole.delete({ userId: roleWithUser.userId, roleId: roleWithUser.roleId });
 
@@ -427,8 +424,8 @@ describe('eventService', () => {
       expect(event).to.not.be.undefined;
       expect(event.name).to.equal(params.name);
       expect(event.createdBy.id).to.equal(params.createdById);
-      expect(event.startDate).to.equal(params.startDate.toISOString());
-      expect(event.endDate).to.equal(params.endDate.toISOString());
+      expect(event.startDate.toISOString()).to.equal(params.startDate.toISOString());
+      expect(event.endDate.toISOString()).to.equal(params.endDate.toISOString());
       expect(event.shifts.length).to.equal(params.shiftIds.length);
 
       const users = ctx.roles
@@ -436,7 +433,7 @@ describe('eventService', () => {
         .map((r) => r.user);
       const userIds = users.map((u) => u.id);
       const actualUserIds = Array.from(new Set(
-        event.shifts.map((s) => s.answers.map((a) => a.user.id)).flat(),
+        event.answers.map((a) => a.user.id),
       ));
       expect(actualUserIds.length).to.be.greaterThan(0);
       expect(actualUserIds).to.deep.equalInAnyOrder(userIds);
@@ -510,7 +507,7 @@ describe('eventService', () => {
       const event = await EventService.updateEvent(originalEvent.id, {
         startDate: startDate,
       });
-      expect(event.startDate).to.equal(startDate.toISOString());
+      expect(event.startDate.toISOString()).to.equal(startDate.toISOString());
       expect((await Event.findOne({ where: { id: originalEvent.id } })).startDate.getTime()).to.equal(startDate.getTime());
     });
     it('should correctly update endDate', async () => {
@@ -518,7 +515,7 @@ describe('eventService', () => {
       const event = await EventService.updateEvent(originalEvent.id, {
         endDate: endDate,
       });
-      expect(event.endDate).to.equal(endDate.toISOString());
+      expect(event.endDate.toISOString()).to.equal(endDate.toISOString());
       expect((await Event.findOne({ where: { id: originalEvent.id } })).endDate.getTime()).to.equal(endDate.getTime());
     });
     it('should correctly update shiftIds by adding a shift', async () => {
@@ -540,7 +537,8 @@ describe('eventService', () => {
       // Answer sheets should include new shift
       expect(event.shifts.map((s) => s.id)).to.deep.equalInAnyOrder(shiftIds);
       event.shifts.forEach((s) => {
-        expect(s.answers.length).to.be.greaterThan(0);
+        const shiftAnswers = event.answers.filter((a) => a.shiftId === s.id);
+        expect(shiftAnswers.length).to.be.greaterThan(0);
       });
 
     });
@@ -580,8 +578,7 @@ describe('eventService', () => {
 
   describe('getShifts', () => {
     it('should return all shifts', async () => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { records: shifts, _pagination } = await EventService.getEventShifts({});
+      const [shifts, count] = await EventService.getEventShifts({});
       expect(shifts.length).to.equal(ctx.eventShifts.filter((s) => s.deletedAt == null).length);
 
       shifts.forEach((s) => {
@@ -590,8 +587,7 @@ describe('eventService', () => {
         checkEventShift(s, actualShift);
       });
 
-      expect(_pagination.count).to.equal(shifts.length);
-      expect(_pagination.take).to.be.undefined;
+      expect(count).to.equal(shifts.length);
     });
   });
 

--- a/test/unit/service/inactive-administrative-cost-service.ts
+++ b/test/unit/service/inactive-administrative-cost-service.ts
@@ -268,8 +268,8 @@ describe('InactiveAdministrativeCostService', () => {
       await new InactiveAdministrativeCostService().deleteInactiveAdministrativeCost(lastId + 1);
     });
     it('should restore the user\'s balance when an inactive administrative cost is deleted', async () => {
-      const balances = await new BalanceService().getBalances({});
-      const user = balances.records.find(x => x.amount.amount > 100);
+      const [balanceRecords] = await new BalanceService().getBalances({});
+      const user = balanceRecords.find(x => x.amount.amount > 100);
 
       const before = (await new BalanceService().getBalance(user.id)).amount.amount;
 
@@ -476,14 +476,11 @@ describe('InactiveAdministrativeCostService', () => {
   });
   describe('getPaginatedInactiveAdministrativeCosts', async (): Promise<void> => {
     it('should paginate inactive administrative costs correctly', async () => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { records, _pagination } = await new InactiveAdministrativeCostService()
+      const [costs, count] = await new InactiveAdministrativeCostService()
         .getPaginatedInactiveAdministrativeCosts({}, { take: 2, skip: 1 });
 
-      expect(records).to.have.lengthOf.at.most(2);
-      expect(_pagination).to.include.keys(['count', 'take', 'skip']);
-      expect(_pagination.take).to.equal(2);
-      expect(_pagination.skip).to.equal(1);
+      expect(costs).to.have.lengthOf.at.most(2);
+      expect(count).to.be.a('number');
     });
 
   });

--- a/test/unit/service/invoice-service.ts
+++ b/test/unit/service/invoice-service.ts
@@ -34,7 +34,6 @@ import {
 } from '../../../src/controller/response/invoice-response';
 import InvoiceService from '../../../src/service/invoice-service';
 import { CreateInvoiceParams, UpdateInvoiceParams } from '../../../src/controller/request/invoice-request';
-import { TransferResponse } from '../../../src/controller/response/transfer-response';
 import TransactionService from '../../../src/service/transaction-service';
 import { BaseTransactionResponse, TransactionResponse } from '../../../src/controller/response/transaction-response';
 import BalanceService from '../../../src/service/balance-service';
@@ -191,20 +190,18 @@ describe('InvoiceService', () => {
   describe('createTransfer function', () => {
     it('should return a correct Transfer', async () => {
       const toId = (await User.findOne({ where: {} })).id;
-      const transactions: BaseTransactionResponse[] = (
-        await new TransactionService().getTransactions({ fromId: toId })
-      ).records;
+      const [transactions]: [BaseTransactionResponse[], number] = await new TransactionService().getTransactions({ fromId: toId });
       let value = 0;
       transactions.forEach((t) => {
         value += t.value.amount;
       });
 
       expect(transactions).to.not.be.empty;
-      const transfer: TransferResponse = (
+      const transfer: Transfer = (
         await new InvoiceService().createTransfer(toId,
           await AppDataSource.manager.find(Transaction, { where: { id: In(transactions.map((t) => t.id)) } }),
           { amount: value, currency: 'EUR', precision: 2 }));
-      expect(transfer.amountInclVat.amount).to.be.equal(value);
+      expect(transfer.amountInclVat.getAmount()).to.be.equal(value);
       expect(transfer.to.id).to.be.equal(toId);
     });
   });
@@ -845,7 +842,7 @@ describe('InvoiceService', () => {
       expect(invoices.length).to.equal(0);
     });
 
-    it('should return all relations needed for BaseInvoiceResponse', async () => {
+    it('should return all relations needed for BaseInvoiceResponse conversion', async () => {
       await inUserContext((await UserFactory()).clone(2), async (debtor: User, creditor: User) => {
         const invoice = await createInvoiceWithTransfers(debtor.id, creditor.id, 1);
 
@@ -860,13 +857,19 @@ describe('InvoiceService', () => {
         expect(invoices).to.be.an('array');
         expect(invoices.length).to.equal(1);
 
-        // Verify all required fields for BaseInvoiceResponse are present
+        // Verify all required relations are loaded on the Invoice entity
         const returnedInvoice = invoices[0];
         expect(returnedInvoice.id).to.be.a('number');
         expect(returnedInvoice.to).to.not.be.undefined;
         expect(returnedInvoice.to.id).to.equal(debtor.id);
-        expect(returnedInvoice.currentState).to.not.be.undefined;
+        expect(returnedInvoice.invoiceStatus).to.not.be.undefined;
+        expect(returnedInvoice.invoiceStatus.length).to.be.greaterThan(0);
         expect(returnedInvoice.transfer).to.not.be.undefined;
+
+        // Verify the entity can be successfully converted to BaseInvoiceResponse
+        const response = InvoiceService.asBaseInvoiceResponse(returnedInvoice);
+        expect(response.currentState).to.not.be.undefined;
+        expect(response.to.id).to.equal(debtor.id);
       });
     });
   });

--- a/test/unit/service/payout-request-service.ts
+++ b/test/unit/service/payout-request-service.ts
@@ -81,8 +81,7 @@ describe('PayoutRequestService', () => {
 
   describe('getPayoutRequests', () => {
     it('should return all payout requests', async () => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { _pagination, records } = await PayoutRequestService.getPayoutRequests({});
+      const [records, count] = await PayoutRequestService.getPayoutRequests({});
 
       expect(records.length).to.equal(ctx.payoutRequests.length);
 
@@ -91,14 +90,12 @@ describe('PayoutRequestService', () => {
         expect(ids).to.include(req.id);
       });
 
-      expect(_pagination.skip).to.be.undefined;
-      expect(_pagination.take).to.be.undefined;
-      expect(_pagination.count).to.equal(ctx.payoutRequests.length);
+      expect(count).to.equal(ctx.payoutRequests.length);
     });
 
     it('should return payout request with specific ID', async () => {
       const { id } = ctx.payoutRequests[0];
-      const { records } = await PayoutRequestService.getPayoutRequests({ id });
+      const [records] = await PayoutRequestService.getPayoutRequests({ id });
 
       expect(records.length).to.equal(1);
       expect(records[0].id).to.equal(id);
@@ -110,7 +107,7 @@ describe('PayoutRequestService', () => {
         .filter((req) => req.requestedBy.id === requestedById);
       const ids = actualPayoutRequests.map((req) => req.id);
 
-      const { records } = await PayoutRequestService.getPayoutRequests({ requestedById });
+      const [records] = await PayoutRequestService.getPayoutRequests({ requestedById });
 
       expect(records.length).to.equal(actualPayoutRequests.length);
       records.forEach((req) => {
@@ -125,7 +122,7 @@ describe('PayoutRequestService', () => {
         .filter((req) => req.approvedBy !== undefined && req.approvedBy.id === approvedById);
       const ids = actualPayoutRequests.map((req) => req.id);
 
-      const { records } = await PayoutRequestService.getPayoutRequests({ approvedById });
+      const [records] = await PayoutRequestService.getPayoutRequests({ approvedById });
 
       expect(records.length).to.equal(actualPayoutRequests.length);
       records.forEach((req) => {
@@ -143,12 +140,15 @@ describe('PayoutRequestService', () => {
         });
       const ids = actualPayoutRequests.map((req) => req.id);
 
-      const { records } = await PayoutRequestService.getPayoutRequests({ status });
+      const [records] = await PayoutRequestService.getPayoutRequests({ status });
 
       expect(records.length).to.equal(actualPayoutRequests.length);
       records.forEach((req) => {
         expect(ids).to.include(req.id);
-        expect(status).to.include(req.status);
+        // Get the latest status from the entity's payoutRequestStatus
+        const latestStatus = req.payoutRequestStatus
+          .sort((a, b) => (a.createdAt.getTime() < b.createdAt.getTime() ? 1 : -1))[0].state;
+        expect(status).to.include(latestStatus);
       });
     };
 
@@ -203,9 +203,8 @@ describe('PayoutRequestService', () => {
         .equal(ctx.validPayoutRequestRequest.bankAccountNumber);
       expect(payoutRequest.bankAccountName).to
         .equal(ctx.validPayoutRequestRequest.bankAccountName);
-      expect(payoutRequest.statuses.length).to.equal(1);
-      expect(payoutRequest.statuses[0].state).to.equal(PayoutRequestState.CREATED);
-      expect(payoutRequest.status).to.equal(PayoutRequestState.CREATED);
+      expect(payoutRequest.payoutRequestStatus.length).to.equal(1);
+      expect(payoutRequest.payoutRequestStatus[0].state).to.equal(PayoutRequestState.CREATED);
       expect(payoutRequest.requestedBy.id).to.equal(user.id);
     });
   });
@@ -304,10 +303,9 @@ describe('PayoutRequestService', () => {
 
       const payoutRequest = await PayoutRequestService
         .updateStatus(id, PayoutRequestState.CREATED, user);
-      expect(payoutRequest.statuses.length).to.equal(1);
-      expect(payoutRequest.statuses[0].state).to.equal(PayoutRequestState.CREATED);
-      expect(payoutRequest.status).to.equal(PayoutRequestState.CREATED);
-      expect(payoutRequest.approvedBy).to.be.undefined;
+      expect(payoutRequest.payoutRequestStatus.length).to.equal(1);
+      expect(payoutRequest.payoutRequestStatus[0].state).to.equal(PayoutRequestState.CREATED);
+      expect(payoutRequest.approvedBy).to.be.null;
     });
 
     it('should correctly update status to CANCELLED', async () => {
@@ -316,10 +314,9 @@ describe('PayoutRequestService', () => {
 
       const payoutRequest = await PayoutRequestService
         .updateStatus(id, PayoutRequestState.CANCELLED, user);
-      expect(payoutRequest.statuses.length).to.equal(2);
-      expect(payoutRequest.statuses[1].state).to.equal(PayoutRequestState.CANCELLED);
-      expect(payoutRequest.status).to.equal(PayoutRequestState.CANCELLED);
-      expect(payoutRequest.approvedBy).to.be.undefined;
+      expect(payoutRequest.payoutRequestStatus.length).to.equal(2);
+      expect(payoutRequest.payoutRequestStatus[1].state).to.equal(PayoutRequestState.CANCELLED);
+      expect(payoutRequest.approvedBy).to.be.null;
     });
 
     it('should correctly update status to DENIED', async () => {
@@ -328,10 +325,9 @@ describe('PayoutRequestService', () => {
 
       const payoutRequest = await PayoutRequestService
         .updateStatus(id, PayoutRequestState.DENIED, user);
-      expect(payoutRequest.statuses.length).to.equal(2);
-      expect(payoutRequest.statuses[1].state).to.equal(PayoutRequestState.DENIED);
-      expect(payoutRequest.status).to.equal(PayoutRequestState.DENIED);
-      expect(payoutRequest.approvedBy).to.be.undefined;
+      expect(payoutRequest.payoutRequestStatus.length).to.equal(2);
+      expect(payoutRequest.payoutRequestStatus[1].state).to.equal(PayoutRequestState.DENIED);
+      expect(payoutRequest.approvedBy).to.be.null;
     });
 
     it('should correctly update status to APPROVED', async () => {
@@ -340,9 +336,8 @@ describe('PayoutRequestService', () => {
 
       const payoutRequest = await PayoutRequestService
         .updateStatus(id, PayoutRequestState.APPROVED, user);
-      expect(payoutRequest.statuses.length).to.equal(2);
-      expect(payoutRequest.statuses[1].state).to.equal(PayoutRequestState.APPROVED);
-      expect(payoutRequest.status).to.equal(PayoutRequestState.APPROVED);
+      expect(payoutRequest.payoutRequestStatus.length).to.equal(2);
+      expect(payoutRequest.payoutRequestStatus[1].state).to.equal(PayoutRequestState.APPROVED);
       expect(payoutRequest.approvedBy).to.not.be.undefined;
       expect(payoutRequest.approvedBy.id).to.equal(user.id);
 

--- a/test/unit/service/point-of-sale-service.ts
+++ b/test/unit/service/point-of-sale-service.ts
@@ -29,7 +29,6 @@ import PointOfSale from '../../../src/entity/point-of-sale/point-of-sale';
 import Database from '../../../src/database/database';
 import Swagger from '../../../src/start/swagger';
 import {
-  PaginatedPointOfSaleResponse,
   PointOfSaleResponse,
   PointOfSaleWithContainersResponse,
 } from '../../../src/controller/response/point-of-sale-response';
@@ -157,9 +156,8 @@ describe('PointOfSaleService', async (): Promise<void> => {
 
   describe('getPointsOfSale function', () => {
     it('should return all point of sales with no input specification', async () => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { records, _pagination } = (await PointOfSaleService
-        .getPointsOfSale()) as PaginatedPointOfSaleResponse;
+      const [revisions, count] = await PointOfSaleService.getPointsOfSale();
+      const records = revisions.map((r) => PointOfSaleService.revisionToResponse(r));
 
       const withRevisions = ctx.pointsOfSale.filter((c) => c.currentRevision > 0);
       expect(records).to.be.length(withRevisions.length);
@@ -168,14 +166,13 @@ describe('PointOfSaleService', async (): Promise<void> => {
         (c: PointOfSaleResponse) => ctx.specification.validateModel('PointOfSaleResponse', c, false, true).valid,
       )).to.be.true;
 
-      expect(_pagination.take).to.be.undefined;
-      expect(_pagination.skip).to.be.undefined;
-      expect(_pagination.count).to.equal(withRevisions.length);
+      expect(count).to.equal(withRevisions.length);
     });
     it('should return points of sale with ownerId specified', async () => {
-      const { records } = (await PointOfSaleService.getPointsOfSale({
+      const [revisions] = await PointOfSaleService.getPointsOfSale({
         ownerId: ctx.pointsOfSale[0].owner.id,
-      }) as PaginatedPointOfSaleResponse);
+      });
+      const records = revisions.map((r) => PointOfSaleService.revisionToResponse(r));
 
       const withRevisions = ctx.pointsOfSale.filter((c) => c.currentRevision > 0);
       expect(pointOfSaleSuperset(records, ctx.pointsOfSale)).to.be.true;
@@ -188,34 +185,31 @@ describe('PointOfSaleService', async (): Promise<void> => {
       expect(records).to.be.length(length);
     });
     it('should return single point of sale if pointOfSaleId is specified', async () => {
-      const { records } = (await PointOfSaleService.getPointsOfSale({
+      const [revisions] = await PointOfSaleService.getPointsOfSale({
         pointOfSaleId: ctx.pointsOfSale[0].id,
-      }) as PaginatedPointOfSaleResponse);
+      });
 
-      expect(records).to.be.length(1);
-      expect(records[0].id).to.be.equal(ctx.pointsOfSale[0].id);
+      expect(revisions).to.be.length(1);
+      expect(revisions[0].pointOfSaleId).to.be.equal(ctx.pointsOfSale[0].id);
     });
     it('should return no points of sale if userId and containerId do not match', async () => {
-      const { records } = (await PointOfSaleService.getPointsOfSale({
+      const [revisions] = await PointOfSaleService.getPointsOfSale({
         ownerId: ctx.pointsOfSale[10].owner.id,
         pointOfSaleId: ctx.pointsOfSale[0].id,
-      }) as PaginatedPointOfSaleResponse);
+      });
 
-      expect(records).to.be.length(0);
+      expect(revisions).to.be.length(0);
     });
     it('should adhere to pagination', async () => {
       const take = 3;
       const skip = 2;
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { records, _pagination } = (await PointOfSaleService.getPointsOfSale({}, {
+      const [revisions, count] = await PointOfSaleService.getPointsOfSale({}, {
         take, skip,
-      }) as PaginatedPointOfSaleResponse);
+      });
 
       const withRevisions = ctx.pointsOfSale.filter((c) => c.currentRevision > 0);
-      expect(_pagination.take).to.equal(take);
-      expect(_pagination.skip).to.equal(skip);
-      expect(_pagination.count).to.equal(withRevisions.length);
-      expect(records.length).to.be.at.most(take);
+      expect(count).to.equal(withRevisions.length);
+      expect(revisions.length).to.be.at.most(take);
     });
     it('should return all points of sale involving a single user and its memberAuthenticator users', async () => {
       const usersOwningAPos = [...new Set(ctx.pointsOfSale.map((pos) => pos.owner))];
@@ -227,19 +221,19 @@ describe('PointOfSaleService', async (): Promise<void> => {
       });
       expect(memberAuthenticators.length).to.equal(0);
 
-      let pointsOfSale = await PointOfSaleService.getPointsOfSale({}, {}, owner);
-      const originalLength = pointsOfSale.records.length;
-      pointsOfSale.records.forEach((pos) => {
-        expect(pos.owner.id).to.equal(owner.id);
+      let [revisions] = await PointOfSaleService.getPointsOfSale({}, {}, owner);
+      const originalLength = revisions.length;
+      revisions.forEach((rev) => {
+        expect(rev.pointOfSale.owner.id).to.equal(owner.id);
       });
 
       await new AuthenticationService().setMemberAuthenticator([owner], usersOwningAPos[1]);
 
       const ownerIds = [owner, usersOwningAPos[1]].map((o) => o.id);
-      pointsOfSale = await PointOfSaleService.getPointsOfSale({}, {}, owner);
-      expect(pointsOfSale.records.length).to.be.greaterThan(originalLength);
-      pointsOfSale.records.forEach((pos) => {
-        expect(ownerIds).to.include(pos.owner.id);
+      [revisions] = await PointOfSaleService.getPointsOfSale({}, {}, owner);
+      expect(revisions.length).to.be.greaterThan(originalLength);
+      revisions.forEach((rev) => {
+        expect(ownerIds).to.include(rev.pointOfSale.owner.id);
       });
 
       // Cleanup
@@ -249,8 +243,8 @@ describe('PointOfSaleService', async (): Promise<void> => {
   describe('createPointOfSale function', () => {
     it('should create a new PointOfSale', async () => {
       const count = await PointOfSale.count();
-      const res = (
-        await PointOfSaleService.createPointOfSale(ctx.validPOSParams));
+      const revision = await PointOfSaleService.createPointOfSale(ctx.validPOSParams);
+      const res = PointOfSaleService.revisionToResponse(revision) as PointOfSaleWithContainersResponse;
 
       expect(await PointOfSale.count()).to.equal(count + 1);
 
@@ -260,7 +254,7 @@ describe('PointOfSaleService', async (): Promise<void> => {
 
       expect(updatedPointOfSale.name).to.equal(ctx.validPOSParams.name);
 
-      requestUpdatedResponseEqual(ctx.validPOSParams, res as PointOfSaleWithContainersResponse);
+      requestUpdatedResponseEqual(ctx.validPOSParams, res);
     });
   });
   describe('directPointOfSaleUpdate function', () => {
@@ -274,7 +268,8 @@ describe('PointOfSaleService', async (): Promise<void> => {
         cashierRoleIds: [ctx.roles[1].role.id],
       };
 
-      const response = (await PointOfSaleService.updatePointOfSale(update)) as PointOfSaleWithContainersResponse;
+      const revision = await PointOfSaleService.updatePointOfSale(update);
+      const response = PointOfSaleService.revisionToResponse(revision) as PointOfSaleWithContainersResponse;
       updateResponseEqual(update, response);
     });
   });

--- a/test/unit/service/product-category-service.ts
+++ b/test/unit/service/product-category-service.ts
@@ -25,7 +25,6 @@ import { expect } from 'chai';
 import Database from '../../../src/database/database';
 import Swagger from '../../../src/start/swagger';
 import ProductCategory from '../../../src/entity/product/product-category';
-import { ProductCategoryResponse } from '../../../src/controller/response/product-category-response';
 import ProductCategoryService from '../../../src/service/product-category-service';
 import ProductCategoryRequest from '../../../src/controller/request/product-category-request';
 import { truncateAllTables } from '../../setup';
@@ -33,25 +32,25 @@ import { finishTestDB } from '../../helpers/test-helpers';
 import { ProductCategorySeeder } from '../../seed';
 
 /**
- * Test if the set of productCategory responses is equal to the full set of productCategories.
- * @param response
+ * Test if the set of productCategories is equal to the full set of productCategories.
+ * @param result
  * @param equalset
  */
 function productCategoryEqualset(
-  response: ProductCategoryResponse[],
+  result: ProductCategory[],
   equalset: ProductCategory[],
 ): Boolean {
-  const responseIsSuperSet = response.every((pc1: ProductCategoryResponse) => (
+  const resultIsSuperSet = result.every((pc1: ProductCategory) => (
     equalset.some((pc2: ProductCategory) => (
       pc2.id === pc1.id && pc2.name === pc1.name
     ))
   ));
   const equalsetIsSuperSet = equalset.every((pc1: ProductCategory) => (
-    response.some((pc2: ProductCategoryResponse) => (
+    result.some((pc2: ProductCategory) => (
       pc2.id === pc1.id && pc2.name === pc1.name
     ))
   ));
-  return (responseIsSuperSet && equalsetIsSuperSet);
+  return (resultIsSuperSet && equalsetIsSuperSet);
 }
 
 describe('ProductCategoryService', async (): Promise<void> => {
@@ -85,12 +84,13 @@ describe('ProductCategoryService', async (): Promise<void> => {
 
   describe('getProductCategories function', async (): Promise<void> => {
     it('should return all productCategories', async () => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { records, _pagination } = await ProductCategoryService.getProductCategories();
+      const [categories, count] = await ProductCategoryService.getProductCategories();
 
-      expect(productCategoryEqualset(records, ctx.categories)).to.be.true;
-      expect(records.every(
-        (c: ProductCategoryResponse) => ctx.specification.validateModel(
+      expect(productCategoryEqualset(categories, ctx.categories)).to.be.true;
+
+      const responses = categories.map(ProductCategoryService.asProductCategoryResponse);
+      expect(responses.every(
+        (c) => ctx.specification.validateModel(
           'ProductCategoryResponse',
           c,
           false,
@@ -98,59 +98,57 @@ describe('ProductCategoryService', async (): Promise<void> => {
         ).valid,
       )).to.be.true;
 
-      expect(_pagination.take).to.be.undefined;
-      expect(_pagination.skip).to.be.undefined;
-      expect(_pagination.count).to.equal(ctx.categories.length);
+      expect(count).to.equal(ctx.categories.length);
     });
     it('should return a single productCategory if id is specified', async () => {
-      const { records } = await ProductCategoryService
+      const [categories] = await ProductCategoryService
         .getProductCategories({ id: ctx.categories[0].id });
 
-      expect(records.length).to.equal(1);
-      expect(records[0].id).to.equal(ctx.categories[0].id);
-      expect(records[0].name).to.equal(ctx.categories[0].name);
+      expect(categories.length).to.equal(1);
+      expect(categories[0].id).to.equal(ctx.categories[0].id);
+      expect(categories[0].name).to.equal(ctx.categories[0].name);
     });
     it('should return nothing if a wrong id is specified', async () => {
-      const { records } = await ProductCategoryService
+      const [categories] = await ProductCategoryService
         .getProductCategories({ id: ctx.categories.length + 1 });
 
-      expect(records).to.be.empty;
+      expect(categories).to.be.empty;
     });
     it('should return a single productCategory if name is specified', async () => {
-      const { records } = await ProductCategoryService
+      const [categories] = await ProductCategoryService
         .getProductCategories({ name: ctx.categories[0].name });
 
-      expect(records.length).to.equal(1);
-      expect(records[0].id).to.equal(ctx.categories[0].id);
-      expect(records[0].name).to.equal(ctx.categories[0].name);
+      expect(categories.length).to.equal(1);
+      expect(categories[0].id).to.equal(ctx.categories[0].id);
+      expect(categories[0].name).to.equal(ctx.categories[0].name);
     });
     it('should return nothing if a wrong name is specified', async () => {
-      const { records } = await ProductCategoryService
+      const [categories] = await ProductCategoryService
         .getProductCategories({ name: 'non-existing' });
 
-      expect(records).to.be.empty;
+      expect(categories).to.be.empty;
     });
     it('should return only root categories', async () => {
       const rootCategories = ctx.categories.filter((c) => c.parent == null);
-      const { records } = await ProductCategoryService
+      const [categories] = await ProductCategoryService
         .getProductCategories({ onlyRoot: true });
 
-      expect(records.length).to.equal(rootCategories.length);
-      expect(records.map((r) => r.id)).to.deep.equalInAnyOrder(rootCategories.map((c) => c.id));
-      records.forEach((c) => {
-        expect(c.parent).to.be.undefined;
+      expect(categories.length).to.equal(rootCategories.length);
+      expect(categories.map((r) => r.id)).to.deep.equalInAnyOrder(rootCategories.map((c) => c.id));
+      categories.forEach((c) => {
+        expect(c.parent).to.satisfy((p: any) => p == null);
       });
     });
     it('should return only leaf categories', async () => {
       // Find all categories that are not a parent, i.e. have no children
       const leafCategories = ctx.categories.filter((c) => !ctx.categories
         .some((c2) => c2.parent?.id === c.id));
-      const { records } = await ProductCategoryService
+      const [categories] = await ProductCategoryService
         .getProductCategories({ onlyLeaf: true });
 
-      expect(records.length).to.equal(leafCategories.length);
-      expect(records.map((r) => r.id)).to.deep.equalInAnyOrder(leafCategories.map((c) => c.id));
-      records.forEach((c) => {
+      expect(categories.length).to.equal(leafCategories.length);
+      expect(categories.map((r) => r.id)).to.deep.equalInAnyOrder(leafCategories.map((c) => c.id));
+      categories.forEach((c) => {
         const children = ctx.categories.filter((c2) => c2.parent?.id === c.id);
         expect(children).to.be.lengthOf(0);
       });
@@ -158,14 +156,11 @@ describe('ProductCategoryService', async (): Promise<void> => {
     it('should adhere to pagination', async () => {
       const take = 5;
       const skip = 3;
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { records, _pagination } = await ProductCategoryService
+      const [categories, count] = await ProductCategoryService
         .getProductCategories({}, { take, skip });
 
-      expect(_pagination.take).to.equal(take);
-      expect(_pagination.skip).to.equal(skip);
-      expect(_pagination.count).to.equal(ctx.categories.length);
-      expect(records.length).to.be.at.most(take);
+      expect(count).to.equal(ctx.categories.length);
+      expect(categories.length).to.be.at.most(take);
     });
   });
   describe('postProductCategory function', () => {
@@ -175,11 +170,11 @@ describe('ProductCategoryService', async (): Promise<void> => {
       expect(c2).to.not.be.null;
       expect(c2.name).to.equal(c1.name);
 
-      const { records } = await ProductCategoryService
+      const [categories] = await ProductCategoryService
         .getProductCategories({ id: c2.id });
 
-      expect(records.length).to.equal(1);
-      expect(records[0].name).to.equal(c1.name);
+      expect(categories.length).to.equal(1);
+      expect(categories[0].name).to.equal(c1.name);
 
       // Cleanup
       await ctx.connection.manager.getRepository(ProductCategory).delete(c2.id);
@@ -194,13 +189,13 @@ describe('ProductCategoryService', async (): Promise<void> => {
       expect(c2.parent.id).to.equal(parent.id);
       expect(c2.parent.name).to.equal(parent.name);
 
-      const { records } = await ProductCategoryService
+      const [categories] = await ProductCategoryService
         .getProductCategories({ id: c2.id });
 
-      expect(records.length).to.equal(1);
-      expect(records[0].name).to.equal(c1.name);
-      expect(records[0].parent).to.not.be.undefined;
-      expect(records[0].parent.id).to.equal(parent.id);
+      expect(categories.length).to.equal(1);
+      expect(categories[0].name).to.equal(c1.name);
+      expect(categories[0].parent).to.not.be.undefined;
+      expect(categories[0].parent.id).to.equal(parent.id);
 
       // Cleanup
       await ctx.connection.manager.getRepository(ProductCategory).delete(c2.id);
@@ -210,32 +205,32 @@ describe('ProductCategoryService', async (): Promise<void> => {
       const promise = ProductCategoryService.postProductCategory(c1);
       await expect(promise).to.eventually.be.rejected;
 
-      const { records } = await ProductCategoryService
+      const [categories] = await ProductCategoryService
         .getProductCategories();
-      expect(records).to.be.lengthOf(ctx.categories.length);
+      expect(categories).to.be.lengthOf(ctx.categories.length);
     });
   });
   describe('patchProductCategory function', async (): Promise<void> => {
     it('should be able to patch a productCategory', async () => {
       const category = ctx.categories[0];
       const c1: ProductCategoryRequest = { name: 'test' };
-      const c2: ProductCategoryResponse = await ProductCategoryService
+      const c2: ProductCategory = await ProductCategoryService
         .patchProductCategory(category.id, c1);
       expect(c2).to.not.be.null;
       expect(c2.name).to.equal(c1.name);
 
-      const { records } = await ProductCategoryService
+      const [categories] = await ProductCategoryService
         .getProductCategories({ id: category.id });
 
-      expect(records).to.not.be.null;
-      expect(records[0].name).to.equal(c1.name);
+      expect(categories).to.not.be.null;
+      expect(categories[0].name).to.equal(c1.name);
 
       // Cleanup
       await ctx.connection.manager.save(ProductCategory, category);
     });
     it('should not be able to patch an invalid productCategory id', async () => {
       const c1: ProductCategoryRequest = { name: 'test' };
-      const c2: ProductCategoryResponse = await ProductCategoryService
+      const c2: ProductCategory = await ProductCategoryService
         .patchProductCategory(ctx.categories.length + 1, c1);
       expect(c2).to.be.null;
     });
@@ -243,7 +238,7 @@ describe('ProductCategoryService', async (): Promise<void> => {
   describe('deleteProductCategory function', async (): Promise<void> => {
     it('should be able to delete a productCategory', async () => {
       const category = ctx.categories.find((c) => c.parent != null);
-      const res: ProductCategoryResponse = await ProductCategoryService
+      const res: ProductCategory = await ProductCategoryService
         .deleteProductCategory(category.id);
 
       expect(res).to.not.be.null;
@@ -255,13 +250,13 @@ describe('ProductCategoryService', async (): Promise<void> => {
     });
     it('should not be able to delete a productCategory with children', async () => {
       const category = ctx.categories.find((c) => c.parent == null);
-      const res: ProductCategoryResponse = await ProductCategoryService
+      const res: ProductCategory = await ProductCategoryService
         .deleteProductCategory(category.id);
 
       expect(res).to.be.null;
     });
     it('should not be able to delete an invalid productCategory id', async () => {
-      const res: ProductCategoryResponse = await ProductCategoryService
+      const res: ProductCategory = await ProductCategoryService
         .deleteProductCategory(ctx.categories.length + 1);
 
       expect(res).to.be.null;

--- a/test/unit/service/product-service.ts
+++ b/test/unit/service/product-service.ts
@@ -48,7 +48,6 @@ import AuthenticationService from '../../../src/service/authentication-service';
 import { truncateAllTables } from '../../setup';
 import { finishTestDB } from '../../helpers/test-helpers';
 import sinon from 'sinon';
-import { ContainerWithProductsResponse } from '../../../src/controller/response/container-response';
 import { ContainerSeeder, PointOfSaleSeeder, ProductSeeder, UserSeeder } from '../../seed';
 
 chai.use(deepEqualInAnyOrder);
@@ -192,8 +191,8 @@ describe('ProductService', async (): Promise<void> => {
 
   describe('getProducts function', () => {
     it('should return all products with no input specification', async () => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { records, _pagination } = await ProductService.getProducts({ returnContainers: true });
+      const [revisions, count] = await ProductService.getProducts({ returnContainers: true });
+      const records = revisions.map((r) => ProductService.revisionToResponse(r));
 
       const products = ctx.products.filter((prod) => prod.currentRevision !== null);
 
@@ -213,14 +212,13 @@ describe('ProductService', async (): Promise<void> => {
         }
       }
 
-      expect(_pagination.take).to.be.undefined;
-      expect(_pagination.skip).to.be.undefined;
-      expect(_pagination.count).to.equal(products.length);
+      expect(count).to.equal(products.length);
     });
     it('should return product with the ownerId specified', async () => {
       const owner = ctx.products[0].owner.id;
       const params: ProductFilterParameters = { ownerId: ctx.products[0].owner.id };
-      const { records } = await ProductService.getProducts(params);
+      const [revisions] = await ProductService.getProducts(params);
+      const records = revisions.map((r) => ProductService.revisionToResponse(r));
 
       const products = ctx.products.filter((prod) => (
         prod.currentRevision !== null && prod.owner.id === owner));
@@ -233,7 +231,8 @@ describe('ProductService', async (): Promise<void> => {
       expect(productRevision).to.be.greaterThan(0);
 
       const params: ProductFilterParameters = { productId, productRevision };
-      const { records } = await ProductService.getProducts(params);
+      const [revisions] = await ProductService.getProducts(params);
+      const records = revisions.map((r) => ProductService.revisionToResponse(r));
 
       const product: ProductWithRevision[] = [productRevisionToProductWithRevision(
         ctx.productRevisions.find((prod) => (
@@ -244,7 +243,8 @@ describe('ProductService', async (): Promise<void> => {
     });
     it('should return a single product if productId is specified', async () => {
       const params: ProductFilterParameters = { productId: ctx.products[0].id };
-      const { records } = await ProductService.getProducts(params);
+      const [revisions] = await ProductService.getProducts(params);
+      const records = revisions.map((r) => ProductService.revisionToResponse(r));
 
       returnsAll(records, [ctx.products[0]]);
     });
@@ -253,15 +253,16 @@ describe('ProductService', async (): Promise<void> => {
         ownerId: ctx.products[0].owner.id + 1,
         productId: ctx.products[0].id,
       };
-      const { records } = await ProductService.getProducts(params);
+      const [revisions] = await ProductService.getProducts(params);
 
-      expect(records).to.be.empty;
+      expect(revisions).to.be.empty;
     });
     it('should return the products belonging to a VAT group', async () => {
       const params: ProductFilterParameters = {
         vatGroupId: 1,
       };
-      const { records } = await ProductService.getProducts(params);
+      const [revisions] = await ProductService.getProducts(params);
+      const records = revisions.map((r) => ProductService.revisionToResponse(r));
 
       const products = ctx.productRevisions
         .filter((rev) => rev.vat.id === params.vatGroupId)
@@ -273,14 +274,11 @@ describe('ProductService', async (): Promise<void> => {
       const take = 5;
       const skip = 3;
 
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { records, _pagination } = await ProductService
+      const [revisions, count] = await ProductService
         .getProducts({  }, { take, skip });
 
-      expect(_pagination.take).to.equal(take);
-      expect(_pagination.skip).to.equal(skip);
-      expect(_pagination.count).to.equal(ctx.products.length);
-      expect(records.length).to.be.at.most(take);
+      expect(count).to.equal(ctx.products.length);
+      expect(revisions.length).to.be.at.most(take);
     });
     it('should return all products involving a single user and its memberAuthenticator users', async () => {
       const usersOwningAProd = [...new Set(ctx.products.map((prod) => prod.owner))];
@@ -292,18 +290,20 @@ describe('ProductService', async (): Promise<void> => {
       });
       expect(memberAuthenticators.length).to.equal(0);
 
-      let products = await ProductService.getProducts({}, {}, owner);
-      const originalLength = products.records.length;
-      products.records.forEach((prod) => {
+      let [revisions] = await ProductService.getProducts({}, {}, owner);
+      let records = revisions.map((r) => ProductService.revisionToResponse(r));
+      const originalLength = records.length;
+      records.forEach((prod) => {
         expect(prod.owner.id).to.equal(owner.id);
       });
 
       await new AuthenticationService().setMemberAuthenticator([owner], usersOwningAProd[1]);
 
       const ownerIds = [owner, usersOwningAProd[1]].map((o) => o.id);
-      products = await ProductService.getProducts({}, {}, owner);
-      expect(products.records.length).to.be.greaterThan(originalLength);
-      products.records.forEach((prod) => {
+      [revisions] = await ProductService.getProducts({}, {}, owner);
+      records = revisions.map((r) => ProductService.revisionToResponse(r));
+      expect(records.length).to.be.greaterThan(originalLength);
+      records.forEach((prod) => {
         expect(ownerIds).to.include(prod.owner.id);
       });
 
@@ -314,7 +314,8 @@ describe('ProductService', async (): Promise<void> => {
       const params: ProductFilterParameters = {
         featured: true,
       };
-      const { records } = await ProductService.getProducts(params);
+      const [revisions] = await ProductService.getProducts(params);
+      const records = revisions.map((r) => ProductService.revisionToResponse(r));
 
       const products = ctx.productRevisions
         .filter((rev) => {
@@ -328,7 +329,8 @@ describe('ProductService', async (): Promise<void> => {
       const params: ProductFilterParameters = {
         preferred: true,
       };
-      const { records } = await ProductService.getProducts(params);
+      const [revisions] = await ProductService.getProducts(params);
+      const records = revisions.map((r) => ProductService.revisionToResponse(r));
 
       const products = ctx.productRevisions
         .filter((rev) => {
@@ -342,7 +344,8 @@ describe('ProductService', async (): Promise<void> => {
       const params: ProductFilterParameters = {
         priceList: true,
       };
-      const { records } = await ProductService.getProducts(params);
+      const [revisions] = await ProductService.getProducts(params);
+      const records = revisions.map((r) => ProductService.revisionToResponse(r));
 
       const products = ctx.productRevisions
         .filter((rev) => {
@@ -372,7 +375,8 @@ describe('ProductService', async (): Promise<void> => {
         },
       };
 
-      const response = await ProductService.createProduct(creation);
+      const revision = await ProductService.createProduct(creation);
+      const response = ProductService.revisionToResponse(revision);
       validateProductProperties(response, creation);
       const entity = await Product.findOne({ where: { id: response.id } });
       expect(entity.currentRevision).to.eq(1);
@@ -406,14 +410,16 @@ describe('ProductService', async (): Promise<void> => {
           currency: 'EUR',
         },
       };
-      let response = await ProductService.updateProduct(update);
+      let revision = await ProductService.updateProduct(update);
+      let response = ProductService.revisionToResponse(revision);
       validateProductProperties(response, update);
 
       const update2: UpdateProductParams = {
         ...update,
         alcoholPercentage: 20,
       };
-      response = await ProductService.updateProduct(update2);
+      revision = await ProductService.updateProduct(update2);
+      response = ProductService.revisionToResponse(revision);
       validateProductProperties(response, update2);
 
       // Cleanup
@@ -441,7 +447,8 @@ describe('ProductService', async (): Promise<void> => {
         },
       };
 
-      const product = await ProductService.createProduct(createProduct);
+      const productRevision = await ProductService.createProduct(createProduct);
+      const product = ProductService.revisionToResponse(productRevision);
 
       const createContainer: CreateContainerParams = {
         name: 'Container Name',
@@ -450,7 +457,7 @@ describe('ProductService', async (): Promise<void> => {
         public: true,
       };
 
-      const container = await ContainerService.createContainer(createContainer);
+      const containerRev = await ContainerService.createContainer(createContainer);
 
       const update: UpdateProductParams = {
         id: product.id,
@@ -468,13 +475,14 @@ describe('ProductService', async (): Promise<void> => {
         },
       };
 
-      const updatedProduct = await ProductService.updateProduct(update);
+      const updatedRevision = await ProductService.updateProduct(update);
+      const updatedProduct = ProductService.revisionToResponse(updatedRevision);
       validateProductProperties(updatedProduct, update);
 
-      const containerEntity = await Container.findOne({ where: { id: container.id } });
+      const containerEntity = await Container.findOne({ where: { id: containerRev.containerId } });
       expect(containerEntity.currentRevision).to.be.eq(2);
 
-      const productInContainer = (await ContainerRevision.findOne({ where: { revision: 2, container: { id: container.id } }, relations: ['container', 'products', 'products.category'] })).products[0];
+      const productInContainer = (await ContainerRevision.findOne({ where: { revision: 2, container: { id: containerRev.containerId } }, relations: ['container', 'products', 'products.category'] })).products[0];
       expect(productInContainer.name).to.eq(update.name);
       expect(typeof productInContainer.alcoholPercentage === 'string'
         ? parseInt(productInContainer.alcoholPercentage, 10)
@@ -483,8 +491,8 @@ describe('ProductService', async (): Promise<void> => {
       expect(productInContainer.category.id).to.eq(update.category);
 
       // Cleanup
-      await ContainerRevision.delete({ containerId: container.id });
-      await Container.delete({ id: container.id });
+      await ContainerRevision.delete({ containerId: containerRev.containerId });
+      await Container.delete({ id: containerRev.containerId });
       await ProductRevision.delete({ productId: product.id });
       await Product.delete({ id: product.id });
     });
@@ -506,7 +514,8 @@ describe('ProductService', async (): Promise<void> => {
         },
       };
 
-      const product = await ProductService.createProduct(createProduct);
+      const productRevision = await ProductService.createProduct(createProduct);
+      const product = ProductService.revisionToResponse(productRevision);
 
       const createContainer: CreateContainerParams = {
         name: 'Container Name',
@@ -515,10 +524,10 @@ describe('ProductService', async (): Promise<void> => {
         public: true,
       };
 
-      const container = await ContainerService.createContainer(createContainer);
+      const containerRev = await ContainerService.createContainer(createContainer);
 
       const createPOS: CreatePointOfSaleParams = {
-        containers: [container.id],
+        containers: [containerRev.containerId],
         name: 'POS Name',
         useAuthentication: true,
         ownerId,
@@ -543,7 +552,7 @@ describe('ProductService', async (): Promise<void> => {
       };
 
       await ProductService.updateProduct(productUpdate);
-      const productFromPos = (await PointOfSaleRevision.findOne({ where: { revision: 2, pointOfSale: { id: pos.id } }, relations: ['pointOfSale', 'containers', 'containers.products', 'containers.products.category'] })).containers[0].products[0];
+      const productFromPos = (await PointOfSaleRevision.findOne({ where: { revision: 2, pointOfSale: { id: pos.pointOfSaleId } }, relations: ['pointOfSale', 'containers', 'containers.products', 'containers.products.category'] })).containers[0].products[0];
 
       expect(productFromPos.name).to.eq(productUpdate.name);
       expect(productFromPos.category.id).to.eq(productUpdate.category);
@@ -551,10 +560,10 @@ describe('ProductService', async (): Promise<void> => {
       expect(productFromPos.priceInclVat.getAmount()).to.eq(productUpdate.priceInclVat.amount);
 
       // Cleanup
-      await PointOfSaleRevision.delete({ pointOfSaleId: pos.id });
-      await PointOfSale.delete({ id: pos.id });
-      await ContainerRevision.delete({ containerId: container.id });
-      await Container.delete({ id: container.id });
+      await PointOfSaleRevision.delete({ pointOfSaleId: pos.pointOfSaleId });
+      await PointOfSale.delete({ id: pos.pointOfSaleId });
+      await ContainerRevision.delete({ containerId: containerRev.containerId });
+      await Container.delete({ id: containerRev.containerId });
       await ProductRevision.delete({ productId: product.id });
       await Product.delete({ id: product.id });
     });
@@ -562,9 +571,9 @@ describe('ProductService', async (): Promise<void> => {
 
   describe('deleteProduct function', () => {
     it('should soft delete product and propagate to containers', async () => {
-      const stub = sinon.stub(ContainerService, 'updateContainer').callsFake(async (params): Promise<ContainerWithProductsResponse> => {
-        const container = await ContainerService.getContainers({ containerId: params.id, returnProducts: true });
-        return container.records[0] as ContainerWithProductsResponse;
+      const stub = sinon.stub(ContainerService, 'updateContainer').callsFake(async (params): Promise<ContainerRevision> => {
+        const [revisions] = await ContainerService.getContainers({ containerId: params.id, returnProducts: true });
+        return revisions[0];
       });
 
       const start = Math.floor(new Date().getTime() / 1000) * 1000;

--- a/test/unit/service/rbac-service.ts
+++ b/test/unit/service/rbac-service.ts
@@ -279,23 +279,27 @@ describe('RBACService', () => {
       const assignments = ctx.assignments.filter((asg) => asg.roleId == roleId);
       const userIds = assignments.map((asg) => asg.userId);
 
-      const users = await UserService.getUsers({ id: userIds });
+      const [expectedUsers] = await UserService.getUsers({ id: userIds });
 
-      const userResult = await RBACService.getRoleUsers(roleId);
-      expect(userResult.records).to.deep.equal(users.records);
+      const [users, count] = await RBACService.getRoleUsers(roleId);
+      expect(users.map((u) => u.id)).to.deep.equal(expectedUsers.map((u) => u.id));
+      expect(count).to.equal(assignments.length);
     });
 
     it('should adhere to pagination', async () => {
       const roleId = ctx.roles[0].role.id;
+      const totalAssignments = ctx.assignments.filter((asg) => asg.roleId == roleId).length;
 
       let take = 2;
-      let userResponse = await RBACService.getRoleUsers(roleId, { take });
-      expect(userResponse.records.length).to.be.equal(take);
+      let [users, count] = await RBACService.getRoleUsers(roleId, { take });
+      expect(users.length).to.be.equal(take);
+      expect(count).to.equal(totalAssignments);
 
-      const skip = ctx.assignments.filter((asg) => asg.roleId == roleId).length - 1;
+      const skip = totalAssignments - 1;
       take = 2;
-      userResponse = await RBACService.getRoleUsers(roleId, { skip, take });
-      expect(userResponse.records.length).to.be.equal(1);
+      [users, count] = await RBACService.getRoleUsers(roleId, { skip, take });
+      expect(users.length).to.be.equal(1);
+      expect(count).to.equal(totalAssignments);
     });
   });
 

--- a/test/unit/service/report-service.ts
+++ b/test/unit/service/report-service.ts
@@ -150,7 +150,8 @@ describe('ReportService', () => {
           tillDate: new Date(2050, 0, 0),
           forId: creditor.id,
         };
-        const t = await new TransactionService().getSingleTransaction(transaction.tId);
+        const transactionService = new TransactionService();
+        const t = await transactionService.asTransactionResponse(await transactionService.getSingleTransaction(transaction.tId));
 
         const report = await new SalesReportService().getReport(parameters);
         expect(report.totalInclVat.getAmount()).to.eq(t.totalPriceInclVat.amount);
@@ -365,7 +366,8 @@ describe('ReportService', () => {
           tillDate: new Date(2050, 0, 0),
           forId: debtor.id,
         };
-        const t = await new TransactionService().getSingleTransaction(transaction.tId);
+        const transactionService = new TransactionService();
+        const t = await transactionService.asTransactionResponse(await transactionService.getSingleTransaction(transaction.tId));
 
         const report = await new BuyerReportService().getReport(parameters);
         expect(report.totalInclVat.getAmount()).to.eq(t.totalPriceInclVat.amount);

--- a/test/unit/service/stripe-service.ts
+++ b/test/unit/service/stripe-service.ts
@@ -88,7 +88,7 @@ describe('StripeService', async (): Promise<void> => {
       expect(depositsFromUser.length).to.equal(deposits.length);
       deposits.forEach((d) => {
         expect(d.to.id).to.equal(user.id);
-        const states = d.depositStatus
+        const states = d.stripePaymentIntent.paymentIntentStatuses
           .map((s) => s.state);
         expect(states[states.length - 1]).to.equal(StripePaymentIntentState.PROCESSING);
       });
@@ -99,20 +99,21 @@ describe('StripeService', async (): Promise<void> => {
     it('should correctly create a payment intent', async () => {
       const countBefore = await StripeDeposit.count();
 
-      const intent = await ctx.stripeService.createStripePaymentIntent(
+      const { deposit, clientSecret } = await ctx.stripeService.createStripePaymentIntent(
         ctx.users[0], ctx.dineroTransformer.from(1500),
       );
 
-      expect(intent).to.not.be.undefined;
+      expect(deposit).to.not.be.undefined;
+      expect(clientSecret).to.be.a('string');
 
       const countAfter = await StripeDeposit.count();
-      const stripeDeposit = await StripeService.getStripeDeposit(intent.id);
+      const stripeDeposit = await StripeService.getStripeDeposit(deposit.id);
 
       expect(stripeDeposit).to.not.be.undefined;
-      expect(stripeDeposit.id).to.equal(intent.id);
+      expect(stripeDeposit.id).to.equal(deposit.id);
       expect(countAfter).to.equal(countBefore + 1);
 
-      expect(intent.stripeId).to.equal(stripeDeposit.stripePaymentIntent.stripeId);
+      expect(deposit.stripePaymentIntent.stripeId).to.equal(stripeDeposit.stripePaymentIntent.stripeId);
       expect(stripeDeposit.stripePaymentIntent.paymentIntentStatuses.length).to.equal(0);
     });
   });

--- a/test/unit/service/transaction-service.ts
+++ b/test/unit/service/transaction-service.ts
@@ -531,32 +531,28 @@ describe('TransactionService', (): void => {
 
   describe('Get all transactions', () => {
     it('should return all transactions', async () => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { records, _pagination } = await new TransactionService().getTransactions({});
+      const [records, count] = await new TransactionService().getTransactions({});
 
       expect(records.length).to.equal(ctx.transactions.length);
       records.map((t) => verifyBaseTransactionEntity(ctx.spec, t));
 
-      expect(_pagination.take).to.be.undefined;
-      expect(_pagination.skip).to.be.undefined;
-      expect(_pagination.count).to.equal(ctx.transactions.length);
+      expect(count).to.equal(ctx.transactions.length);
     });
 
     it('should return a paginated list when take is set', async () => {
       const take = 69;
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { records, _pagination } = await new TransactionService().getTransactions({}, { take });
+      const [records, count] = await new TransactionService().getTransactions({}, { take });
 
       const total = await Transaction.count();
 
       expect(records.length).to.equal(take);
-      expect(_pagination.count).to.equal(total);
+      expect(count).to.equal(total);
     });
 
     it('should not return a paginated list when skip is set', async () => {
       const skip = 69;
       const take = 999999999999;
-      const { records } = await new TransactionService().getTransactions({}, { take, skip });
+      const [records] = await new TransactionService().getTransactions({}, { take, skip });
 
       expect(records.length).to.equal(ctx.transactions.length - 69);
     });
@@ -564,12 +560,11 @@ describe('TransactionService', (): void => {
     it('should return a paginated list when take and skip are set', async () => {
       const skip = 120;
       const take = 50;
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { records, _pagination } = await new TransactionService().getTransactions({}, { take, skip });
+      const [records, count] = await new TransactionService().getTransactions({}, { take, skip });
 
       const total = await Transaction.count();
 
-      expect(_pagination.count).to.equal(total);
+      expect(count).to.equal(total);
       expect(records.length).to.equal(
         Math.min(take, ctx.transactions.length - skip),
       );
@@ -577,7 +572,7 @@ describe('TransactionService', (): void => {
 
     it('should filter on fromId', async () => {
       const fromId = 1;
-      const { records } = await new TransactionService().getTransactions({
+      const [records] = await new TransactionService().getTransactions({
         fromId,
       });
 
@@ -592,7 +587,7 @@ describe('TransactionService', (): void => {
 
     it('should filter on createdById', async () => {
       const createdById = 1;
-      const { records } = await new TransactionService().getTransactions({
+      const [records] = await new TransactionService().getTransactions({
         createdById,
       });
 
@@ -607,7 +602,7 @@ describe('TransactionService', (): void => {
 
     it('should filter on toId', async () => {
       const toId = 7;
-      const { records } = await new TransactionService().getTransactions({
+      const [records] = await new TransactionService().getTransactions({
         toId,
       });
       const transactionIds = ctx.transactions.map((t) => {
@@ -628,7 +623,7 @@ describe('TransactionService', (): void => {
 
     it('should filter on point of sale', async () => {
       const pointOfSale = { id: 14 };
-      const { records } = await new TransactionService().getTransactions({
+      const [records] = await new TransactionService().getTransactions({
         pointOfSaleId: pointOfSale.id,
       });
 
@@ -642,7 +637,7 @@ describe('TransactionService', (): void => {
 
     it('should filter on point of sale with revision', async () => {
       const pointOfSale = { id: 14, revision: 2 };
-      const { records } = await new TransactionService().getTransactions({
+      const [records] = await new TransactionService().getTransactions({
         pointOfSaleId: pointOfSale.id,
         pointOfSaleRevision: pointOfSale.revision,
       });
@@ -658,7 +653,7 @@ describe('TransactionService', (): void => {
 
     it('should filter on container', async () => {
       const container = { id: 11 };
-      const { records } = await new TransactionService().getTransactions({
+      const [records] = await new TransactionService().getTransactions({
         containerId: container.id,
       });
 
@@ -673,7 +668,7 @@ describe('TransactionService', (): void => {
 
     it('should filter on container with revision', async () => {
       const container = { id: 11, revision: 2 };
-      const { records } = await new TransactionService().getTransactions({
+      const [records] = await new TransactionService().getTransactions({
         containerId: container.id,
         containerRevision: container.revision,
       });
@@ -690,7 +685,7 @@ describe('TransactionService', (): void => {
 
     it('should filter on product', async () => {
       const product = { id: 44 };
-      const { records } = await new TransactionService().getTransactions({
+      const [records] = await new TransactionService().getTransactions({
         productId: product.id,
       });
 
@@ -706,7 +701,7 @@ describe('TransactionService', (): void => {
 
     it('should filter on product with revision', async () => {
       const product = { id: 44, revision: 2 };
-      const { records } = await new TransactionService().getTransactions({
+      const [records] = await new TransactionService().getTransactions({
         productId: product.id,
         productRevision: product.revision,
       });
@@ -724,7 +719,7 @@ describe('TransactionService', (): void => {
 
     it('should return transactions newer than date', async () => {
       let fromDate = new Date(ctx.transactions[0].createdAt.getTime() - 1000 * 60 * 60 * 24);
-      let { records } = await new TransactionService().getTransactions({
+      let [records] = await new TransactionService().getTransactions({
         fromDate,
       });
 
@@ -741,16 +736,16 @@ describe('TransactionService', (): void => {
       });
 
       fromDate = new Date(ctx.transactions[0].createdAt.getTime() + 1000 * 60 * 60 * 24);
-      records = (await new TransactionService().getTransactions({
+      [records] = await new TransactionService().getTransactions({
         fromDate,
-      })).records;
+      });
 
       expect(records.length).to.equal(0);
     });
 
     it('should return transactions older than date', async () => {
       let tillDate = new Date(ctx.transactions[0].createdAt.getTime() + 1000 * 60 * 60 * 24);
-      let { records } = await new TransactionService().getTransactions({
+      let [records] = await new TransactionService().getTransactions({
         tillDate,
       });
 
@@ -767,9 +762,9 @@ describe('TransactionService', (): void => {
       });
 
       tillDate = new Date(ctx.transactions[0].createdAt.getTime() - 1000 * 60 * 60 * 24);
-      records = (await new TransactionService().getTransactions({
+      [records] = await new TransactionService().getTransactions({
         tillDate,
-      })).records;
+      });
 
       expect(records.length).to.equal(0);
     });
@@ -777,7 +772,7 @@ describe('TransactionService', (): void => {
     it('should not return transactions createdBy given user', async () => {
       const transaction = ctx.transactions[0];
 
-      const records = (await new TransactionService().getTransactions({ excludeById: transaction.createdBy.id })).records;
+      const [records] = await new TransactionService().getTransactions({ excludeById: transaction.createdBy.id });
       records.forEach((r) => {
         expect(r.createdBy).to.not.eq(transaction.createdBy.id);
       });
@@ -787,7 +782,7 @@ describe('TransactionService', (): void => {
   describe('Get all transactions involving a user', () => {
     it('should return a paginated list', async () => {
       const user = ctx.users[0];
-      const { records } = await new TransactionService().getTransactions({}, {}, user);
+      const [records] = await new TransactionService().getTransactions({}, {}, user);
 
       const actualTransactions = await AppDataSource.createQueryBuilder(Transaction, 'transaction')
         .leftJoinAndSelect('transaction.from', 'from')
@@ -808,7 +803,7 @@ describe('TransactionService', (): void => {
   });
 
   describe('Create a transaction', () => {
-    it('should return a transaction response corresponding to the saved transaction', async () => {
+    it('should return a transaction entity corresponding to the saved transaction', async () => {
       // check response without prices
       const transactionService = new TransactionService();
       const verification = await transactionService.verifyTransaction(ctx.validTransReq);
@@ -816,8 +811,11 @@ describe('TransactionService', (): void => {
         throw new Error('Invalid transaction in test');
       }
       const savedTransaction = await transactionService.createTransaction(ctx.validTransReq, verification.context);
-      const correctResponse = await new TransactionService().getSingleTransaction(savedTransaction.id);
-      expect(savedTransaction, 'request not saved correctly').to.eql(correctResponse);
+      const fetchedTransaction = await new TransactionService().getSingleTransaction(savedTransaction.id);
+      expect(savedTransaction.id, 'request not saved correctly').to.equal(fetchedTransaction.id);
+
+      // Convert to response to check prices
+      const correctResponse = await new TransactionService().asTransactionResponse(fetchedTransaction);
 
       // check transaction response prices
       expect(correctResponse.totalPriceInclVat, 'top level price incorrect').to.eql(ctx.validTransReq.totalPriceInclVat);
@@ -852,7 +850,7 @@ describe('TransactionService', (): void => {
   });
 
   describe('Delete a transaction', () => {
-    it('should return a transaction response corresponding to the deleted transaction', async () => {
+    it('should return a transaction entity corresponding to the deleted transaction', async () => {
       const transactionService = new TransactionService();
       const verification = await transactionService.verifyTransaction(ctx.validTransReq);
       if (!verification.valid || !verification.context) {
@@ -860,7 +858,7 @@ describe('TransactionService', (): void => {
       }
       const savedTransaction = await transactionService.createTransaction(ctx.validTransReq, verification.context);
       const deletedTransaction = await new TransactionService().deleteTransaction(savedTransaction.id);
-      expect(deletedTransaction, 'return value incorrect').to.eql(savedTransaction);
+      expect(deletedTransaction.id, 'return value incorrect').to.equal(savedTransaction.id);
 
       // check deletion of transaction
       expect(await Transaction.findOne({ where: { id: deletedTransaction.id } }), 'transaction not deleted').to.be.null;
@@ -875,19 +873,22 @@ describe('TransactionService', (): void => {
         }));
       }));
 
+      // Convert to response to check prices
+      const deletedResponse = await new TransactionService().asTransactionResponse(deletedTransaction);
+
       // check transaction response prices
-      expect(deletedTransaction.totalPriceInclVat, 'top level price incorrect').to.eql(ctx.validTransReq.totalPriceInclVat);
+      expect(deletedResponse.totalPriceInclVat, 'top level price incorrect').to.eql(ctx.validTransReq.totalPriceInclVat);
 
       // check sub transaction response prices
-      for (let i = 0; i < deletedTransaction.subTransactions.length; i += 1) {
-        expect(deletedTransaction.subTransactions[i].totalPriceInclVat, 'sub transaction price incorrect')
+      for (let i = 0; i < deletedResponse.subTransactions.length; i += 1) {
+        expect(deletedResponse.subTransactions[i].totalPriceInclVat, 'sub transaction price incorrect')
           .to.eql(ctx.validTransReq.subTransactions[i].totalPriceInclVat);
 
         // check sub transaction row response prices
         for (let j = 0;
-          j < deletedTransaction.subTransactions[i].subTransactionRows.length;
+          j < deletedResponse.subTransactions[i].subTransactionRows.length;
           j += 1) {
-          expect(deletedTransaction.subTransactions[i].subTransactionRows[j].totalPriceInclVat, 'sub transaction row price incorrect')
+          expect(deletedResponse.subTransactions[i].subTransactionRows[j].totalPriceInclVat, 'sub transaction row price incorrect')
             .to.eql(ctx.validTransReq.subTransactions[i].subTransactionRows[j].totalPriceInclVat);
         }
       }
@@ -895,7 +896,7 @@ describe('TransactionService', (): void => {
   });
 
   describe('Update a transaction', () => {
-    it('should return a transaction response corresponding to the updated transaction', async () => {
+    it('should return a transaction entity corresponding to the updated transaction', async () => {
       // create a transaction
       const transactionService = new TransactionService();
       const verification = await transactionService.verifyTransaction(ctx.validTransReq);
@@ -916,14 +917,11 @@ describe('TransactionService', (): void => {
       );
 
       // check if currently saved transaction is updated
-      expect(savedTransaction, 'transaction not updated').to.not.eql(await new TransactionService().getSingleTransaction(
-        savedTransaction.id,
-      ));
-      expect(updatedTransaction, 'transaction updated incorrectly').to.eql(await new TransactionService().getSingleTransaction(
-        savedTransaction.id,
-      ));
+      const currentTransaction = await new TransactionService().getSingleTransaction(savedTransaction.id);
+      expect(savedTransaction.id, 'transaction not updated').to.equal(currentTransaction.id);
+      expect(updatedTransaction.id, 'transaction updated incorrectly').to.equal(currentTransaction.id);
 
-      // check deletion of sub transactions
+      // check deletion of sub transactions (old ones from saved)
       await Promise.all(savedTransaction.subTransactions.map(async (sub) => {
         expect(await SubTransaction.findOne({ where: { id: sub.id } }), 'sub transaction not deleted').to.be.null;
 
@@ -933,16 +931,19 @@ describe('TransactionService', (): void => {
         }));
       }));
 
+      // Convert to response to check prices
+      const updatedResponse = await new TransactionService().asTransactionResponse(updatedTransaction);
+
       // check transaction response prices
-      expect(updatedTransaction.totalPriceInclVat, 'top level price incorrect').to.eql(updateReq.totalPriceInclVat);
+      expect(updatedResponse.totalPriceInclVat, 'top level price incorrect').to.eql(updateReq.totalPriceInclVat);
 
       // check sub transaction response prices
-      for (let i = 0; i < updatedTransaction.subTransactions.length; i += 1) {
-        expect(updatedTransaction.subTransactions[i].totalPriceInclVat, 'sub transaction price incorrect')
+      for (let i = 0; i < updatedResponse.subTransactions.length; i += 1) {
+        expect(updatedResponse.subTransactions[i].totalPriceInclVat, 'sub transaction price incorrect')
           .to.eql(updateReq.subTransactions[i].totalPriceInclVat);
 
         // sort on subtransactionrow id for comparing
-        updatedTransaction.subTransactions[i].subTransactionRows.sort((a, b) => {
+        updatedResponse.subTransactions[i].subTransactionRows.sort((a, b) => {
           if (a.id < b.id) return -1;
           if (a.id > b.id) return 1;
           return 0;
@@ -950,9 +951,9 @@ describe('TransactionService', (): void => {
 
         // check sub transaction row response prices
         for (let j = 0;
-          j < updatedTransaction.subTransactions[i].subTransactionRows.length;
+          j < updatedResponse.subTransactions[i].subTransactionRows.length;
           j += 1) {
-          expect(updatedTransaction.subTransactions[i].subTransactionRows[j].totalPriceInclVat, 'sub transaction row price incorrect')
+          expect(updatedResponse.subTransactions[i].subTransactionRows[j].totalPriceInclVat, 'sub transaction row price incorrect')
             .to.eql(updateReq.subTransactions[i].subTransactionRows[j].totalPriceInclVat);
         }
       }

--- a/test/unit/service/transfer-service.ts
+++ b/test/unit/service/transfer-service.ts
@@ -25,7 +25,6 @@ import express, { Application } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';
 import { DataSource } from 'typeorm';
 import TransferRequest from '../../../src/controller/request/transfer-request';
-import { PaginatedTransferResponse } from '../../../src/controller/response/transfer-response';
 import Database from '../../../src/database/database';
 import Transfer from '../../../src/entity/transactions/transfer';
 import User from '../../../src/entity/user/user';
@@ -96,35 +95,35 @@ describe('TransferService', async (): Promise<void> => {
   });
   describe('getTransfers function', async (): Promise<void> => {
     it('should return all transfers', async () => {
-      const res: PaginatedTransferResponse = await new TransferService().getTransfers();
-      expect(res.records.length).to.equal(ctx.transfers.length);
+      const [records] = await new TransferService().getTransfers();
+      expect(records.length).to.equal(ctx.transfers.length);
       const ids = new Set(ctx.transfers.map((obj) => obj.id));
-      res.records.forEach((element) => ids.delete(element.id));
+      records.forEach((element) => ids.delete(element.id));
       expect(ids.size).to.equal(0);
     });
 
     it('should return all transfers involving a single user', async () => {
       const user = ctx.users[0];
-      const res: PaginatedTransferResponse = await new TransferService().getTransfers({}, {}, user);
+      const [records] = await new TransferService().getTransfers({}, {}, user);
       const actualTransfers = ctx.transfers
         .filter((t) => (t.from && t.from.id === user.id) || (t.to && t.to.id === user.id));
-      expect(res.records.length).to.equal(actualTransfers.length);
-      res.records.forEach((t) => expect(
+      expect(records.length).to.equal(actualTransfers.length);
+      records.forEach((t) => expect(
         (t.from && t.from.id === user.id) || (t.to && t.to.id === user.id),
       ).to.be.true);
     });
 
     it('should return a single transfer if id is specified', async () => {
-      const res: PaginatedTransferResponse = await new TransferService()
+      const [records] = await new TransferService()
         .getTransfers({ id: ctx.transfers[0].id });
-      expect(res.records.length).to.equal(1);
-      expect(res.records[0].id).to.equal(ctx.transfers[0].id);
+      expect(records.length).to.equal(1);
+      expect(records[0].id).to.equal(ctx.transfers[0].id);
     });
 
     it('should return nothing if a wrong id is specified', async () => {
-      const res: PaginatedTransferResponse = await new TransferService()
+      const [records] = await new TransferService()
         .getTransfers({ id: ctx.transfers.length + 1 });
-      expect(res.records).to.be.empty;
+      expect(records).to.be.empty;
     });
 
     it('should return all transfer after a given date', async () => {
@@ -136,10 +135,10 @@ describe('TransferService', async (): Promise<void> => {
       expect(actualTransfers.length).to.be.at.most(ctx.transfers.length - 2);
       expect(actualTransfers.length).to.be.at.least(1);
 
-      const res = await new TransferService().getTransfers({ fromDate });
-      expect(res.records).to.be.lengthOf(actualTransfers.length);
-      res.records.forEach((t) => {
-        expect(new Date(t.createdAt)).to.be.greaterThanOrEqual(fromDate);
+      const [records] = await new TransferService().getTransfers({ fromDate });
+      expect(records).to.be.lengthOf(actualTransfers.length);
+      records.forEach((t) => {
+        expect(t.createdAt).to.be.greaterThanOrEqual(fromDate);
       });
     });
 
@@ -152,10 +151,10 @@ describe('TransferService', async (): Promise<void> => {
       expect(actualTransfers.length).to.be.at.most(ctx.transfers.length - 2);
       expect(actualTransfers.length).to.be.at.least(1);
 
-      const res = await new TransferService().getTransfers({ tillDate });
-      expect(res.records).to.be.lengthOf(actualTransfers.length);
-      res.records.forEach((t) => {
-        expect(new Date(t.createdAt)).to.be.lessThan(tillDate);
+      const [records] = await new TransferService().getTransfers({ tillDate });
+      expect(records).to.be.lengthOf(actualTransfers.length);
+      records.forEach((t) => {
+        expect(t.createdAt).to.be.lessThan(tillDate);
       });
     });
 
@@ -172,48 +171,48 @@ describe('TransferService', async (): Promise<void> => {
       expect(actualTransfers.length).to.be.at.most(ctx.transfers.length - 2);
       expect(actualTransfers.length).to.be.at.least(1);
 
-      const res = await new TransferService().getTransfers({ fromDate, tillDate });
-      expect(res.records).to.be.lengthOf(actualTransfers.length);
-      res.records.forEach((t) => {
-        expect(new Date(t.createdAt)).to.be.greaterThanOrEqual(fromDate);
-        expect(new Date(t.createdAt)).to.be.lessThan(tillDate);
+      const [records] = await new TransferService().getTransfers({ fromDate, tillDate });
+      expect(records).to.be.lengthOf(actualTransfers.length);
+      records.forEach((t) => {
+        expect(t.createdAt).to.be.greaterThanOrEqual(fromDate);
+        expect(t.createdAt).to.be.lessThan(tillDate);
       });
     });
 
     it('should return corresponding invoice if transfer has any', async () => {
       const transfer = ctx.transfers.filter((t) => t.invoice != null)[0];
       expect(transfer).to.not.be.undefined;
-      const res: PaginatedTransferResponse = await new TransferService()
+      const [records] = await new TransferService()
         .getTransfers({ id: transfer.id });
-      expect(res.records.length).to.equal(1);
-      expect(res.records[0].invoice).to.not.be.null;
+      expect(records.length).to.equal(1);
+      expect(records[0].invoice).to.not.be.null;
     });
 
     it('should return corresponding deposit if transfer has any', async () => {
       const transfer = ctx.transfers.filter((t) => t.deposit != null)[0];
       expect(transfer).to.not.be.undefined;
-      const res: PaginatedTransferResponse = await new TransferService()
+      const [records] = await new TransferService()
         .getTransfers({ id: transfer.id });
-      expect(res.records.length).to.equal(1);
-      expect(res.records[0].deposit).to.not.be.null;
+      expect(records.length).to.equal(1);
+      expect(records[0].deposit).to.not.be.null;
     });
 
     it('should return corresponding payoutRequest if transfer has any', async () => {
       const transfer = ctx.transfers.filter((t) => t.payoutRequest != null)[0];
       expect(transfer).to.not.be.undefined;
-      const res: PaginatedTransferResponse = await new TransferService()
+      const [records] = await new TransferService()
         .getTransfers({ id: transfer.id });
-      expect(res.records.length).to.equal(1);
-      expect(res.records[0].payoutRequest).to.not.be.null;
+      expect(records.length).to.equal(1);
+      expect(records[0].payoutRequest).to.not.be.null;
     });
 
     it('should return corresponding fine if transfer has any', async () => {
       const transfer = ctx.transfers.filter((t) => t.fine != null)[0];
       expect(transfer).to.not.be.undefined;
-      const res: PaginatedTransferResponse = await new TransferService()
+      const [records] = await new TransferService()
         .getTransfers({ id: transfer.id });
-      expect(res.records.length).to.equal(1);
-      expect(res.records[0].fine).to.not.be.null;
+      expect(records.length).to.equal(1);
+      expect(records[0].fine).to.not.be.null;
     });
 
     it('should return corresponding waived fines if transfer has any', async () => {
@@ -229,10 +228,10 @@ describe('TransferService', async (): Promise<void> => {
         waivedFines: userFineGroup,
       } as Transfer);
 
-      const res: PaginatedTransferResponse = await new TransferService()
+      const [records] = await new TransferService()
         .getTransfers({ id: t.id });
-      expect(res.records.length).to.equal(1);
-      expect(res.records[0].waivedFines).to.not.be.null;
+      expect(records.length).to.equal(1);
+      expect(records[0].waivedFines).to.not.be.null;
 
       // Cleanup
       await Transfer.delete(t.id);
@@ -253,9 +252,9 @@ describe('TransferService', async (): Promise<void> => {
       const resPost = await new TransferService().postTransfer(req);
       expect(resPost).to.not.be.null;
 
-      const res: PaginatedTransferResponse = await new TransferService().getTransfers();
-      const transfers = res.records;
-      const lastEntry = transfers.reduce((prev, curr) => (prev.id < curr.id ? curr : prev));
+      const [transfers] = await new TransferService().getTransfers();
+      const records = transfers.map((t) => TransferService.asTransferResponse(t));
+      const lastEntry = records.reduce((prev, curr) => (prev.id < curr.id ? curr : prev));
       expect(lastEntry.amountInclVat.amount).to.equal(req.amount.amount);
       expect(lastEntry.amountInclVat.currency).to.equal(req.amount.currency);
       expect(lastEntry.amountInclVat.precision).to.equal(req.amount.precision);
@@ -300,9 +299,9 @@ describe('TransferService', async (): Promise<void> => {
       const resPost = await new TransferService().createTransfer(req);
       expect(resPost).to.not.be.null;
 
-      const res: PaginatedTransferResponse = await new TransferService().getTransfers();
-      const transfers = res.records;
-      const lastEntry = transfers.reduce((prev, curr) => (prev.id < curr.id ? curr : prev));
+      const [transfers] = await new TransferService().getTransfers();
+      const records = transfers.map((t) => TransferService.asTransferResponse(t));
+      const lastEntry = records.reduce((prev, curr) => (prev.id < curr.id ? curr : prev));
       expect(lastEntry.amountInclVat.amount).to.equal(req.amount.amount);
       expect(lastEntry.amountInclVat.currency).to.equal(req.amount.currency);
       expect(lastEntry.amountInclVat.precision).to.equal(req.amount.precision);

--- a/test/unit/service/user-service.ts
+++ b/test/unit/service/user-service.ts
@@ -302,52 +302,52 @@ describe('UserService', async (): Promise<void> => {
   });
 
   describe('getUsers', () => {
-    it('should return paginated users', async () => {
-      const result = await UserService.getUsers({}, { take: 10, skip: 0 });
+    it('should return users and count as tuple', async () => {
+      const [records, count] = await UserService.getUsers({}, { take: 10, skip: 0 });
 
-      expect(result).to.have.property('records');
-      expect(result).to.have.property('_pagination');
-      expect(result.records.length).to.be.greaterThan(0);
+      expect(records).to.be.an('array');
+      expect(count).to.be.a('number');
+      expect(records.length).to.be.greaterThan(0);
     });
 
     it('should filter by active status', async () => {
-      const result = await UserService.getUsers({ active: true }, { take: 100 });
+      const [records] = await UserService.getUsers({ active: true }, { take: 100 });
 
-      result.records.forEach((user) => {
+      records.forEach((user) => {
         expect(user.active).to.be.true;
       });
     });
 
     it('should filter by user type', async () => {
-      const result = await UserService.getUsers({ type: UserType.MEMBER }, { take: 100 });
+      const [records] = await UserService.getUsers({ type: UserType.MEMBER }, { take: 100 });
 
-      result.records.forEach((user) => {
+      records.forEach((user) => {
         expect(user.type).to.equal(UserType.MEMBER);
       });
     });
 
     it('should filter by id', async () => {
       const userId = ctx.users[0].id;
-      const result = await UserService.getUsers({ id: userId }, { take: 100 });
+      const [records] = await UserService.getUsers({ id: userId }, { take: 100 });
 
-      expect(result.records.length).to.equal(1);
-      expect(result.records[0].id).to.equal(userId);
+      expect(records.length).to.equal(1);
+      expect(records[0].id).to.equal(userId);
     });
 
     it('should filter by multiple ids', async () => {
       const userIds = [ctx.users[0].id, ctx.users[1].id];
-      const result = await UserService.getUsers({ id: userIds }, { take: 100 });
+      const [records] = await UserService.getUsers({ id: userIds }, { take: 100 });
 
-      expect(result.records.length).to.equal(2);
-      expect(result.records.map((u) => u.id)).to.include.members(userIds);
+      expect(records.length).to.equal(2);
+      expect(records.map((u) => u.id)).to.include.members(userIds);
     });
 
     it('should filter by organId', async () => {
       if (ctx.organs.length > 0) {
         const organId = ctx.organs[0].id;
-        const result = await UserService.getUsers({ organId }, { take: 100 });
+        const [records] = await UserService.getUsers({ organId }, { take: 100 });
 
-        expect(result.records.length).to.be.greaterThan(0);
+        expect(records.length).to.be.greaterThan(0);
       }
     });
 
@@ -356,24 +356,24 @@ describe('UserService', async (): Promise<void> => {
       const user = ctx.users[0];
       await UserService.addUserRole(user, ctx.roles[0]);
 
-      const result = await UserService.getUsers({ assignedRoleIds: [ctx.roles[0].id] }, { take: 100 });
+      const [records] = await UserService.getUsers({ assignedRoleIds: [ctx.roles[0].id] }, { take: 100 });
 
-      expect(result.records.some((u) => u.id === user.id)).to.be.true;
+      expect(records.some((u) => u.id === user.id)).to.be.true;
     });
 
     it('should search by name', async () => {
       const user = ctx.users[0];
-      const result = await UserService.getUsers({ search: user.firstName }, { take: 100 });
+      const [records] = await UserService.getUsers({ search: user.firstName }, { take: 100 });
 
-      expect(result.records.some((u) => u.id === user.id)).to.be.true;
+      expect(records.some((u) => u.id === user.id)).to.be.true;
     });
 
     it('should search by email for local users', async () => {
       const localUser = ctx.users.find((u) => u.type === UserType.LOCAL_USER);
       if (localUser && localUser.email) {
-        const result = await UserService.getUsers({ search: localUser.email }, { take: 100 });
+        const [records] = await UserService.getUsers({ search: localUser.email }, { take: 100 });
 
-        expect(result.records.some((u) => u.id === localUser.id)).to.be.true;
+        expect(records.some((u) => u.id === localUser.id)).to.be.true;
       }
     });
 
@@ -382,9 +382,9 @@ describe('UserService', async (): Promise<void> => {
       user.deleted = true;
       await user.save();
 
-      const result = await UserService.getUsers({}, { take: 100 });
+      const [records] = await UserService.getUsers({}, { take: 100 });
 
-      expect(result.records.some((u) => u.id === user.id)).to.be.false;
+      expect(records.some((u) => u.id === user.id)).to.be.false;
 
       user.deleted = false;
       await user.save();
@@ -395,81 +395,81 @@ describe('UserService', async (): Promise<void> => {
       user.deleted = true;
       await user.save();
 
-      const result = await UserService.getUsers({ allowDeleted: true }, { take: 100 });
+      const [records] = await UserService.getUsers({ allowDeleted: true }, { take: 100 });
 
-      expect(result.records.some((u) => u.id === user.id)).to.be.true;
+      expect(records.some((u) => u.id === user.id)).to.be.true;
 
       user.deleted = false;
       await user.save();
     });
 
     it('should exclude POINT_OF_SALE users by default', async () => {
-      const result = await UserService.getUsers({}, { take: 100 });
+      const [records] = await UserService.getUsers({}, { take: 100 });
 
-      result.records.forEach((user) => {
+      records.forEach((user) => {
         expect(user.type).to.not.equal(UserType.POINT_OF_SALE);
       });
     });
 
     it('should handle empty search results', async () => {
-      const result = await UserService.getUsers({ search: 'nonexistentuser12345' }, { take: 100 });
+      const [records] = await UserService.getUsers({ search: 'nonexistentuser12345' }, { take: 100 });
 
-      expect(result.records.length).to.equal(0);
+      expect(records.length).to.equal(0);
     });
 
     it('should search with multiple terms', async () => {
       const user = ctx.users[0];
-      const result = await UserService.getUsers({ search: `${user.firstName} ${user.lastName}` }, { take: 100 });
+      const [records] = await UserService.getUsers({ search: `${user.firstName} ${user.lastName}` }, { take: 100 });
 
-      expect(result.records.some((u) => u.id === user.id)).to.be.true;
+      expect(records.some((u) => u.id === user.id)).to.be.true;
     });
 
     it('should search by nickname', async () => {
       const user = ctx.users.find((u) => u.nickname);
       if (user && user.nickname) {
-        const result = await UserService.getUsers({ search: user.nickname }, { take: 100 });
+        const [records] = await UserService.getUsers({ search: user.nickname }, { take: 100 });
 
-        expect(result.records.some((u) => u.id === user.id)).to.be.true;
+        expect(records.some((u) => u.id === user.id)).to.be.true;
       }
     });
 
     it('should filter by pointOfSaleId', async () => {
       if (ctx.pointsOfSale.length > 0) {
         const pos = ctx.pointsOfSale[0];
-        const result = await UserService.getUsers({ pointOfSaleId: pos.id }, { take: 100 });
+        const [records] = await UserService.getUsers({ pointOfSaleId: pos.id }, { take: 100 });
 
-        expect(result.records.length).to.be.greaterThan(0);
-        expect(result.records.some((u) => u.id === pos.user.id)).to.be.true;
+        expect(records.length).to.be.greaterThan(0);
+        expect(records.some((u) => u.id === pos.user.id)).to.be.true;
       }
     });
 
     it('should include POINT_OF_SALE users when type filter is set', async () => {
-      const result = await UserService.getUsers({ type: UserType.POINT_OF_SALE }, { take: 100 });
+      const [records] = await UserService.getUsers({ type: UserType.POINT_OF_SALE }, { take: 100 });
 
-      expect(result.records.length).to.be.greaterThan(0);
-      result.records.forEach((user) => {
+      expect(records.length).to.be.greaterThan(0);
+      records.forEach((user) => {
         expect(user.type).to.equal(UserType.POINT_OF_SALE);
       });
     });
 
     it('should handle search with id filter intersection', async () => {
       const user = ctx.users[0];
-      const result = await UserService.getUsers({
+      const [records] = await UserService.getUsers({
         id: [user.id, 999999],
         search: user.firstName,
       }, { take: 100 });
 
-      expect(result.records.some((u) => u.id === user.id)).to.be.true;
-      expect(result.records.some((u) => u.id === 999999)).to.be.false;
+      expect(records.some((u) => u.id === user.id)).to.be.true;
+      expect(records.some((u) => u.id === 999999)).to.be.false;
     });
 
     it('should handle search with id filter that results in empty intersection', async () => {
-      const result = await UserService.getUsers({
+      const [records] = await UserService.getUsers({
         id: [999999],
         search: ctx.users[0].firstName,
       }, { take: 100 });
 
-      expect(result.records.length).to.equal(0);
+      expect(records.length).to.equal(0);
     });
   });
 

--- a/test/unit/service/vat-group-service.ts
+++ b/test/unit/service/vat-group-service.ts
@@ -79,49 +79,42 @@ describe('VatGroupService', () => {
 
   describe('Get VAT groups', () => {
     it('should return all VAT groups', async () => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { records, _pagination } = await VatGroupService.getVatGroups({});
+      const [records, count] = await VatGroupService.getVatGroups({});
 
       expect(records.length).to.equal(ctx.vatGroups.length);
-
-      expect(_pagination.take).to.be.undefined;
-      expect(_pagination.skip).to.be.undefined;
-      expect(_pagination.count).to.equal(ctx.vatGroups.length);
+      expect(count).to.equal(ctx.vatGroups.length);
     });
     it('should adhere to pagination', async () => {
       const take = 3;
       const skip = 2;
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { records, _pagination } = await VatGroupService.getVatGroups({}, {
-        take: 3,
-        skip: 2,
+      const [records, count] = await VatGroupService.getVatGroups({}, {
+        take,
+        skip,
       });
 
       expect(records.length).to.equal(Math.min(ctx.vatGroups.length - skip, take));
-      expect(_pagination.take).to.equal(take);
-      expect(_pagination.skip).to.equal(skip);
-      expect(_pagination.count).to.equal(ctx.vatGroups.length);
+      expect(count).to.equal(ctx.vatGroups.length);
     });
     it('should filter on id', async () => {
       const vatGroupId = ctx.vatGroups[0].id;
-      const { records } = await VatGroupService.getVatGroups({ vatGroupId });
+      const [records] = await VatGroupService.getVatGroups({ vatGroupId });
 
       expect(records.length).to.equal(1);
       expect(records[0].id).to.equal(vatGroupId);
     });
     it('should filter on name', async () => {
       const { name } = ctx.vatGroups[0];
-      const { records } = await VatGroupService.getVatGroups({ name });
+      const [records] = await VatGroupService.getVatGroups({ name });
       records.map((r) => expect(r.name).to.equal(name));
     });
     it('should filter on percentage', async () => {
       const { percentage } = ctx.vatGroups[1];
-      const { records } = await VatGroupService.getVatGroups({ percentage });
+      const [records] = await VatGroupService.getVatGroups({ percentage });
       records.map((r) => expect(r.percentage).to.equal(percentage));
     });
     it('should filter on deleted', async () => {
       const deleted = false;
-      const { records } = await VatGroupService.getVatGroups({ deleted });
+      const [records] = await VatGroupService.getVatGroups({ deleted });
       records.map((r) => expect(r.deleted).to.equal(deleted));
     });
   });

--- a/test/unit/service/voucher-group-service.ts
+++ b/test/unit/service/voucher-group-service.ts
@@ -22,21 +22,21 @@ import { expect } from 'chai';
 import Sinon from 'sinon';
 import { DataSource } from 'typeorm';
 import { VoucherGroupParams, VoucherGroupRequest } from '../../../src/controller/request/voucher-group-request';
-import VoucherGroupResponse from '../../../src/controller/response/voucher-group-response';
 import Database from '../../../src/database/database';
 import Transfer from '../../../src/entity/transactions/transfer';
-import { TermsOfServiceStatus } from '../../../src/entity/user/user';
+import User, { TermsOfServiceStatus } from '../../../src/entity/user/user';
+import VoucherGroup from '../../../src/entity/user/voucher-group';
 import VoucherGroupService from '../../../src/service/voucher-group-service';
 import { truncateAllTables } from '../../setup';
 import { finishTestDB } from '../../helpers/test-helpers';
 
-export function bkgEq(req: VoucherGroupParams, res: VoucherGroupResponse): void {
+export function bkgEq(req: VoucherGroupParams, voucherGroup: VoucherGroup, users: User[]): void {
   // check if non user fields are equal
-  expect(res.name).to.equal(req.name);
-  expect(res.activeStartDate).to.equal(req.activeStartDate.toISOString());
-  expect(res.activeEndDate).to.equal(req.activeEndDate.toISOString());
-  expect(res.users).to.be.of.length(req.amount);
-  expect(res.balance.amount).to.equal(req.balance.getAmount());
+  expect(voucherGroup.name).to.equal(req.name);
+  expect(voucherGroup.activeStartDate.toISOString()).to.equal(req.activeStartDate.toISOString());
+  expect(voucherGroup.activeEndDate.toISOString()).to.equal(req.activeEndDate.toISOString());
+  expect(users).to.be.of.length(req.amount);
+  expect(voucherGroup.balance.getAmount()).to.equal(req.balance.getAmount());
 }
 
 export async function seedVoucherGroups(): Promise<{ paramss: VoucherGroupParams[], bkgIds: number[] }> {
@@ -55,10 +55,9 @@ export async function seedVoucherGroups(): Promise<{ paramss: VoucherGroupParams
       amount: 4,
     };
     const params = VoucherGroupService.asVoucherGroupParams(bkgReq);
-    const bkgRes = await VoucherGroupService.createVoucherGroup(params);
-    // paramss.push(params);
-    bkgIds[bkgRes.id - 1] = bkgRes.id;
-    paramss[bkgRes.id - 1] = params;
+    const { voucherGroup } = await VoucherGroupService.createVoucherGroup(params);
+    bkgIds[voucherGroup.id - 1] = voucherGroup.id;
+    paramss[voucherGroup.id - 1] = params;
   }));
   return { paramss, bkgIds };
 }
@@ -226,9 +225,9 @@ describe('VoucherGroupService', async (): Promise<void> => {
         amount: 4,
       };
       const params = VoucherGroupService.asVoucherGroupParams(req);
-      const bkgRes = await VoucherGroupService.createVoucherGroup(params);
-      bkgEq(params, bkgRes);
-      await Promise.all(bkgRes.users.map(async (user) => {
+      const { voucherGroup, users } = await VoucherGroupService.createVoucherGroup(params);
+      bkgEq(params, voucherGroup, users);
+      await Promise.all(users.map(async (user) => {
         expect(user.active, 'user inactive').to.equal(false);
         expect(user.acceptedToS).to.equal(TermsOfServiceStatus.NOT_REQUIRED);
         const transfers = await Transfer.find({ where: { toId: user.id } });
@@ -250,9 +249,9 @@ describe('VoucherGroupService', async (): Promise<void> => {
         amount: 4,
       };
       const params = VoucherGroupService.asVoucherGroupParams(req);
-      const bkgRes = await VoucherGroupService.createVoucherGroup(params);
-      bkgEq(params, bkgRes);
-      await Promise.all(bkgRes.users.map(async (user) => {
+      const { voucherGroup, users } = await VoucherGroupService.createVoucherGroup(params);
+      bkgEq(params, voucherGroup, users);
+      await Promise.all(users.map(async (user) => {
         expect(user.active, 'user active').to.equal(true);
         const transfers = await Transfer.find({ where: { toId: user.id } });
         const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
@@ -277,8 +276,8 @@ describe('VoucherGroupService', async (): Promise<void> => {
         amount: 4,
       };
       const params = VoucherGroupService.asVoucherGroupParams(req);
-      const bkgRes = await VoucherGroupService.createVoucherGroup(params);
-      bkgId = bkgRes.id;
+      const { voucherGroup } = await VoucherGroupService.createVoucherGroup(params);
+      bkgId = voucherGroup.id;
     });
 
     it('should update an existing voucher groups name', async () => {
@@ -294,9 +293,9 @@ describe('VoucherGroupService', async (): Promise<void> => {
         amount: 4,
       };
       const params = VoucherGroupService.asVoucherGroupParams(req);
-      const bkgRes = await VoucherGroupService.updateVoucherGroup(bkgId, params);
-      bkgEq(params, bkgRes);
-      await Promise.all(bkgRes.users.map(async (user) => {
+      const { voucherGroup, users } = await VoucherGroupService.updateVoucherGroup(bkgId, params);
+      bkgEq(params, voucherGroup, users);
+      await Promise.all(users.map(async (user) => {
         expect(user.active, 'user inactive').to.equal(false);
         const transfers = await Transfer.find({ where: { toId: user.id } });
         const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
@@ -318,9 +317,9 @@ describe('VoucherGroupService', async (): Promise<void> => {
         amount: 4,
       };
       const params = VoucherGroupService.asVoucherGroupParams(req);
-      const bkgRes = await VoucherGroupService.updateVoucherGroup(bkgId, params);
-      bkgEq(params, bkgRes);
-      await Promise.all(bkgRes.users.map(async (user) => {
+      const { voucherGroup, users } = await VoucherGroupService.updateVoucherGroup(bkgId, params);
+      bkgEq(params, voucherGroup, users);
+      await Promise.all(users.map(async (user) => {
         expect(user.active, 'user inactive').to.equal(false);
         const transfers = await Transfer.find({ where: { toId: user.id } });
         const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
@@ -342,9 +341,9 @@ describe('VoucherGroupService', async (): Promise<void> => {
         amount: 4,
       };
       const params = VoucherGroupService.asVoucherGroupParams(req);
-      const bkgRes = await VoucherGroupService.updateVoucherGroup(bkgId, params);
-      bkgEq(params, bkgRes);
-      await Promise.all(bkgRes.users.map(async (user) => {
+      const { voucherGroup, users } = await VoucherGroupService.updateVoucherGroup(bkgId, params);
+      bkgEq(params, voucherGroup, users);
+      await Promise.all(users.map(async (user) => {
         expect(user.active, 'user inactive').to.equal(false);
         const transfers = await Transfer.find({ where: { toId: user.id } });
         const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
@@ -366,9 +365,9 @@ describe('VoucherGroupService', async (): Promise<void> => {
         amount: 4,
       };
       const params = VoucherGroupService.asVoucherGroupParams(req);
-      const bkgRes = await VoucherGroupService.updateVoucherGroup(bkgId, params);
-      bkgEq(params, bkgRes);
-      await Promise.all(bkgRes.users.map(async (user) => {
+      const { voucherGroup, users } = await VoucherGroupService.updateVoucherGroup(bkgId, params);
+      bkgEq(params, voucherGroup, users);
+      await Promise.all(users.map(async (user) => {
         expect(user.active, 'user active').to.equal(true);
         const transfers = await Transfer.find({ where: { toId: user.id } });
         const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
@@ -390,9 +389,9 @@ describe('VoucherGroupService', async (): Promise<void> => {
         amount: 5,
       };
       const params = VoucherGroupService.asVoucherGroupParams(req);
-      const bkgRes = await VoucherGroupService.updateVoucherGroup(bkgId, params);
-      bkgEq(params, bkgRes);
-      await Promise.all(bkgRes.users.map(async (user) => {
+      const { voucherGroup, users } = await VoucherGroupService.updateVoucherGroup(bkgId, params);
+      bkgEq(params, voucherGroup, users);
+      await Promise.all(users.map(async (user) => {
         expect(user.active, 'user active').to.equal(false);
         const transfers = await Transfer.find({ where: { toId: user.id } });
         const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
@@ -414,9 +413,9 @@ describe('VoucherGroupService', async (): Promise<void> => {
         amount: 4,
       };
       const params = VoucherGroupService.asVoucherGroupParams(req);
-      const bkgRes = await VoucherGroupService.updateVoucherGroup(bkgId, params);
-      bkgEq(params, bkgRes);
-      await Promise.all(bkgRes.users.map(async (user) => {
+      const { voucherGroup, users } = await VoucherGroupService.updateVoucherGroup(bkgId, params);
+      bkgEq(params, voucherGroup, users);
+      await Promise.all(users.map(async (user) => {
         expect(user.active, 'user active').to.equal(false);
         const transfers = await Transfer.find({ where: { toId: user.id } });
         const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
@@ -438,9 +437,9 @@ describe('VoucherGroupService', async (): Promise<void> => {
         amount: 4,
       };
       const params = VoucherGroupService.asVoucherGroupParams(req);
-      const bkgRes = await VoucherGroupService.updateVoucherGroup(bkgId, params);
-      bkgEq(params, bkgRes);
-      await Promise.all(bkgRes.users.map(async (user) => {
+      const { voucherGroup, users } = await VoucherGroupService.updateVoucherGroup(bkgId, params);
+      bkgEq(params, voucherGroup, users);
+      await Promise.all(users.map(async (user) => {
         expect(user.active, 'user active').to.equal(false);
         const transfersPos = await Transfer.find({ where: { toId: user.id } });
         const transfersNeg = await Transfer.find({ where: { fromId: user.id } });
@@ -466,8 +465,8 @@ describe('VoucherGroupService', async (): Promise<void> => {
         amount: 4,
       };
       const params = VoucherGroupService.asVoucherGroupParams(req);
-      const bkgRes = await VoucherGroupService.updateVoucherGroup(bkgId + 1, params);
-      expect(bkgRes).to.be.undefined;
+      const result = await VoucherGroupService.updateVoucherGroup(bkgId + 1, params);
+      expect(result).to.be.undefined;
     });
   });
 
@@ -481,10 +480,11 @@ describe('VoucherGroupService', async (): Promise<void> => {
     });
 
     it('should get an voucher group by id', async () => {
-      const bkgRes = (await VoucherGroupService.getVoucherGroups({ bkgId: bkgIds[0] }))
-        .records[0];
-      bkgEq(paramss[0], bkgRes);
-      await Promise.all(bkgRes.users.map(async (user) => {
+      const [bkgs] = await VoucherGroupService.getVoucherGroups({ bkgId: bkgIds[0] });
+      const bkg = bkgs[0];
+      const users = bkg.vouchers.map((v) => v.user);
+      bkgEq(paramss[0], bkg, users);
+      await Promise.all(users.map(async (user) => {
         expect(user.active, 'user inactive').to.equal(false);
         const transfers = await Transfer.find({ where: { toId: user.id } });
         const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
@@ -494,21 +494,21 @@ describe('VoucherGroupService', async (): Promise<void> => {
     });
 
     it('should return undefined when given a wrong id', async () => {
-      const bkgRes = (await VoucherGroupService.getVoucherGroups({ bkgId: bkgIds.length + 1 }))
-        .records[0];
-      expect(bkgRes).to.be.undefined;
+      const [bkgs] = await VoucherGroupService.getVoucherGroups({ bkgId: bkgIds.length + 1 });
+      expect(bkgs[0]).to.be.undefined;
     });
 
     it('should get all voucher groups', async () => {
-      const bkgRes = (await VoucherGroupService.getVoucherGroups({})).records;
-      await Promise.all(bkgRes.map(async (res) => {
-        bkgEq(paramss[res.id - 1], res);
-        await Promise.all(res.users.map(async (user) => {
+      const [bkgs] = await VoucherGroupService.getVoucherGroups({});
+      await Promise.all(bkgs.map(async (bkg) => {
+        const users = bkg.vouchers.map((v) => v.user);
+        bkgEq(paramss[bkg.id - 1], bkg, users);
+        await Promise.all(users.map(async (user) => {
           expect(user.active, 'user inactive').to.equal(false);
           const transfers = await Transfer.find({ where: { toId: user.id } });
           const balanceAmounts = transfers.map((transfer) => transfer.amountInclVat.getAmount());
           const balance = balanceAmounts.reduce((a, b) => a + b);
-          expect(balance, 'correct transfers').to.equal(paramss[res.id - 1].balance.getAmount());
+          expect(balance, 'correct transfers').to.equal(paramss[bkg.id - 1].balance.getAmount());
         }));
       }));
     });

--- a/test/unit/service/write-off-service.ts
+++ b/test/unit/service/write-off-service.ts
@@ -64,9 +64,10 @@ describe('WriteOffService', () => {
 
   describe('getWriteOffs function', () => {
     it('should return all write-offs with no input specification', async () => {
-      const res = await WriteOffService.getWriteOffs();
-      expect(res.records.length).to.equal(ctx.writeOffs.length);
-      expect(res.records.map(writeOff => writeOff.id)).to.deep.equalInAnyOrder(ctx.writeOffs.map(writeOff => writeOff.id));
+      const [records, count] = await WriteOffService.getWriteOffs();
+      expect(records.length).to.equal(ctx.writeOffs.length);
+      expect(count).to.equal(ctx.writeOffs.length);
+      expect(records.map(writeOff => writeOff.id)).to.deep.equalInAnyOrder(ctx.writeOffs.map(writeOff => writeOff.id));
     });
   });
   describe('getOptions function', () => {
@@ -99,10 +100,10 @@ describe('WriteOffService', () => {
       const builder = await (await UserFactory()).addBalance(-amount);
       await inUserContext([await builder.get()], async (user: User) => {
         const writeOff = await (new WriteOffService()).createWriteOffAndCloseUser(user);
-        expect(writeOff.amount.amount).to.equal(100);
+        expect(writeOff.amount.getAmount()).to.equal(100);
         expect(writeOff.to.id).to.equal(user.id);
         expect(writeOff.transfer).to.not.be.undefined;
-        expect(writeOff.transfer.amountInclVat.amount).to.equal(100);
+        expect(writeOff.transfer.amountInclVat.getAmount()).to.equal(100);
         expect(writeOff.transfer.to.id).to.equal(user.id);
         const u = await User.findOne({ where: { id: user.id } });
         expect(u.deleted).to.be.true;


### PR DESCRIPTION
# Description

Refactor all service classes to return entities/tuples instead of HTTP response objects. Response conversion is now handled by controllers, not services.

**Key changes:**
- ~20 services: return types changed from `PaginatedXResponse` → `[Entity[], number]` and `XResponse` → `Entity`
- Controllers now call static converter methods (e.g. `asUserResponse()`, `revisionToResponse()`) and wrap with `toResponse()` helper
- Eliminated `.records` extraction — internal callers destructure `[records, count]` tuples directly
- Fixed direct `User.findOne()` calls outside UserService → use `UserService.getOptions()`
- Added `toResponse<R>()` pagination helper in `src/helpers/pagination.ts`

## Related issues/external references

Closes #153

## Types of changes

- Style _(Change that do not affect the functionality of the code)_

---
## ✅ PR Checklist
- [x] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [x] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [x] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB
