### PR TITLE
Add sellerPayout relation to Transfer entity

### DIFF
--- a/src/controller/response/transfer-response.ts
+++ b/src/controller/response/transfer-response.ts
@@ -35,6 +35,7 @@ import { FineResponse, UserFineGroupResponse } from './debtor-response';
 import { BaseVatGroupResponse } from './vat-group-response';
 import { BaseWriteOffResponse } from './write-off-response';
 import { BaseInactiveAdministrativeCostResponse } from './inactive-administrative-cost-response';
+import { SellerPayoutResponse } from './seller-payout-response';
 
 /**
  * @typedef {allOf|BaseResponse} TransferResponse
@@ -51,6 +52,7 @@ import { BaseInactiveAdministrativeCostResponse } from './inactive-administrativ
  * @property {BaseWriteOffResponse} writeOff - write-off belonging to this transfer
  * @property {UserFineGroupResponse} waivedFines - fines that have been waived by this transfer
  * @property {BaseInactiveAdministrativeCostResponse} inactiveAdministrativeCost - inactive administrative cost that belongs to this transfer
+ * @property {SellerPayoutResponse} sellerPayout - seller payout belonging to this transfer
  */
 export interface TransferResponse extends BaseResponse {
   amountInclVat: DineroObjectResponse;
@@ -69,6 +71,7 @@ export interface TransferResponse extends BaseResponse {
   writeOff?: BaseWriteOffResponse;
   waivedFines?: UserFineGroupResponse;
   inactiveAdministrativeCost?: BaseInactiveAdministrativeCostResponse;
+  sellerPayout?: SellerPayoutResponse;
 }
 
 /**

--- a/src/entity/transactions/transfer.ts
+++ b/src/entity/transactions/transfer.ts
@@ -33,6 +33,7 @@ import BaseEntity from '../base-entity';
 import User from '../user/user';
 import DineroTransformer from '../transformer/dinero-transformer';
 import PayoutRequest from './payout/payout-request';
+import SellerPayout from './payout/seller-payout';
 import StripeDeposit from '../stripe/stripe-deposit';
 import Invoice from '../invoices/invoice';
 import Fine from '../fine/fine';
@@ -109,6 +110,9 @@ export default class Transfer extends UnstoredPdfAble(BaseEntity) {
 
   @OneToOne(() => InactiveAdministrativeCost, (a) => a.transfer, { nullable: true })
   public inactiveAdministrativeCost: InactiveAdministrativeCost | null;
+
+  @OneToOne(() => SellerPayout, (s) => s.transfer, { nullable: true })
+  public sellerPayout: SellerPayout | null;
 
   pdfService = new TransferPdfService();
 }

--- a/src/service/transfer-service.ts
+++ b/src/service/transfer-service.ts
@@ -43,6 +43,7 @@ import DebtorService from './debtor-service';
 import VatGroup from '../entity/vat-group';
 import { toMySQLString } from '../helpers/timestamps';
 import WriteOffService from './write-off-service';
+import SellerPayoutService from './seller-payout-service';
 import WithManager from '../database/with-manager';
 import UserService from './user-service';
 import BalanceService from './balance-service';
@@ -58,6 +59,7 @@ export interface TransferFilterParameters {
 export enum TransferCategory {
   DEPOSIT = 'deposit',
   PAYOUT_REQUEST = 'payoutRequest',
+  SELLER_PAYOUT = 'sellerPayout',
   INVOICE = 'invoice',
   FINE = 'fine',
   WAIVED_FINES = 'waivedFines',
@@ -115,6 +117,7 @@ export default class TransferService extends WithManager {
       waivedFines: transfer.waivedFines ? DebtorService.asUserFineGroupResponse(transfer.waivedFines) : null,
       writeOff: transfer.writeOff ? WriteOffService.asBaseWriteOffResponse(transfer.writeOff) : null,
       inactiveAdministrativeCost: transfer.inactiveAdministrativeCost ? transfer.inactiveAdministrativeCost.toBaseResponse() : null,
+      sellerPayout: transfer.sellerPayout ? SellerPayoutService.asSellerPayoutResponse(transfer.sellerPayout) : null,
       vat: transfer.vat ? parseVatGroupToResponse(transfer.vat) : null,
     };
   }
@@ -198,6 +201,7 @@ export default class TransferService extends WithManager {
         invoice: { invoiceStatus: true, transfer: true },
         deposit: { stripePaymentIntent: { paymentIntentStatuses: true } },
         payoutRequest: { payoutRequestStatus: true, requestedBy: true },
+        sellerPayout: { requestedBy: true },
         fine: { userFineGroup: { user: true } },
         waivedFines: { fines: { userFineGroup: true } },
         inactiveAdministrativeCost: {  transfer: true  },
@@ -242,6 +246,7 @@ export default class TransferService extends WithManager {
     const categoryRelationMap: Record<TransferCategory, string> = {
       [TransferCategory.DEPOSIT]: 'deposit',
       [TransferCategory.PAYOUT_REQUEST]: 'payoutRequest',
+      [TransferCategory.SELLER_PAYOUT]: 'sellerPayout',
       [TransferCategory.INVOICE]: 'invoice',
       [TransferCategory.FINE]: 'fine',
       [TransferCategory.WAIVED_FINES]: 'waivedFines',
@@ -283,14 +288,14 @@ export default class TransferService extends WithManager {
   public async deleteTransfer(id: number): Promise<void> {
     const transfer = await this.manager.findOne(Transfer, {
       where: { id },
-      relations: ['from', 'to', 'payoutRequest', 'deposit', 'invoice', 'fine', 'writeOff', 'waivedFines', 'inactiveAdministrativeCost'],
+      relations: ['from', 'to', 'payoutRequest', 'sellerPayout', 'deposit', 'invoice', 'fine', 'writeOff', 'waivedFines', 'inactiveAdministrativeCost'],
     });
 
     if (!transfer) {
       throw new Error('Transfer not found');
     }
 
-    if (transfer.payoutRequest || transfer.deposit || transfer.invoice || transfer.fine || transfer.writeOff || transfer.waivedFines || transfer.inactiveAdministrativeCost) {
+    if (transfer.payoutRequest || transfer.sellerPayout || transfer.deposit || transfer.invoice || transfer.fine || transfer.writeOff || transfer.waivedFines || transfer.inactiveAdministrativeCost) {
       throw new Error('Cannot delete transfer because it is referenced by another entity');
     }
 

--- a/test/unit/service/transfer-service.ts
+++ b/test/unit/service/transfer-service.ts
@@ -38,11 +38,13 @@ import {
   ContainerSeeder, DepositSeeder, FineSeeder, InvoiceSeeder, PayoutRequestSeeder,
   PointOfSaleSeeder,
   ProductSeeder,
+  SellerPayoutSeeder,
   TransactionSeeder, TransferSeeder,
   UserSeeder,
   VatGroupSeeder,
 } from '../../seed';
 import sinon from 'sinon';
+import SellerPayout from '../../../src/entity/transactions/payout/seller-payout';
 
 describe('TransferService', async (): Promise<void> => {
   let ctx: {
@@ -51,6 +53,7 @@ describe('TransferService', async (): Promise<void> => {
     specification: SwaggerSpecification,
     users: User[],
     transfers: Transfer[],
+    sellerPayouts: SellerPayout[],
     vatGroups: VatGroup[],
   };
   before(async () => {
@@ -67,13 +70,19 @@ describe('TransferService', async (): Promise<void> => {
     const { pointOfSaleRevisions } = await new PointOfSaleSeeder().seed(users, containerRevisions);
     const transfers = await new TransferSeeder().seed(users, begin, end);
     const { transactions } = await new TransactionSeeder().seed(users, pointOfSaleRevisions, begin, end);
+    const subTransactions = transactions.map((t) => t.subTransactions).flat();
     const { invoiceTransfers } = await new InvoiceSeeder().seed(users, transactions);
     const { payoutRequestTransfers } = await new PayoutRequestSeeder().seed(users);
     const { stripeDepositTransfers } = await new DepositSeeder().seed(users);
+    const { sellerPayouts, transfers: sellerPayoutTransfers } = await new SellerPayoutSeeder()
+      .seed(users, transactions, subTransactions, transfers);
 
-    const transfers2 = transfers.concat(invoiceTransfers).concat(payoutRequestTransfers).concat(stripeDepositTransfers);
+    const transfers2 = transfers.concat(invoiceTransfers).concat(payoutRequestTransfers).concat(stripeDepositTransfers).concat(sellerPayoutTransfers);
 
     const { users: users2, fineTransfers } = await new FineSeeder().seed(users, transactions, transfers, true);
+
+    // Sanity check: seeder must produce at least one seller payout
+    if (sellerPayouts.length === 0) throw new Error('SellerPayoutSeeder produced no payouts — check seed data');
 
     // start app
     const app = express();
@@ -86,6 +95,7 @@ describe('TransferService', async (): Promise<void> => {
       app,
       specification,
       users: users2,
+      sellerPayouts,
       vatGroups,
       transfers: transfers2.concat(fineTransfers),
     };
@@ -206,6 +216,16 @@ describe('TransferService', async (): Promise<void> => {
       expect(records[0].payoutRequest).to.not.be.null;
     });
 
+    it('should return corresponding sellerPayout if transfer has any', async () => {
+      const sellerPayoutTransfer = ctx.sellerPayouts[0].transfer;
+      expect(sellerPayoutTransfer).to.not.be.undefined;
+      const [records] = await new TransferService()
+        .getTransfers({ id: sellerPayoutTransfer.id });
+      expect(records.length).to.equal(1);
+      expect(records[0].sellerPayout).to.not.be.null;
+      expect(records[0].sellerPayout.id).to.equal(ctx.sellerPayouts[0].id);
+    });
+
     it('should return corresponding fine if transfer has any', async () => {
       const transfer = ctx.transfers.filter((t) => t.fine != null)[0];
       expect(transfer).to.not.be.undefined;
@@ -314,7 +334,7 @@ describe('TransferService', async (): Promise<void> => {
   describe('deleteTransfer function', () => {
     it('should successfully delete a transfer with no relations', async () => {
       // Find a transfer that has no relations
-      const transfer = ctx.transfers.find((t) => !t.invoice && !t.deposit && !t.payoutRequest && !t.fine && !t.writeOff && !t.waivedFines && !t.inactiveAdministrativeCost);
+      const transfer = ctx.transfers.find((t) => !t.invoice && !t.deposit && !t.payoutRequest && !t.sellerPayout && !t.fine && !t.writeOff && !t.waivedFines && !t.inactiveAdministrativeCost);
       expect(transfer).to.not.be.undefined;
 
       const transferCount = await Transfer.count();
@@ -354,6 +374,22 @@ describe('TransferService', async (): Promise<void> => {
 
       expect(await Transfer.count()).to.equal(transferCount);
       expect(await Transfer.findOne({ where: { id: transfer.id } })).to.not.be.null;
+    });
+
+    it('should throw error when trying to delete a transfer with sellerPayout relation', async () => {
+      const sellerPayoutTransfer = ctx.sellerPayouts[0].transfer;
+      expect(sellerPayoutTransfer).to.not.be.undefined;
+
+      const transferCount = await Transfer.count();
+      try {
+        await new TransferService().deleteTransfer(sellerPayoutTransfer.id);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error.message).to.equal('Cannot delete transfer because it is referenced by another entity');
+      }
+
+      expect(await Transfer.count()).to.equal(transferCount);
+      expect(await Transfer.findOne({ where: { id: sellerPayoutTransfer.id } })).to.not.be.null;
     });
 
     it('should throw error when trying to delete a transfer with deposit relation', async () => {


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the title above. -->

# Description
Transfer lacked an inverse `@OneToOne` back to SellerPayout, so the sellerPayout field was never loaded or serialised. This caused the frontend to fall back to displaying seller payouts as deposits.


## Related issues/external references
Closes #810 

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_