### PR TITLE
fix: make redis optional for local-development

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export class Application {
 
   webSocketService: WebSocketService;
 
-  redisConnection: Redis;
+  redisConnection: Redis | undefined;
 
   public async stop(): Promise<void> {
     this.logger.info('Stopping application instance...');
@@ -120,6 +120,9 @@ export class Application {
     }
     this.tasks.forEach((task) => task.stop());
     this.workers.forEach((worker) => worker.close());
+    if (this.redisConnection) {
+      await this.redisConnection.quit();
+    }
     await this.connection.destroy();
     this.logger.info('Application stopped.');
   }
@@ -272,11 +275,84 @@ export default async function createApp(): Promise<Application> {
   });
   application.webSocketService = webSocketService;
 
-  application.redisConnection = new Redis({
-    host: process.env.REDIS_HOST || 'localhost',
-    port: Number(process.env.REDIS_PORT) || 6379,
-    maxRetriesPerRequest: null,
-  });
+  // Try to connect to Redis. If it is unreachable (common in local dev
+  // environments) we fall back to direct SMTP sending instead of crashing.
+  // In production we always require Redis and re-throw to prevent silent
+  // degradation of email delivery semantics.
+  //
+  // The connect timeout defaults to 100 ms in test environments (to avoid
+  // slowing down suites that run without Redis) and 3 s otherwise.
+  // Override via REDIS_CONNECT_TIMEOUT_MS if needed.
+  const isTestEnv = process.env.NODE_ENV === 'test';
+  const connectTimeout = Number(
+    process.env.REDIS_CONNECT_TIMEOUT_MS ?? (isTestEnv ? '100' : '3000'),
+  );
+
+  let redisClient: Redis | undefined;
+  try {
+    redisClient = new Redis({
+      host: process.env.REDIS_HOST || 'localhost',
+      port: Number(process.env.REDIS_PORT) || 6379,
+      maxRetriesPerRequest: null,
+      // Give up quickly so startup is not delayed when Redis is absent.
+      // We intentionally omit retryStrategy so that once the connection is
+      // established, ioredis uses its default reconnection behaviour on drop.
+      connectTimeout,
+    });
+
+    // Wait for the connection to be established (or fail).
+    // Named handlers are used so each one can remove the other, preventing
+    // a stale listener from hiding subsequent errors or firing unexpectedly.
+    await new Promise<void>((resolve, reject) => {
+      // Declare first so each handler can reference the other without
+      // triggering the no-use-before-define lint rule.
+      let handleReady: () => void;
+      let handleError: (err: Error) => void;
+
+      handleReady = () => {
+        redisClient.removeListener('error', handleError);
+        resolve();
+      };
+      handleError = (err: Error) => {
+        redisClient.removeListener('ready', handleReady);
+        reject(err);
+      };
+
+      redisClient.once('ready', handleReady);
+      redisClient.once('error', handleError);
+    });
+
+    // Attach a persistent error handler so any post-startup Redis errors are
+    // logged rather than crashing the process with an unhandled error event.
+    redisClient.on('error', (err: Error) => {
+      logger.error(`Redis client error: ${err.message}`);
+    });
+
+    application.redisConnection = redisClient;
+    logger.info('Redis connection established.');
+  } catch (err) {
+    // Clean up any lingering sockets / timers on the failed client so the
+    // event loop is not kept alive unnecessarily.
+    if (redisClient) {
+      redisClient.removeAllListeners();
+      redisClient.disconnect();
+    }
+    application.redisConnection = undefined;
+
+    if (process.env.NODE_ENV === 'production') {
+      // In production a Redis outage must be an explicit, loud failure rather
+      // than a silent fallback that changes email delivery semantics.
+      throw new Error(
+        `Redis is required in production but could not be reached: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    logger.warn(
+      `Could not connect to Redis (${err instanceof Error ? err.message : String(err)}). `
+      + 'Email queueing will be disabled – emails will be sent directly via SMTP. '
+      + 'Start Redis or set REDIS_HOST / REDIS_PORT to enable queued sending.',
+    );
+  }
 
   new Mailer(application.redisConnection);
 
@@ -320,7 +396,9 @@ export default async function createApp(): Promise<Application> {
 
   webSocketService.initiateWebSocket();
 
-  application.workers = [startMailWorker(application.redisConnection)];
+  application.workers = application.redisConnection
+    ? [startMailWorker(application.redisConnection)]
+    : [];
 
   // Start express application.
   logger.info(`Server listening on port ${process.env.HTTP_PORT}.`);

--- a/src/mailer/mailer.ts
+++ b/src/mailer/mailer.ts
@@ -30,6 +30,8 @@ import MailMessage, { Language } from './mail-message';
 import Mail from 'nodemailer/lib/mailer';
 import { ConnectionOptions, Queue } from 'bullmq';
 import Redis from 'ioredis';
+import createSMTPTransporter from './transporter';
+import { Transporter } from 'nodemailer';
 
 enum MailQueues {
   SendEmail = 'send-email',
@@ -38,28 +40,37 @@ enum MailQueues {
 export default class Mailer {
   private static instance: Mailer;
 
-  private mailQueue: Queue;
+  private mailQueue: Queue | undefined;
+
+  private transporter: Transporter | undefined;
 
   private logger: Logger = log4js.getLogger('Mailer');
 
-  constructor(redisConnection: Redis) {
+  /**
+   * Create a Mailer instance.
+   *
+   * When a Redis connection is provided, emails are queued via BullMQ (production
+   * behaviour). When no connection is provided the Mailer falls back to sending
+   * emails directly through the SMTP transporter – useful for local development
+   * where Redis may not be running.
+   */
+  constructor(redisConnection?: Redis) {
     this.logger.level = process.env.LOG_LEVEL;
 
-    const redisHost = process.env.REDIS_HOST || '127.0.0.1';
-    const redisPort = Number(process.env.REDIS_PORT) || 6379;
-
-    if (!redisHost || typeof redisHost !== 'string') {
-      throw new Error('Invalid Redis configuration: REDIS_HOST must be a non-empty string.');
-    }
-    if (!Number.isInteger(redisPort) || redisPort <= 0) {
-      throw new Error(
-        `Invalid Redis configuration: REDIS_PORT must be a positive integer (got "${redisPort}").`,
+    if (redisConnection) {
+      this.mailQueue = new Queue('mail-queue', {
+        connection: redisConnection as unknown as ConnectionOptions,
+      });
+      this.logger.info('Mailer initialised in queued mode (Redis).');
+    } else {
+      this.transporter = createSMTPTransporter();
+      this.logger.warn(
+        'Redis unavailable – Mailer running in direct-send mode. '
+        + 'Emails will be sent synchronously without retries. '
+        + 'Set REDIS_HOST / REDIS_PORT to enable queued sending.',
       );
     }
 
-    this.mailQueue = new Queue('mail-queue', {
-      connection: redisConnection as unknown as ConnectionOptions,
-    });
     Mailer.instance = this;
   }
 
@@ -81,28 +92,47 @@ export default class Mailer {
       ...extraOptions,
       to: to.email,
     };
-    try {
-      await this.mailQueue.add(MailQueues.SendEmail, mailOptions, {
-        attempts: 5,
-        backoff: { type: 'exponential', delay: 2000 },
-      });
 
-      this.logger.info({
-        template: template.constructor.name,
-        to: to.email,
-      }, 'Email successfully queued');
-    } catch (error) {
-      this.logger.error({
-        err: error.message,
-        template: template.constructor.name,
-        to: to.email,
-      }, 'Failed to add email to queue');
+    if (this.mailQueue) {
+      // Queued path – normal production behaviour.
+      try {
+        await this.mailQueue.add(MailQueues.SendEmail, mailOptions, {
+          attempts: 5,
+          backoff: { type: 'exponential', delay: 2000 },
+        });
 
-      throw error;
+        this.logger.info({
+          template: template.constructor.name,
+          to: to.email,
+        }, 'Email successfully queued');
+      } catch (error) {
+        this.logger.error({
+          err: error.message,
+          template: template.constructor.name,
+          to: to.email,
+        }, 'Failed to add email to queue');
+
+        throw error;
+      }
+    } else {
+      // Direct-send fallback – no Redis available (e.g. local dev).
+      try {
+        await this.transporter.sendMail(mailOptions);
+
+        this.logger.info({
+          template: template.constructor.name,
+          to: to.email,
+        }, 'Email sent directly (no-Redis fallback)');
+      } catch (error) {
+        this.logger.error({
+          err: error.message,
+          template: template.constructor.name,
+          to: to.email,
+        }, 'Failed to send email directly');
+
+        throw error;
+      }
     }
-
-
-    this.logger.info(`Queued email: ${template.constructor.name} for ${to.email}`);
   }
 
   /**

--- a/test/unit/mailer/mailer.ts
+++ b/test/unit/mailer/mailer.ts
@@ -31,6 +31,7 @@ import { finishTestDB } from '../../helpers/test-helpers';
 import fs from 'fs';
 import { rootStubs } from '../../root-hooks';
 import Redis from 'ioredis';
+import nodemailer from 'nodemailer';
 
 describe('Mailer', () => {
   let ctx: {
@@ -149,5 +150,29 @@ describe('Mailer', () => {
     const promise = mailer.send(ctx.user, new HelloWorld({ name: ctx.user.firstName }), 'binary' as any);
 
     await expect(promise).to.eventually.be.rejected;
+  });
+
+  // eslint-disable-next-line func-names
+  it('should send mail directly via SMTP when initialised without Redis', async function () {
+    // The test's beforeEach restores the global nodemailer stub, so we
+    // create our own for this test via the sandbox.
+    const sendMailStub = sandbox.stub().resolves({ messageId: 'direct-test-id' });
+    sandbox.stub(nodemailer, 'createTransport').returns({ sendMail: sendMailStub } as any);
+
+    Mailer.reset();
+    const noRedisMailer = new Mailer(/* no redis connection */);
+
+    await noRedisMailer.send(ctx.user, new HelloWorld({ name: ctx.user.firstName }));
+
+    // sendMail should have been called once with the correct recipient.
+    expect(sendMailStub.calledOnce).to.be.true;
+    expect(sendMailStub.firstCall.args[0]).to.have.property('to', ctx.user.email);
+
+    // The BullMQ queue should not have been touched.
+    expect(rootStubs.queueAdd.called).to.be.false;
+
+    // Restore the singleton to the Redis-backed instance for subsequent tests.
+    Mailer.reset();
+    new Mailer(redis);
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Don't wanne have redid running

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_

---

## ✅ PR Checklist

- [x] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [x] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [x] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB

## 🔗 Additional Notes
<!-- Any additional information that reviewers should know -->