### PR TITLE
Add buildTarget support to AsyncValidatorMiddleware

### DIFF
--- a/src/middleware/async-validator-middleware.ts
+++ b/src/middleware/async-validator-middleware.ts
@@ -55,21 +55,26 @@ export default class AsyncValidatorMiddleware {
   }
 
   /**
-   * Middleware handler. Looks up the spec for the model name and runs it against req.body.
+   * Middleware handler. Looks up the spec for the model name and validates the
+   * request. When a `buildTarget` is registered, it constructs the validation
+   * target from the full request (params, token, body); otherwise `req.body`
+   * is validated directly.
    * @param req - the express request to handle.
    * @param res - the express response object.
    * @param next - the express next function to continue processing of the request.
    */
   public async handle(req: RequestWithToken, res: Response, next: Function): Promise<void> {
-    const specFactory = this.registry.get(this.validator.modelName);
-    if (!specFactory) {
+    const entry = this.registry.get(this.validator.modelName);
+    if (!entry) {
       next();
       return;
     }
 
     // Mirror RequestValidatorMiddleware behavior: if this endpoint allows a blank
-    // body and the incoming body is empty/undefined, skip async validation entirely.
-    if (this.validator.allowBlankTarget) {
+    // body and the incoming body is empty/undefined, skip async validation — but
+    // only when no buildTarget is registered, since buildTarget may construct a
+    // valid target from route params or token data even with an empty body.
+    if (this.validator.allowBlankTarget && !entry.buildTarget) {
       const body = req.body;
       const isUndefinedOrNull = body === undefined || body === null;
       const isEmptyObject =
@@ -85,8 +90,9 @@ export default class AsyncValidatorMiddleware {
     }
 
     try {
-      const spec = specFactory();
-      const result = await validateSpecification(req.body, spec);
+      const spec = entry.factory();
+      const target = entry.buildTarget ? entry.buildTarget(req) : req.body;
+      const result = await validateSpecification(target, spec);
       if (isFail(result)) {
         res.status(400).json({ valid: false, errors: [String(result.fail.value)] });
         return;

--- a/src/middleware/async-validator-registry.ts
+++ b/src/middleware/async-validator-registry.ts
@@ -24,6 +24,7 @@
  * @module internal/middleware
  */
 
+import { RequestWithToken } from './token-middleware';
 import { Joinable, Specification } from '../helpers/specification-validation';
 
 /**
@@ -31,29 +32,44 @@ import { Joinable, Specification } from '../helpers/specification-validation';
  * Controllers register their specs at startup; the AsyncValidatorMiddleware
  * looks them up at request time.
  */
+
 /**
  * A factory function that returns a fresh Specification per call.
  * This prevents ValidationError.join() from mutating shared trace instances across requests.
  */
 export type SpecificationFactory<T = any, F extends Joinable = Joinable> = () => Specification<T, F>;
 
+/**
+ * Builds the validation target from the request. When provided, the middleware
+ * calls this instead of using raw `req.body`, allowing specs that need route
+ * params, token data, or other request context.
+ */
+export type BuildTarget<T = any> = (req: RequestWithToken) => T;
+
+export interface RegistryEntry {
+  factory: SpecificationFactory;
+  buildTarget?: BuildTarget;
+}
+
 export default class AsyncValidatorRegistry {
-  private readonly registry = new Map<string, SpecificationFactory>();
+  private readonly registry = new Map<string, RegistryEntry>();
 
   /**
    * Register an async validation spec factory for a given Swagger model name.
    * @param modelName - The Swagger model name (must match the `modelName` in BodyValidator).
    * @param factory - A function returning a fresh specification per request.
+   * @param buildTarget - Optional function that builds the validation target from the
+   *   request. When omitted the middleware validates `req.body` directly.
    */
-  public register(modelName: string, factory: SpecificationFactory): void {
-    this.registry.set(modelName, factory);
+  public register<T>(modelName: string, factory: SpecificationFactory<T>, buildTarget?: BuildTarget<T>): void {
+    this.registry.set(modelName, { factory, buildTarget });
   }
 
   /**
-   * Retrieve the spec factory registered for the given model name, or undefined if none.
+   * Retrieve the registry entry for the given model name, or undefined if none.
    * @param modelName - The Swagger model name to look up.
    */
-  public get(modelName: string): SpecificationFactory | undefined {
+  public get(modelName: string): RegistryEntry | undefined {
     return this.registry.get(modelName);
   }
 }


### PR DESCRIPTION
Partial #116

## Summary
- Add optional `buildTarget` parameter to `AsyncValidatorRegistry.register()` — a function `(req: RequestWithToken) => T` that constructs the validation target from the full request
- When `buildTarget` is provided, the middleware validates against its return value instead of raw `req.body`
- This enables specs that depend on route params (e.g. `invoiceId` from `:id`) or token-derived defaults (e.g. `byId` from the token) to run in the middleware rather than inline in the handler
- Fully backwards compatible: existing `register(name, factory)` calls continue to work — the middleware falls back to `req.body` when no `buildTarget` is registered

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] Existing banner and container controller specs still compile and work unchanged (no `buildTarget` provided, so `req.body` is used as before)