### PR TITLE
Lift invoice validators into AsyncValidatorMiddleware

### DIFF
--- a/src/controller/banner-controller.ts
+++ b/src/controller/banner-controller.ts
@@ -171,7 +171,7 @@ export default class BannerController extends BaseController {
    * @param {BannerRequest} request.body.required - The banner which should be created
    * @security JWT
    * @return {BannerResponse} 200 - The created banner entity
-   * @return {object} 400 - Validation error
+   * @return {ValidationResponse} 400 - Validation error
    * @return {string} 500 - Internal server error
    */
   public async createBanner(req: RequestWithToken, res: Response): Promise<void> {
@@ -281,7 +281,7 @@ export default class BannerController extends BaseController {
    * @param {BannerRequest} request.body.required - The updated banner
    * @security JWT
    * @return {BannerResponse} 200 - The requested banner entity
-   * @return {object} 400 - Validation error
+   * @return {ValidationResponse} 400 - Validation error
    * @return {string} 404 - Not found error
    * @return {string} 500 - Internal server error
    */

--- a/src/controller/container-controller.ts
+++ b/src/controller/container-controller.ts
@@ -211,7 +211,7 @@ export default class ContainerController extends BaseController {
    *    The container which should be created
    * @security JWT
    * @return {ContainerWithProductsResponse} 200 - The created container entity
-   * @return {object} 400 - Validation error
+   * @return {ValidationResponse} 400 - Validation error
    * @return {string} 500 - Internal server error
    */
   public async createContainer(req: RequestWithToken, res: Response): Promise<void> {
@@ -273,7 +273,7 @@ export default class ContainerController extends BaseController {
    *    The container which should be updated
    * @security JWT
    * @return {ContainerWithProductsResponse} 200 - The created container entity
-   * @return {object} 400 - Validation error
+   * @return {ValidationResponse} 400 - Validation error
    * @return {string} 404 - Product not found error
    * @return {string} 500 - Internal server error
    */

--- a/src/controller/invoice-controller.ts
+++ b/src/controller/invoice-controller.ts
@@ -37,8 +37,8 @@ import {
   UpdateInvoiceParams,
   UpdateInvoiceRequest,
 } from './request/invoice-request';
-import verifyCreateInvoiceRequest, { verifyUpdateInvoiceRequest } from './request/validators/invoice-request-spec';
-import { isFail } from '../helpers/specification-validation';
+import { createInvoiceRequestSpec, updateInvoiceRequestSpec } from './request/validators/invoice-request-spec';
+import { globalAsyncValidatorRegistry } from '../middleware/async-validator-registry';
 import { asBoolean, asDate, asInvoiceState, asNumber } from '../helpers/validators';
 import Invoice from '../entity/invoices/invoice';
 import User, { UserType } from '../entity/user/user';
@@ -61,6 +61,13 @@ export default class InvoiceController extends BaseController {
   public constructor(options: BaseControllerOptions) {
     super(options);
     this.logger.level = process.env.LOG_LEVEL;
+    globalAsyncValidatorRegistry.register('CreateInvoiceRequest', createInvoiceRequestSpec);
+    globalAsyncValidatorRegistry.register('UpdateInvoiceRequest', updateInvoiceRequestSpec, (req) => ({
+      ...req.body,
+      invoiceId: parseInt(req.params.id, 10),
+      state: asInvoiceState((req.body as UpdateInvoiceRequest).state),
+      byId: (req.body as UpdateInvoiceRequest).byId ?? req.token.user.id,
+    }));
   }
 
   /**
@@ -233,7 +240,7 @@ export default class InvoiceController extends BaseController {
    * @param {CreateInvoiceRequest} request.body.required -
    * The invoice which should be created
    * @return {InvoiceResponse} 200 - The created invoice entity
-   * @return {string} 400 - Validation error
+   * @return {ValidationResponse} 400 - Validation error
    * @return {string} 500 - Internal server error
    */
   public async createInvoice(req: RequestWithToken, res: Response): Promise<void> {
@@ -252,12 +259,6 @@ export default class InvoiceController extends BaseController {
         byId: body.byId ?? req.token.user.id,
         description: body.description ?? '',
       };
-
-      const validation = await verifyCreateInvoiceRequest(params);
-      if (isFail(validation)) {
-        res.status(400).json(validation.fail.value);
-        return;
-      }
 
       const invoice: Invoice = await AppDataSource.manager.transaction(async (manager) =>
         new InvoiceService(manager).createInvoice(params));
@@ -282,7 +283,7 @@ export default class InvoiceController extends BaseController {
    * @param {UpdateInvoiceRequest} request.body.required -
    * The invoice update to process
    * @return {BaseInvoiceResponse} 200 - The updated invoice entity
-   * @return {string} 400 - Validation error
+   * @return {ValidationResponse} 400 - Validation error
    * @return {string} 500 - Internal server error
    */
   public async updateInvoice(req: RequestWithToken, res: Response): Promise<void> {
@@ -299,12 +300,6 @@ export default class InvoiceController extends BaseController {
         state: asInvoiceState(body.state),
         byId: body.byId ?? req.token.user.id,
       };
-
-      const validation = await verifyUpdateInvoiceRequest(params);
-      if (isFail(validation)) {
-        res.status(400).json(validation.fail.value);
-        return;
-      }
 
       const invoice: Invoice = await AppDataSource.manager.transaction(async (manager) =>
         new InvoiceService(manager).updateInvoice(params));

--- a/src/controller/request/validators/invoice-request-spec.ts
+++ b/src/controller/request/validators/invoice-request-spec.ts
@@ -26,13 +26,12 @@
 
 import { FindOptionsRelations, In } from 'typeorm';
 import {
-  BaseInvoice, CreateInvoiceParams, CreateInvoiceRequest, UpdateInvoiceParams,
+  BaseInvoice, CreateInvoiceParams, UpdateInvoiceParams,
 } from '../invoice-request';
 import {
   Specification,
   toFail,
   toPass,
-  validateSpecification,
   ValidationError,
 } from '../../../helpers/specification-validation';
 import Transaction from '../../../entity/transactions/transaction';
@@ -117,6 +116,15 @@ async function differentState<T extends UpdateInvoiceParams>(p: T) {
 }
 
 /**
+ * Validates that the user exists, but only if the value is provided.
+ * Skips validation when the field is undefined (the handler will default it from the token).
+ */
+const userMustExistIfProvided = async (p: number | undefined) => {
+  if (p === undefined || p === null) return toPass(p);
+  return userMustExist(p);
+};
+
+/**
  * Specification for an InvoiceRequest
  */
 function baseInvoiceRequestSpec<T extends BaseInvoice>(): Specification<T, ValidationError> {
@@ -127,40 +135,34 @@ function baseInvoiceRequestSpec<T extends BaseInvoice>(): Specification<T, Valid
 }
 
 /**
- * Specification for an UpdateInvoiceParams
+ * Specification for an UpdateInvoiceParams.
+ * Registered with the async validator middleware using a buildTarget that
+ * merges route params (invoiceId) and token defaults (byId) into the
+ * validation target.
  */
-const updateInvoiceRequestSpec: Specification<UpdateInvoiceParams, ValidationError> = [
-  [stringSpec(), 'description', new ValidationError('description:')],
-  differentState,
-  existsAndNotPaidOrDeleted,
-];
-
-/**
- * Specification for an CreateInvoiceParams
- */
-const createInvoiceRequestSpec: () => Specification<CreateInvoiceParams, ValidationError> = () => [
-  ...baseInvoiceRequestSpec<CreateInvoiceParams>(),
-  [[userMustExist], 'byId', new ValidationError('byId:')],
-  [stringSpec(), 'street', new ValidationError('street:')],
-  [stringSpec(), 'postalCode', new ValidationError('postalCode:')],
-  [stringSpec(), 'city', new ValidationError('city:')],
-  [stringSpec(), 'country', new ValidationError('country:')],
-  [stringSpec(), 'reference', new ValidationError('reference:')],
-  [stringSpec(), 'description', new ValidationError('description:')],
-];
-
-export default async function verifyCreateInvoiceRequest(
-  createInvoiceRequest: CreateInvoiceRequest,
-) {
-  return Promise.resolve(await validateSpecification(
-    createInvoiceRequest, createInvoiceRequestSpec(),
-  ));
+export function updateInvoiceRequestSpec(): Specification<UpdateInvoiceParams, ValidationError> {
+  return [
+    [stringSpec(), 'description', new ValidationError('description:')],
+    differentState,
+    existsAndNotPaidOrDeleted,
+  ];
 }
 
-export async function verifyUpdateInvoiceRequest(
-  updateInvoiceRequest: UpdateInvoiceParams,
-) {
-  return Promise.resolve(await validateSpecification(
-    updateInvoiceRequest, updateInvoiceRequestSpec,
-  ));
+/**
+ * Specification for a CreateInvoiceRequest.
+ * Registered with the async validator middleware; runs against req.body before
+ * the handler. byId is validated only if provided (the handler defaults it
+ * from the token).
+ */
+export function createInvoiceRequestSpec(): Specification<CreateInvoiceParams, ValidationError> {
+  return [
+    ...baseInvoiceRequestSpec<CreateInvoiceParams>(),
+    [[userMustExistIfProvided], 'byId', new ValidationError('byId:')],
+    [stringSpec(), 'street', new ValidationError('street:')],
+    [stringSpec(), 'postalCode', new ValidationError('postalCode:')],
+    [stringSpec(), 'city', new ValidationError('city:')],
+    [stringSpec(), 'country', new ValidationError('country:')],
+    [stringSpec(), 'reference', new ValidationError('reference:')],
+    [stringSpec(), 'description', new ValidationError('description:')],
+  ];
 }

--- a/src/controller/response/validation-response.ts
+++ b/src/controller/response/validation-response.ts
@@ -1,0 +1,34 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * @hidden
+ * @module
+ */
+
+/**
+ * @typedef {object} ValidationResponse
+ * @property {boolean} valid.required - Whether the request passed validation.
+ * @property {Array<string>} errors.required - List of validation error messages.
+ */
+export interface ValidationResponse {
+  valid: boolean;
+  errors: string[];
+}

--- a/test/unit/controller/invoice-controller.ts
+++ b/test/unit/controller/invoice-controller.ts
@@ -260,7 +260,9 @@ describe('InvoiceController', async () => {
         .set('Authorization', `Bearer ${ctx.adminToken}`)
         .send(req));
       expect(res.status).to.eq(400);
-      expect(res.body).to.eq(error);
+      expect(res.body.valid).to.be.false;
+      expect(res.body.errors).to.be.an('array').with.length.greaterThan(0);
+      expect(res.body.errors[0]).to.include(error);
     }
 
     it('should verify that all transactions are owned by the debtor', async () => {
@@ -270,7 +272,7 @@ describe('InvoiceController', async () => {
     });
     it('should verify that forId is a valid user', async () => {
       const req: CreateInvoiceRequest = { ...ctx.validInvoiceRequest, forId: -1, transactionIDs: [1] };
-      await expectError(req, `forId: ${INVALID_USER_ID().value}`);
+      await expectError(req, INVALID_USER_ID().value);
     });
     it('should verify that transactionIDs is not empty', async () => {
       const req: CreateInvoiceRequest = { ...ctx.validInvoiceRequest, transactionIDs: [] };
@@ -279,7 +281,7 @@ describe('InvoiceController', async () => {
     it('should verify that description is a valid string', async () => {
       const transactionIDs = (await Transaction.find({ relations: ['from'] })).filter((i) => i.from.id === ctx.validInvoiceRequest.forId).map((t) => t.id);
       const req: CreateInvoiceRequest = { ...ctx.validInvoiceRequest, description: '', transactionIDs };
-      await expectError(req, `description: ${ZERO_LENGTH_STRING().value}`);
+      await expectError(req, ZERO_LENGTH_STRING().value);
     });
     it('should disallow double invoicing of a transaction', async () => {
       await inUserContext(await (await UserFactory()).clone(2),
@@ -566,7 +568,9 @@ describe('InvoiceController', async () => {
         .send(req);
 
       expect(res.status).to.eq(400);
-      expect(res.body).to.eq(SAME_INVOICE_STATE().value);
+      expect(res.body.valid).to.be.false;
+      expect(res.body.errors).to.be.an('array').with.length.greaterThan(0);
+      expect(res.body.errors[0]).to.include(SAME_INVOICE_STATE().value);
     });
     it('should verify that invoice is not deleted', async () => {
       const invoice = ctx.invoices.find((i) => InvoiceService.isState(i, InvoiceState.DELETED));
@@ -582,7 +586,9 @@ describe('InvoiceController', async () => {
         .send(req);
 
       expect(res.status).to.eq(400);
-      expect(res.body).to.eq(INVOICE_IS_DELETED().value);
+      expect(res.body.valid).to.be.false;
+      expect(res.body.errors).to.be.an('array').with.length.greaterThan(0);
+      expect(res.body.errors[0]).to.include(INVOICE_IS_DELETED().value);
     });
     it('should verify that invoice is not paid', async () => {
       const invoice = ctx.invoices.find((i) => InvoiceService.isState(i, InvoiceState.PAID));
@@ -598,7 +604,9 @@ describe('InvoiceController', async () => {
         .send(req);
 
       expect(res.status).to.eq(400);
-      expect(res.body).to.eq(INVOICE_IS_PAID().value);
+      expect(res.body.valid).to.be.false;
+      expect(res.body.errors).to.be.an('array').with.length.greaterThan(0);
+      expect(res.body.errors[0]).to.include(INVOICE_IS_PAID().value);
     });
   });
   describe('DELETE /invoices/{id}', () => {


### PR DESCRIPTION
Partial #116 (InvoiceController items). Stacked on #830.

## Summary
- Register `CreateInvoiceRequest` and `UpdateInvoiceRequest` specs with `globalAsyncValidatorRegistry` in the `InvoiceController` constructor
- Export `createInvoiceRequestSpec` and `updateInvoiceRequestSpec` as factory functions so the registry produces a fresh spec per request
- Use `buildTarget` (from #830) for `UpdateInvoiceRequest` to merge route params (`invoiceId`) and token defaults (`byId`) into the validation target
- Add `userMustExistIfProvided` guard so `byId` is only validated when explicitly provided (the handler defaults it from the token)
- Remove all inline `isFail` checks from `createInvoice` and `updateInvoice` handlers
- Add `ValidationResponse` typedef for consistent `@return` annotations across all migrated controllers
- Update controller tests to assert the `{ valid: false, errors[] }` response shape instead of a bare string

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `testValidationOnRoute` tests updated to assert `{ valid: false, errors[] }` shape
- [x] PATCH `/invoices/:id` validation tests updated to assert new shape