### PR TITLE
Add description filter to invoice search

### DIFF
--- a/src/controller/invoice-controller.ts
+++ b/src/controller/invoice-controller.ts
@@ -136,6 +136,7 @@ export default class InvoiceController extends BaseController {
    * @param {boolean} returnEntries.query - Boolean if invoice entries should be returned
    * @param {string} fromDate.query - Start date for selected invoices (inclusive)
    * @param {string} tillDate.query - End date for selected invoices (exclusive)
+   * @param {string} description.query - Filter invoices by description (partial match)
    * @param {integer} take.query - How many entries the endpoint should return
    * @param {integer} skip.query - How many entries should be skipped (for pagination)
    * @return {PaginatedInvoiceResponse} 200 - All existing invoices

--- a/src/helpers/query-filter.ts
+++ b/src/helpers/query-filter.ts
@@ -106,7 +106,7 @@ export default class QueryFilter {
         const split = property.split('.');
         if (split.length === 1 && property.substring(0, 1) === '%') {
           // No dot, so no nested where clause. However, search starts with a "%"
-          where[property.substring(1)] = Like(`%${value}%`);
+          where[property.replace(/^%|%$/g, '')] = Like(`%${value}%`);
         } else if (split.length === 1) {
           // No dot, so no nested where clause and no LIKE-search
           where[property] = value;

--- a/src/service/invoice-service.ts
+++ b/src/service/invoice-service.ts
@@ -87,6 +87,10 @@ export interface InvoiceFilterParameters {
    * Filter based on till date,
    */
   tillDate?: Date
+  /**
+   * Filter based on a partial match of the invoice description.
+   */
+  description?: string;
 }
 
 
@@ -98,6 +102,7 @@ export function parseInvoiceFilterParameters(req: RequestWithToken): InvoiceFilt
     returnInvoiceEntries: asBoolean(req.query.returnInvoiceEntries),
     fromDate: asDate(req.query.fromDate),
     tillDate: asDate(req.query.tillDate),
+    description: typeof req.query.description === 'string' ? req.query.description : undefined,
   };
 }
 
@@ -526,6 +531,7 @@ export default class InvoiceService extends WithManager {
       currentState: 'currentState',
       toId: 'toId',
       invoiceId: 'id',
+      description: '%description%',
     };
 
     let stateFilter: FindOptionsWhere<Invoice> = { };

--- a/test/unit/service/invoice-service.ts
+++ b/test/unit/service/invoice-service.ts
@@ -155,6 +155,21 @@ describe('InvoiceService', () => {
       );
       returnsAll(res, [ctx.invoices[0]], keyMapping);
     });
+    it('should return invoices whose description contains the search term', async () => {
+      const target = ctx.invoices[0];
+      // Use a mid-string slice to ensure LIKE '%term%' (not just a prefix match)
+      const start = Math.floor(target.description.length / 2);
+      const substring = target.description.substring(start, start + 4);
+      const res = await new InvoiceService().getInvoices({ description: substring });
+      expect(res.length).to.be.greaterThan(0);
+      res.forEach((inv) => {
+        expect(inv.description.toLowerCase()).to.include(substring.toLowerCase());
+      });
+    });
+    it('should return no invoices when the description does not match', async () => {
+      const res = await new InvoiceService().getInvoices({ description: '__no_match_xyzzy__' });
+      expect(res).to.be.empty;
+    });
   });
   describe('getDefaultInvoiceParams function', () => {
     it('should return the default invoice parameters for an invoice user', async () => {


### PR DESCRIPTION
## Summary

- Adds optional `description` query parameter to `GET /invoices` for partial (LIKE) match on the invoice description column
- Extends `QueryFilter.createFilterWhereClause` to support `%property%` notation (strips both delimiters), making LIKE mappings self-documenting while remaining backward-compatible with existing `%property` entries
- Updates OpenAPI/JSDoc on `getAllInvoices` for the new parameter
- Adds two tests: positive substring match and no-match (empty result)

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run lint` — no lint warnings
- [x] New tests pass: partial description match returns correct invoices; nonsense string returns empty
- [x] `GET /v1/invoices?description=foo` returns only invoices whose description contains "foo"

Closes #811