### PR TITLE
Add drift detection endpoint for invoice transfer amounts

### DIFF
--- a/src/controller/invoice-controller.ts
+++ b/src/controller/invoice-controller.ts
@@ -121,6 +121,12 @@ export default class InvoiceController extends BaseController {
           handler: this.getEligibleTransactions.bind(this),
         },
       },
+      '/drift': {
+        GET: {
+          policy: async (req) => this.roleManager.can(req.token.roles, 'get', 'all', 'Invoice', ['*']),
+          handler: this.getDriftedInvoices.bind(this),
+        },
+      },
     };
   }
 
@@ -536,6 +542,26 @@ export default class InvoiceController extends BaseController {
     }
   }
 
+
+  /**
+   * GET /invoices/drift
+   * @summary Returns all invoices with transfer amount drift: for active invoices transfer != row sum; for deleted invoices transfer != credit transfer.
+   * @operationId getInvoiceDrift
+   * @tags invoices - Operations of the invoices controller
+   * @security JWT
+   * @return {Array<InvoiceDriftResponse>} 200 - All invoices with transfer amount drift
+   * @return {string} 500 - Internal server error
+   */
+  public async getDriftedInvoices(req: RequestWithToken, res: Response): Promise<void> {
+    this.logger.trace('Get drifted invoices by user', req.token.user);
+    try {
+      const results = await new InvoiceService().findDriftedInvoices();
+      res.json(results.map(InvoiceService.asInvoiceDriftResponse));
+    } catch (error) {
+      this.logger.error('Could not return drifted invoices:', error);
+      res.status(500).json('Internal server error.');
+    }
+  }
 
   /**
    * Function to determine which credentials are needed to get invoice

--- a/src/controller/response/invoice-response.ts
+++ b/src/controller/response/invoice-response.ts
@@ -119,3 +119,17 @@ export interface PaginatedInvoiceResponse {
   _pagination: PaginationResult,
   records: InvoiceResponseTypes[],
 }
+
+/**
+ * @typedef {object} InvoiceDriftResponse
+ * @property {BaseInvoiceResponse} invoice.required - The invoice whose transfer amount has drifted.
+ * @property {DineroObjectResponse} actualAmount.required - The transfer amount currently recorded.
+ * @property {DineroObjectResponse} expectedAmount.required - For non-deleted invoices: sum of sub-transaction row totals. For deleted invoices: the credit transfer amount.
+ * @property {DineroObjectResponse} deltaAmount.required - The difference between actual and expected (actual − expected).
+ */
+export interface InvoiceDriftResponse {
+  invoice: BaseInvoiceResponse;
+  actualAmount: DineroObjectResponse;
+  expectedAmount: DineroObjectResponse;
+  deltaAmount: DineroObjectResponse;
+}

--- a/src/service/invoice-service.ts
+++ b/src/service/invoice-service.ts
@@ -34,6 +34,7 @@ import {
 import InvoiceStatus, { InvoiceState } from '../entity/invoices/invoice-status';
 import {
   BaseInvoiceResponse,
+  InvoiceDriftResponse,
   InvoiceEntryResponse,
   InvoiceResponse,
   InvoiceStatusResponse,
@@ -61,6 +62,7 @@ import InvoiceUser, { InvoiceUserDefaults } from '../entity/user/invoice-user';
 import Transfer from '../entity/transactions/transfer';
 import WithManager from '../database/with-manager';
 import DineroTransformer from '../entity/transformer/dinero-transformer';
+import { Dinero } from 'dinero.js';
 
 export interface InvoiceFilterParameters {
   /**
@@ -106,6 +108,13 @@ export function parseInvoiceFilterParameters(req: RequestWithToken): InvoiceFilt
   };
 }
 
+
+export interface InvoiceDriftResult {
+  invoice: Invoice;
+  actualAmount: Dinero;
+  expectedAmount: Dinero;
+  deltaAmount: Dinero;
+}
 
 export default class InvoiceService extends WithManager {
   /**
@@ -612,5 +621,66 @@ export default class InvoiceService extends WithManager {
     });
 
     return Array.from(invoiceMap.values());
+  }
+
+  /**
+   * Returns all invoices with a transfer amount drift:
+   * - Non-deleted invoices: transfer.amountInclVat != sum(row.amount * row.product.priceInclVat)
+   * - Deleted invoices: transfer.amountInclVat != creditTransfer.amountInclVat
+   *   (the credit transfer should fully reverse the original)
+   */
+  public async findDriftedInvoices(): Promise<InvoiceDriftResult[]> {
+    const invoices = await this.manager.find(Invoice, {
+      relations: {
+        to: true,
+        invoiceStatus: true,
+        transfer: { to: true, from: true },
+        creditTransfer: { to: true, from: true },
+        pdf: true,
+        subTransactionRows: { product: true },
+      },
+    });
+
+    const results: InvoiceDriftResult[] = [];
+
+    for (const invoice of invoices) {
+      if (!invoice.transfer) continue;
+
+      const actualCents = invoice.transfer.amountInclVat.getAmount();
+      let expectedCents: number;
+
+      if (InvoiceService.isState(invoice, InvoiceState.DELETED)) {
+        // For deleted invoices the credit transfer should fully reverse the original
+        if (!invoice.creditTransfer) continue;
+        expectedCents = invoice.creditTransfer.amountInclVat.getAmount();
+      } else {
+        expectedCents = invoice.subTransactionRows.reduce(
+          (sum, row) => sum + row.amount * row.product.priceInclVat.getAmount(),
+          0,
+        );
+      }
+
+      const deltaCents = actualCents - expectedCents;
+
+      if (deltaCents !== 0) {
+        results.push({
+          invoice,
+          actualAmount: DineroTransformer.Instance.from(actualCents),
+          expectedAmount: DineroTransformer.Instance.from(expectedCents),
+          deltaAmount: DineroTransformer.Instance.from(deltaCents),
+        });
+      }
+    }
+
+    return results;
+  }
+
+  public static asInvoiceDriftResponse(result: InvoiceDriftResult): InvoiceDriftResponse {
+    return {
+      invoice: InvoiceService.asBaseInvoiceResponse(result.invoice),
+      actualAmount: result.actualAmount.toObject(),
+      expectedAmount: result.expectedAmount.toObject(),
+      deltaAmount: result.deltaAmount.toObject(),
+    };
   }
 }

--- a/test/unit/service/invoice-service.ts
+++ b/test/unit/service/invoice-service.ts
@@ -47,6 +47,7 @@ import { truncateAllTables } from '../../setup';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { InvoiceSeeder, TransactionSeeder, UserSeeder } from '../../seed';
 import Transfer from '../../../src/entity/transactions/transfer';
+import DineroTransformer from '../../../src/entity/transformer/dinero-transformer';
 import { Currency } from 'dinero.js';
 import SubTransactionRow from '../../../src/entity/transactions/sub-transaction-row';
 
@@ -932,6 +933,116 @@ describe('InvoiceService', () => {
         expect(response.currentState).to.not.be.undefined;
         expect(response.to.id).to.equal(debtor.id);
       });
+    });
+  });
+
+  describe('findDriftedInvoices function', () => {
+    it('should return an invoice whose transfer amount does not match the row sum', async () => {
+      await inUserContext(
+        await (await UserFactory()).clone(2),
+        async (debtor: User, creditor: User) => {
+          const invoice = await createInvoiceWithTransfers(debtor.id, creditor.id, 1);
+          const originalCents = invoice.transfer.amountInclVat.getAmount();
+
+          // Introduce drift by bumping the transfer amount by 100 cents
+          await Transfer.update(invoice.transfer.id, {
+            amountInclVat: DineroTransformer.Instance.from(originalCents + 100),
+          });
+
+          const results = await new InvoiceService().findDriftedInvoices();
+          const match = results.find((r) => r.invoice.id === invoice.id);
+
+          expect(match).to.not.be.undefined;
+          expect(match.deltaAmount.getAmount()).to.equal(100);
+          expect(match.actualAmount.getAmount()).to.equal(originalCents + 100);
+          expect(match.expectedAmount.getAmount()).to.equal(originalCents);
+        },
+      );
+    });
+
+    it('should not return an invoice whose transfer amount matches the row sum', async () => {
+      await inUserContext(
+        await (await UserFactory()).clone(2),
+        async (debtor: User, creditor: User) => {
+          const invoice = await createInvoiceWithTransfers(debtor.id, creditor.id, 1);
+
+          const results = await new InvoiceService().findDriftedInvoices();
+          const ids = results.map((r) => r.invoice.id);
+
+          expect(ids).to.not.include(invoice.id);
+        },
+      );
+    });
+
+    it('should not return a deleted invoice when its credit transfer matches the original', async () => {
+      await inUserContext(
+        await (await UserFactory()).clone(2),
+        async (debtor: User, creditor: User) => {
+          const invoice = await createInvoiceWithTransfers(debtor.id, creditor.id, 1);
+
+          // Delete it — the service creates a credit transfer equal to the original amount
+          await AppDataSource.manager.transaction(async (manager) => {
+            await new InvoiceService(manager).deleteInvoice(invoice.id, creditor.id);
+          });
+
+          const results = await new InvoiceService().findDriftedInvoices();
+          const ids = results.map((r) => r.invoice.id);
+
+          expect(ids).to.not.include(invoice.id);
+        },
+      );
+    });
+
+    it('should return a deleted invoice when its credit transfer does not match the original transfer', async () => {
+      await inUserContext(
+        await (await UserFactory()).clone(2),
+        async (debtor: User, creditor: User) => {
+          const invoice = await createInvoiceWithTransfers(debtor.id, creditor.id, 1);
+          const originalCents = invoice.transfer.amountInclVat.getAmount();
+
+          // Delete it so a credit transfer is created
+          const deleted = await AppDataSource.manager.transaction(async (manager) => {
+            return new InvoiceService(manager).deleteInvoice(invoice.id, creditor.id);
+          });
+
+          // Tamper with the credit transfer so it no longer matches
+          await Transfer.update(deleted.creditTransfer.id, {
+            amountInclVat: DineroTransformer.Instance.from(originalCents + 300),
+          });
+
+          const results = await new InvoiceService().findDriftedInvoices();
+          const match = results.find((r) => r.invoice.id === invoice.id);
+
+          expect(match).to.not.be.undefined;
+          expect(match.deltaAmount.getAmount()).to.equal(-300);
+        },
+      );
+    });
+
+    it('asInvoiceDriftResponse should embed a full BaseInvoiceResponse', async () => {
+      await inUserContext(
+        await (await UserFactory()).clone(2),
+        async (debtor: User, creditor: User) => {
+          const invoice = await createInvoiceWithTransfers(debtor.id, creditor.id, 1);
+          const cents = invoice.transfer.amountInclVat.getAmount();
+
+          await Transfer.update(invoice.transfer.id, {
+            amountInclVat: DineroTransformer.Instance.from(cents + 200),
+          });
+
+          const results = await new InvoiceService().findDriftedInvoices();
+          const match = results.find((r) => r.invoice.id === invoice.id);
+          expect(match).to.not.be.undefined;
+
+          const response = InvoiceService.asInvoiceDriftResponse(match);
+          expect(response.invoice).to.not.be.undefined;
+          expect(response.invoice.id).to.equal(invoice.id);
+          expect(response.invoice.to.id).to.equal(debtor.id);
+          expect(response.deltaAmount.amount).to.equal(200);
+          expect(response.actualAmount.amount).to.equal(cents + 200);
+          expect(response.expectedAmount.amount).to.equal(cents);
+        },
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `GET /invoices/drift` — admin-only endpoint (same `get all Invoice` policy as all other admin invoice endpoints) that scans every invoice and returns those where `transfer.amountInclVat ≠ sum(row.amount × row.product.priceInclVat)` or `transfer ≠ creditTransfer` for deleted invoices.
- Each response entry embeds a full `BaseInvoiceResponse` so the frontend has complete invoice context without a follow-up fetch, plus `actualAmount`, `expectedAmount`, and `delta` as `DineroObjectResponse` objects
- Adds `InvoiceDriftResponse` typedef to `invoice-response.ts` (picked up by Swagger automatically)
- Adds `findDriftedInvoices()` + `asInvoiceDriftResponse()` to `InvoiceService`

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run lint` — clean
- [x] Positive drift test: bumps transfer amount by 100 cents, asserts invoice appears in results with correct delta/actual/expected
- [x] No-drift test: freshly created invoice does NOT appear in results
- [x] Deleted invoice test: invoice with drift that is subsequently deleted does NOT appear, if deletion is correct.
- [x] `asInvoiceDriftResponse` test: verifies full `BaseInvoiceResponse` is embedded with correct Dinero fields

Closes #790