### PR TITLE
Add summary endpoint and CREDIT_INVOICE type

### DIFF
--- a/src/controller/response/transfer-response.ts
+++ b/src/controller/response/transfer-response.ts
@@ -93,3 +93,33 @@ export interface TransferAggregateResponse {
   total: DineroObjectResponse;
   count: number;
 }
+
+/**
+ * @typedef {object} TransferSummaryResponse
+ * @property {TransferAggregateResponse} total.required - Aggregate over all transfers
+ * @property {TransferAggregateResponse} deposits.required - Aggregate over deposit transfers
+ * @property {TransferAggregateResponse} payoutRequests.required - Aggregate over payout-request transfers
+ * @property {TransferAggregateResponse} sellerPayouts.required - Aggregate over seller-payout transfers
+ * @property {TransferAggregateResponse} invoices.required - Aggregate over invoice transfers (excluding credited/deleted invoices)
+ * @property {TransferAggregateResponse} creditInvoices.required - Aggregate over credit-invoice (reversal) transfers
+ * @property {TransferAggregateResponse} fines.required - Aggregate over fine transfers
+ * @property {TransferAggregateResponse} waivedFines.required - Aggregate over waived-fines transfers
+ * @property {TransferAggregateResponse} writeOffs.required - Aggregate over write-off transfers
+ * @property {TransferAggregateResponse} inactiveAdministrativeCosts.required - Aggregate over inactive-administrative-cost transfers
+ * @property {TransferAggregateResponse} manualCreations.required - Aggregate over orphaned transfers where fromId is null (money entering the system without a linked entity)
+ * @property {TransferAggregateResponse} manualDeletions.required - Aggregate over orphaned transfers where toId is null (money leaving the system without a linked entity)
+ */
+export interface TransferSummaryResponse {
+  total: TransferAggregateResponse;
+  deposits: TransferAggregateResponse;
+  payoutRequests: TransferAggregateResponse;
+  sellerPayouts: TransferAggregateResponse;
+  invoices: TransferAggregateResponse;
+  creditInvoices: TransferAggregateResponse;
+  fines: TransferAggregateResponse;
+  waivedFines: TransferAggregateResponse;
+  writeOffs: TransferAggregateResponse;
+  inactiveAdministrativeCosts: TransferAggregateResponse;
+  manualCreations: TransferAggregateResponse;
+  manualDeletions: TransferAggregateResponse;
+}

--- a/src/controller/transfer-controller.ts
+++ b/src/controller/transfer-controller.ts
@@ -29,7 +29,7 @@ import log4js, { Logger } from 'log4js';
 import BaseController, { BaseControllerOptions } from './base-controller';
 import Policy from './policy';
 import { RequestWithToken } from '../middleware/token-middleware';
-import TransferService, { parseGetTransferAggregateFilters, parseGetTransferFilters } from '../service/transfer-service';
+import TransferService, { parseGetTransferAggregateFilters, parseGetTransferFilters, parseGetTransferSummaryFilters } from '../service/transfer-service';
 import TransferRequest from './request/transfer-request';
 import Transfer from '../entity/transactions/transfer';
 import { parseRequestPagination, toResponse } from '../helpers/pagination';
@@ -54,6 +54,12 @@ export default class TransferController extends BaseController {
         GET: {
           policy: async (req) => this.roleManager.can(req.token.roles, 'get', 'all', 'Transfer', ['*']),
           handler: this.returnTransferAggregate.bind(this),
+        },
+      },
+      '/summary': {
+        GET: {
+          policy: async (req) => this.roleManager.can(req.token.roles, 'get', 'all', 'Transfer', ['*']),
+          handler: this.returnTransferSummary.bind(this),
         },
       },
       '/': {
@@ -118,7 +124,7 @@ export default class TransferController extends BaseController {
    * @param {string} tillDate.query - End date for selected transfers (exclusive)
    * @param {integer} fromId.query - Filter transfers from this user ID
    * @param {integer} toId.query - Filter transfers to this user ID
-   * @param {string} category.query - Restrict to a specific transfer category: deposit, payoutRequest, invoice, fine, waivedFines, writeOff, inactiveAdministrativeCost
+   * @param {string} category.query - Restrict to a specific transfer category: deposit, payoutRequest, sellerPayout, invoice, creditInvoice, fine, waivedFines, writeOff, inactiveAdministrativeCost
    * @return {TransferAggregateResponse} 200 - Aggregate sum and count of matching transfers
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
@@ -139,6 +145,53 @@ export default class TransferController extends BaseController {
       res.json({ total: total.toObject(), count });
     } catch (error) {
       this.logger.error('Could not return transfer aggregate:', error);
+      res.status(500).json('Internal server error.');
+    }
+  }
+
+  /**
+   * GET /transfers/summary
+   * @summary Returns an aggregate breakdown of transfers for every category plus an overall total
+   * @operationId getTransferSummary
+   * @tags transfers - Operations of transfer controller
+   * @security JWT
+   * @param {string} fromDate.query - Start date for selected transfers (inclusive)
+   * @param {string} tillDate.query - End date for selected transfers (exclusive)
+   * @param {integer} fromId.query - Filter transfers from this user ID
+   * @param {integer} toId.query - Filter transfers to this user ID
+   * @return {TransferSummaryResponse} 200 - Per-category aggregate sums and counts
+   * @return {string} 400 - Validation error
+   * @return {string} 500 - Internal server error
+   */
+  public async returnTransferSummary(req: RequestWithToken, res: Response): Promise<void> {
+    this.logger.trace('Get transfer summary by user', req.token.user);
+
+    let filters;
+    try {
+      filters = parseGetTransferSummaryFilters(req);
+    } catch (e) {
+      res.status(400).send(e.message);
+      return;
+    }
+
+    try {
+      const summary = await new TransferService().getTransferSummary(filters);
+      res.json({
+        total: { total: summary.total.total.toObject(), count: summary.total.count },
+        deposits: { total: summary.deposits.total.toObject(), count: summary.deposits.count },
+        payoutRequests: { total: summary.payoutRequests.total.toObject(), count: summary.payoutRequests.count },
+        sellerPayouts: { total: summary.sellerPayouts.total.toObject(), count: summary.sellerPayouts.count },
+        invoices: { total: summary.invoices.total.toObject(), count: summary.invoices.count },
+        creditInvoices: { total: summary.creditInvoices.total.toObject(), count: summary.creditInvoices.count },
+        fines: { total: summary.fines.total.toObject(), count: summary.fines.count },
+        waivedFines: { total: summary.waivedFines.total.toObject(), count: summary.waivedFines.count },
+        writeOffs: { total: summary.writeOffs.total.toObject(), count: summary.writeOffs.count },
+        inactiveAdministrativeCosts: { total: summary.inactiveAdministrativeCosts.total.toObject(), count: summary.inactiveAdministrativeCosts.count },
+        manualCreations: { total: summary.manualCreations.total.toObject(), count: summary.manualCreations.count },
+        manualDeletions: { total: summary.manualDeletions.total.toObject(), count: summary.manualDeletions.count },
+      });
+    } catch (error) {
+      this.logger.error('Could not return transfer summary:', error);
       res.status(500).json('Internal server error.');
     }
   }

--- a/src/entity/invoices/invoice.ts
+++ b/src/entity/invoices/invoice.ts
@@ -150,7 +150,7 @@ export default class Invoice extends PdfAble(BaseEntity) {
   /**
    * If this invoice is deleted, this will be credit transfer.
    */
-  @OneToOne(() => Transfer, { nullable: true })
+  @OneToOne(() => Transfer, (t) => t.creditInvoice, { nullable: true })
   @JoinColumn()
   public creditTransfer?: Transfer;
 

--- a/src/entity/transactions/transfer.ts
+++ b/src/entity/transactions/transfer.ts
@@ -99,6 +99,9 @@ export default class Transfer extends UnstoredPdfAble(BaseEntity) {
   @OneToOne(() => Invoice, (i) => i.transfer, { nullable: true })
   public invoice: Invoice | null;
 
+  @OneToOne(() => Invoice, (i) => i.creditTransfer, { nullable: true })
+  public creditInvoice: Invoice | null;
+
   @OneToOne(() => Fine, (f) => f.transfer, { nullable: true })
   public fine: Fine | null;
 

--- a/src/service/transfer-service.ts
+++ b/src/service/transfer-service.ts
@@ -61,10 +61,41 @@ export enum TransferCategory {
   PAYOUT_REQUEST = 'payoutRequest',
   SELLER_PAYOUT = 'sellerPayout',
   INVOICE = 'invoice',
+  CREDIT_INVOICE = 'creditInvoice',
   FINE = 'fine',
   WAIVED_FINES = 'waivedFines',
   WRITE_OFF = 'writeOff',
   INACTIVE_ADMINISTRATIVE_COST = 'inactiveAdministrativeCost',
+  /**
+   * Orphaned transfer with no entity attached where fromId IS NULL — money entering the system
+   * without a linked deposit, invoice, etc.
+   */
+  MANUAL_CREATION = 'manualCreation',
+  /**
+   * Orphaned transfer with no entity attached where toId IS NULL — money leaving the system
+   * without a linked payout request, invoice, etc.
+   */
+  MANUAL_DELETION = 'manualDeletion',
+}
+
+export interface TransferAggregateResult {
+  total: Dinero;
+  count: number;
+}
+
+export interface TransferSummaryResult {
+  total: TransferAggregateResult;
+  deposits: TransferAggregateResult;
+  payoutRequests: TransferAggregateResult;
+  sellerPayouts: TransferAggregateResult;
+  invoices: TransferAggregateResult;
+  creditInvoices: TransferAggregateResult;
+  fines: TransferAggregateResult;
+  waivedFines: TransferAggregateResult;
+  writeOffs: TransferAggregateResult;
+  inactiveAdministrativeCosts: TransferAggregateResult;
+  manualCreations: TransferAggregateResult;
+  manualDeletions: TransferAggregateResult;
 }
 
 export interface TransferAggregateFilterParameters {
@@ -78,6 +109,15 @@ export interface TransferAggregateFilterParameters {
 export function parseGetTransferFilters(req: RequestWithToken): TransferFilterParameters {
   return {
     id: asNumber(req.query.id),
+    fromId: asNumber(req.query.fromId),
+    toId: asNumber(req.query.toId),
+    fromDate: asDate(req.query.fromDate),
+    tillDate: asDate(req.query.tillDate),
+  };
+}
+
+export function parseGetTransferSummaryFilters(req: RequestWithToken): Omit<TransferAggregateFilterParameters, 'category'> {
+  return {
     fromId: asNumber(req.query.fromId),
     toId: asNumber(req.query.toId),
     fromDate: asDate(req.query.fromDate),
@@ -242,12 +282,13 @@ export default class TransferService extends WithManager {
    * The aggregation is performed entirely on the database side.
    * @param filters - Optional filters to narrow the set of transfers
    */
-  public async getTransferAggregate(filters: TransferAggregateFilterParameters = {}): Promise<{ total: Dinero, count: number }> {
-    const categoryRelationMap: Record<TransferCategory, string> = {
+  public async getTransferAggregate(filters: TransferAggregateFilterParameters = {}): Promise<TransferAggregateResult> {
+    const categoryRelationMap: Partial<Record<TransferCategory, string>> = {
       [TransferCategory.DEPOSIT]: 'deposit',
       [TransferCategory.PAYOUT_REQUEST]: 'payoutRequest',
       [TransferCategory.SELLER_PAYOUT]: 'sellerPayout',
       [TransferCategory.INVOICE]: 'invoice',
+      [TransferCategory.CREDIT_INVOICE]: 'creditInvoice',
       [TransferCategory.FINE]: 'fine',
       [TransferCategory.WAIVED_FINES]: 'waivedFines',
       [TransferCategory.WRITE_OFF]: 'writeOff',
@@ -257,8 +298,22 @@ export default class TransferService extends WithManager {
     let query = this.manager.createQueryBuilder(Transfer, 'transfer');
 
     if (filters.category !== undefined) {
-      const rel = categoryRelationMap[filters.category];
-      query = query.innerJoin(`transfer.${rel}`, rel);
+      switch (filters.category) {
+        case TransferCategory.MANUAL_CREATION:
+          query = query.andWhere('transfer.fromId IS NULL');
+          break;
+        case TransferCategory.MANUAL_DELETION:
+          query = query.andWhere('transfer.toId IS NULL');
+          break;
+        default: {
+          const rel = categoryRelationMap[filters.category];
+          if (!rel) throw new Error(`Unsupported transfer category: ${filters.category}`);
+          query = query.innerJoin(`transfer.${rel}`, rel);
+          if (filters.category === TransferCategory.INVOICE) {
+            query = query.andWhere('invoice.creditTransferId IS NULL');
+          }
+        }
+      }
     }
 
     if (filters.fromId !== undefined) {
@@ -285,17 +340,41 @@ export default class TransferService extends WithManager {
     };
   }
 
+  /**
+   * Returns an aggregate breakdown of transfers for every category plus an overall total.
+   * All filters except `category` are forwarded to each per-category query.
+   * @param filters - Optional filters (fromId, toId, fromDate, tillDate)
+   */
+  public async getTransferSummary(filters: Omit<TransferAggregateFilterParameters, 'category'> = {}): Promise<TransferSummaryResult> {
+    const [total, deposits, payoutRequests, sellerPayouts, invoices, creditInvoices, fines, waivedFines, writeOffs, inactiveAdministrativeCosts, manualCreations, manualDeletions] = await Promise.all([
+      this.getTransferAggregate(filters),
+      this.getTransferAggregate({ ...filters, category: TransferCategory.DEPOSIT }),
+      this.getTransferAggregate({ ...filters, category: TransferCategory.PAYOUT_REQUEST }),
+      this.getTransferAggregate({ ...filters, category: TransferCategory.SELLER_PAYOUT }),
+      this.getTransferAggregate({ ...filters, category: TransferCategory.INVOICE }),
+      this.getTransferAggregate({ ...filters, category: TransferCategory.CREDIT_INVOICE }),
+      this.getTransferAggregate({ ...filters, category: TransferCategory.FINE }),
+      this.getTransferAggregate({ ...filters, category: TransferCategory.WAIVED_FINES }),
+      this.getTransferAggregate({ ...filters, category: TransferCategory.WRITE_OFF }),
+      this.getTransferAggregate({ ...filters, category: TransferCategory.INACTIVE_ADMINISTRATIVE_COST }),
+      this.getTransferAggregate({ ...filters, category: TransferCategory.MANUAL_CREATION }),
+      this.getTransferAggregate({ ...filters, category: TransferCategory.MANUAL_DELETION }),
+    ]);
+
+    return { total, deposits, payoutRequests, sellerPayouts, invoices, creditInvoices, fines, waivedFines, writeOffs, inactiveAdministrativeCosts, manualCreations, manualDeletions };
+  }
+
   public async deleteTransfer(id: number): Promise<void> {
     const transfer = await this.manager.findOne(Transfer, {
       where: { id },
-      relations: ['from', 'to', 'payoutRequest', 'sellerPayout', 'deposit', 'invoice', 'fine', 'writeOff', 'waivedFines', 'inactiveAdministrativeCost'],
+      relations: ['from', 'to', 'payoutRequest', 'sellerPayout', 'deposit', 'invoice', 'creditInvoice', 'fine', 'writeOff', 'waivedFines', 'inactiveAdministrativeCost'],
     });
 
     if (!transfer) {
       throw new Error('Transfer not found');
     }
 
-    if (transfer.payoutRequest || transfer.sellerPayout || transfer.deposit || transfer.invoice || transfer.fine || transfer.writeOff || transfer.waivedFines || transfer.inactiveAdministrativeCost) {
+    if (transfer.payoutRequest || transfer.sellerPayout || transfer.deposit || transfer.invoice || transfer.creditInvoice || transfer.fine || transfer.writeOff || transfer.waivedFines || transfer.inactiveAdministrativeCost) {
       throw new Error('Cannot delete transfer because it is referenced by another entity');
     }
 

--- a/test/unit/controller/transfer-controller.ts
+++ b/test/unit/controller/transfer-controller.ts
@@ -783,6 +783,7 @@ describe('TransferController', async (): Promise<void> => {
   });
 
   describe('GET /transfers/aggregate', () => {
+    let creditInvoiceTransfer: Transfer;
 
     before(async () => {
       const user1 = ctx.users[0];
@@ -812,6 +813,40 @@ describe('TransferController', async (): Promise<void> => {
 
       depositTransferEntity.deposit = deposit;
       await Transfer.save(depositTransferEntity);
+
+      // Create a credited invoice so that creditInvoice category tests have data
+      const invoiceTransfer = await Transfer.save(Object.assign(new Transfer(), {
+        toId: user1.id,
+        amountInclVat: DineroTransformer.Instance.from(750),
+        description: 'Invoice transfer for credit aggregate test',
+        version: 1,
+      }));
+
+      creditInvoiceTransfer = await Transfer.save(Object.assign(new Transfer(), {
+        fromId: user1.id,
+        amountInclVat: DineroTransformer.Instance.from(750),
+        description: 'Credit invoice transfer for aggregate test',
+        version: 1,
+      }));
+
+      const invoice = Object.assign(new Invoice(), {
+        to: user1,
+        addressee: user1.firstName,
+        reference: 'CTRL-AGG-CREDIT-001',
+        city: 'Eindhoven',
+        country: 'Netherlands',
+        postalCode: '5612 AE',
+        street: 'Test Street 1',
+        description: 'Aggregate test credited invoice',
+        transfer: invoiceTransfer,
+        creditTransfer: creditInvoiceTransfer,
+        date: new Date(),
+        subTransactionRows: [],
+        invoiceStatus: [],
+      });
+      const savedInvoice = await Invoice.save(invoice);
+      invoiceTransfer.invoice = savedInvoice;
+      await Transfer.save(invoiceTransfer);
     });
 
     it('should return HTTP 200 with a valid model', async () => {
@@ -929,6 +964,43 @@ describe('TransferController', async (): Promise<void> => {
       expect(restrictedRes.body.count).to.be.lessThan(totalCount);
     });
 
+    it('should filter by creditInvoice category', async () => {
+      const creditInvoiceTransfers = await Transfer.createQueryBuilder('transfer')
+        .innerJoin('transfer.creditInvoice', 'creditInvoice')
+        .getMany();
+      const expectedCount = creditInvoiceTransfers.length;
+      const expectedTotal = creditInvoiceTransfers.reduce(
+        (sum, t) => sum + t.amountInclVat.getAmount(), 0,
+      );
+
+      const res = await request(app)
+        .get('/transfers/aggregate')
+        .query({ category: 'creditInvoice' })
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.count).to.equal(expectedCount);
+      expect(res.body.count).to.be.greaterThan(0);
+      expect(res.body.total.amount).to.equal(expectedTotal);
+    });
+
+    it('should not count the credited invoice transfer under the invoice category', async () => {
+      const invoiceTransfers = await Transfer.createQueryBuilder('transfer')
+        .innerJoin('transfer.invoice', 'invoice')
+        .where('invoice.creditTransferId IS NULL')
+        .getMany();
+
+      const res = await request(app)
+        .get('/transfers/aggregate')
+        .query({ category: 'invoice' })
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.count).to.equal(invoiceTransfers.length);
+      // The creditInvoiceTransfer itself (the reversal) must not appear here
+      expect(invoiceTransfers.map((t) => t.id)).to.not.include(creditInvoiceTransfer.id);
+    });
+
     it('should return HTTP 400 for an invalid category', async () => {
       const res = await request(app)
         .get('/transfers/aggregate')
@@ -944,6 +1016,77 @@ describe('TransferController', async (): Promise<void> => {
         .set('Authorization', `Bearer ${token}`);
 
       expect(res.status).to.equal(403);
+    });
+  });
+
+  describe('GET /transfers/summary', () => {
+    it('should return HTTP 200 with a valid model', async () => {
+      const res = await request(app)
+        .get('/transfers/summary')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).to.equal(200);
+      expect(specification.validateModel(
+        'TransferSummaryResponse',
+        res.body,
+        false,
+        true,
+      ).valid).to.be.true;
+    });
+
+    it('should return HTTP 403 if user does not have Transfer:get:all permission', async () => {
+      const res = await request(app)
+        .get('/transfers/summary')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).to.equal(403);
+    });
+
+    it('should return overall total matching the unfiltered aggregate', async () => {
+      const allTransfers = await Transfer.find();
+      const expectedTotal = allTransfers.reduce(
+        (sum, t) => sum + t.amountInclVat.getAmount(), 0,
+      );
+
+      const res = await request(app)
+        .get('/transfers/summary')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.total.count).to.equal(allTransfers.length);
+      expect(res.body.total.total.amount).to.equal(expectedTotal);
+    });
+
+    it('should report credited invoices under creditInvoices, not invoices', async () => {
+      const invoiceTransfers = await Transfer.createQueryBuilder('transfer')
+        .innerJoin('transfer.invoice', 'invoice')
+        .where('invoice.creditTransferId IS NULL')
+        .getMany();
+      const creditInvoiceTransfers = await Transfer.createQueryBuilder('transfer')
+        .innerJoin('transfer.creditInvoice', 'creditInvoice')
+        .getMany();
+
+      const res = await request(app)
+        .get('/transfers/summary')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.invoices.count).to.equal(invoiceTransfers.length);
+      expect(res.body.creditInvoices.count).to.equal(creditInvoiceTransfers.length);
+      expect(res.body.creditInvoices.count).to.be.greaterThan(0);
+    });
+
+    it('should filter by fromId across all categories', async () => {
+      const user1 = ctx.users[0];
+      const fromUser1 = await Transfer.find({ where: { fromId: user1.id } });
+
+      const res = await request(app)
+        .get('/transfers/summary')
+        .query({ fromId: user1.id })
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.total.count).to.equal(fromUser1.length);
     });
   });
 });

--- a/test/unit/service/transfer-service.ts
+++ b/test/unit/service/transfer-service.ts
@@ -28,7 +28,8 @@ import TransferRequest from '../../../src/controller/request/transfer-request';
 import Database from '../../../src/database/database';
 import Transfer from '../../../src/entity/transactions/transfer';
 import User from '../../../src/entity/user/user';
-import TransferService from '../../../src/service/transfer-service';
+import TransferService, { TransferCategory } from '../../../src/service/transfer-service';
+import Invoice from '../../../src/entity/invoices/invoice';
 import Swagger from '../../../src/start/swagger';
 import DineroTransformer from '../../../src/entity/transformer/dinero-transformer';
 import { truncateAllTables } from '../../setup';
@@ -434,6 +435,159 @@ describe('TransferService', async (): Promise<void> => {
       } catch (error) {
         expect(error.message).to.equal('Transfer not found');
       }
+    });
+  });
+
+  describe('getTransferAggregate function', async () => {
+    let creditInvoiceTransfer: Transfer;
+    let originalInvoiceTransfer: Transfer;
+
+    before(async () => {
+      const user = ctx.users[0];
+
+      originalInvoiceTransfer = await Transfer.save(Object.assign(new Transfer(), {
+        to: user,
+        amountInclVat: DineroTransformer.Instance.from(1000),
+        description: 'Invoice transfer for aggregate test',
+      }));
+
+      creditInvoiceTransfer = await Transfer.save(Object.assign(new Transfer(), {
+        from: user,
+        amountInclVat: DineroTransformer.Instance.from(1000),
+        description: 'Credit invoice transfer for aggregate test',
+      }));
+
+      const invoice = Object.assign(new Invoice(), {
+        to: user,
+        addressee: user.firstName,
+        reference: 'SVC-AGG-CREDIT-001',
+        city: 'Eindhoven',
+        country: 'Netherlands',
+        postalCode: '5612 AE',
+        street: 'Test Street 1',
+        description: 'Aggregate test credited invoice',
+        transfer: originalInvoiceTransfer,
+        creditTransfer: creditInvoiceTransfer,
+        date: new Date(),
+        subTransactionRows: [],
+        invoiceStatus: [],
+      });
+      const savedInvoice = await Invoice.save(invoice);
+      originalInvoiceTransfer.invoice = savedInvoice;
+      await Transfer.save(originalInvoiceTransfer);
+    });
+
+    it('should return the total and count for all transfers', async () => {
+      const allTransfers = await Transfer.find();
+      const result = await new TransferService().getTransferAggregate();
+      expect(result.count).to.equal(allTransfers.length);
+      const expectedTotal = allTransfers.reduce((sum, t) => sum + t.amountInclVat.getAmount(), 0);
+      expect(result.total.getAmount()).to.equal(expectedTotal);
+    });
+
+    it('should exclude credited invoice transfers from the INVOICE category', async () => {
+      const invoiceTransfers = await Transfer.createQueryBuilder('transfer')
+        .innerJoin('transfer.invoice', 'invoice')
+        .where('invoice.creditTransferId IS NULL')
+        .getMany();
+
+      const result = await new TransferService().getTransferAggregate({ category: TransferCategory.INVOICE });
+      expect(result.count).to.equal(invoiceTransfers.length);
+      expect(result.total.getAmount()).to.equal(
+        invoiceTransfers.reduce((sum, t) => sum + t.amountInclVat.getAmount(), 0),
+      );
+    });
+
+    it('should return only credit invoice transfers for the CREDIT_INVOICE category', async () => {
+      const creditTransfers = await Transfer.createQueryBuilder('transfer')
+        .innerJoin('transfer.creditInvoice', 'creditInvoice')
+        .getMany();
+
+      const result = await new TransferService().getTransferAggregate({ category: TransferCategory.CREDIT_INVOICE });
+      expect(result.count).to.equal(creditTransfers.length);
+      expect(result.count).to.be.greaterThan(0);
+      expect(result.total.getAmount()).to.equal(
+        creditTransfers.reduce((sum, t) => sum + t.amountInclVat.getAmount(), 0),
+      );
+    });
+
+    it('should not count the credited invoice original transfer under CREDIT_INVOICE', async () => {
+      const creditInvoiceIds = (await Transfer.createQueryBuilder('transfer')
+        .innerJoin('transfer.creditInvoice', 'creditInvoice')
+        .select('transfer.id')
+        .getMany()).map((t) => t.id);
+
+      // The credit transfer itself should be listed; the original invoice transfer should not
+      expect(creditInvoiceIds).to.include(creditInvoiceTransfer.id);
+      expect(creditInvoiceIds).to.not.include(originalInvoiceTransfer.id);
+    });
+
+    it('should return all transfers with null fromId for the MANUAL_CREATION category', async () => {
+      const manualCreations = await Transfer.createQueryBuilder('transfer')
+        .where('transfer.fromId IS NULL')
+        .getMany();
+
+      const result = await new TransferService().getTransferAggregate({ category: TransferCategory.MANUAL_CREATION });
+      expect(result.count).to.equal(manualCreations.length);
+      expect(result.count).to.be.greaterThan(0);
+      expect(result.total.getAmount()).to.equal(
+        manualCreations.reduce((sum, t) => sum + t.amountInclVat.getAmount(), 0),
+      );
+    });
+
+    it('should return all transfers with null toId for the MANUAL_DELETION category', async () => {
+      const manualDeletions = await Transfer.createQueryBuilder('transfer')
+        .where('transfer.toId IS NULL')
+        .getMany();
+
+      const result = await new TransferService().getTransferAggregate({ category: TransferCategory.MANUAL_DELETION });
+      expect(result.count).to.equal(manualDeletions.length);
+      expect(result.count).to.be.greaterThan(0);
+      expect(result.total.getAmount()).to.equal(
+        manualDeletions.reduce((sum, t) => sum + t.amountInclVat.getAmount(), 0),
+      );
+    });
+  });
+
+  describe('getTransferSummary function', async () => {
+    it('should contain all expected category keys', async () => {
+      const summary = await new TransferService().getTransferSummary();
+      expect(summary).to.have.all.keys([
+        'total', 'deposits', 'payoutRequests', 'sellerPayouts',
+        'invoices', 'creditInvoices', 'fines', 'waivedFines',
+        'writeOffs', 'inactiveAdministrativeCosts', 'manualCreations', 'manualDeletions',
+      ]);
+    });
+
+    it('should match the unfiltered aggregate for the overall total', async () => {
+      const [aggregate, summary] = await Promise.all([
+        new TransferService().getTransferAggregate(),
+        new TransferService().getTransferSummary(),
+      ]);
+      expect(summary.total.count).to.equal(aggregate.count);
+      expect(summary.total.total.getAmount()).to.equal(aggregate.total.getAmount());
+    });
+
+    it('should match per-category aggregates for invoices and creditInvoices', async () => {
+      const [invoiceAggregate, creditInvoiceAggregate, summary] = await Promise.all([
+        new TransferService().getTransferAggregate({ category: TransferCategory.INVOICE }),
+        new TransferService().getTransferAggregate({ category: TransferCategory.CREDIT_INVOICE }),
+        new TransferService().getTransferSummary(),
+      ]);
+      expect(summary.invoices.count).to.equal(invoiceAggregate.count);
+      expect(summary.invoices.total.getAmount()).to.equal(invoiceAggregate.total.getAmount());
+      expect(summary.creditInvoices.count).to.equal(creditInvoiceAggregate.count);
+      expect(summary.creditInvoices.total.getAmount()).to.equal(creditInvoiceAggregate.total.getAmount());
+    });
+
+    it('should apply filters across all categories', async () => {
+      const user = ctx.users[0];
+      const [aggregate, summary] = await Promise.all([
+        new TransferService().getTransferAggregate({ fromId: user.id }),
+        new TransferService().getTransferSummary({ fromId: user.id }),
+      ]);
+      expect(summary.total.count).to.equal(aggregate.count);
+      expect(summary.total.total.getAmount()).to.equal(aggregate.total.getAmount());
     });
   });
 


### PR DESCRIPTION

# Description
Adds a `summary` endpoint to transfers, which combines all the aggregations. Also adds `CREDIT_INVOICE` as an transfer type.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
=
- New feature _(non-breaking change which adds functionality)_
