### PR TITLE
Lift inactive admin cost validators into AsyncValidatorMiddleware

### DIFF
--- a/src/controller/inactive-administrative-cost-controller.ts
+++ b/src/controller/inactive-administrative-cost-controller.ts
@@ -30,16 +30,17 @@ import Policy from './policy';
 import { RequestWithToken } from '../middleware/token-middleware';
 import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import InactiveAdministrativeCostService, { parseInactiveAdministrativeCostFilterParameters, InactiveAdministrativeCostFilterParameters } from '../service/inactive-administrative-cost-service';
-import { isFail } from '../helpers/specification-validation';
 import {
   CreateInactiveAdministrativeCostRequest,
   HandoutInactiveAdministrativeCostsRequest,
 } from './request/inactive-administrative-cost-request';
 import { NotImplementedError } from '../errors';
-import verifyValidUserId from './request/validators/inactive-administrative-cost-request-spec';
+import {
+  createInactiveAdministrativeCostRequestSpec,
+  handoutInactiveAdministrativeCostsRequestSpec,
+} from './request/validators/inactive-administrative-cost-request-spec';
+import { globalAsyncValidatorRegistry } from '../middleware/async-validator-registry';
 import InactiveAdministrativeCost from '../entity/transactions/inactive-administrative-cost';
-import User from '../entity/user/user';
-import { In } from 'typeorm';
 import { asBoolean, asFromAndTillDate } from '../helpers/validators';
 import { PdfError } from '../errors';
 import { formatTitleDate } from '../helpers/pdf';
@@ -58,6 +59,8 @@ export default class InactiveAdministrativeCostController extends BaseController
   public constructor(options: BaseControllerOptions) {
     super(options);
     this.configureLogger(this.logger);
+    globalAsyncValidatorRegistry.register('CreateInactiveAdministrativeCostRequest', createInactiveAdministrativeCostRequestSpec);
+    globalAsyncValidatorRegistry.register('HandoutInactiveAdministrativeCostsRequest', handoutInactiveAdministrativeCostsRequestSpec);
   }
 
   /**
@@ -208,7 +211,7 @@ export default class InactiveAdministrativeCostController extends BaseController
    * @param {CreateInactiveAdministrativeCostRequest} request.body.required -
    * The inactive administrative cost which should be created
    * @return {InactiveAdministrativeCostResponse} 200 - The created inactive administrative cost entity
-   * @return {string} 400 - Validation error
+   * @return {ValidationResponse} 400 - Validation error
    * @return {string} 500 - Internal server error
    */
   public async createInactiveAdministrativeCost(req: RequestWithToken, res: Response): Promise<void> {
@@ -217,12 +220,6 @@ export default class InactiveAdministrativeCostController extends BaseController
 
     // handle request
     try {
-      const validation = await verifyValidUserId(body);
-      if (isFail(validation)) {
-        res.status(400).json(validation.fail.value);
-        return;
-      }
-
       const inactiveAdministrativeCost = await new InactiveAdministrativeCostService().createInactiveAdministrativeCost(body);
       res.json(inactiveAdministrativeCost.toResponse());
     } catch (error) {
@@ -302,22 +299,12 @@ export default class InactiveAdministrativeCostController extends BaseController
    * @param {HandoutInactiveAdministrativeCostsRequest} request.body.required -
    * The users that should be notified
    * @return 204 - Success
-   * @return {string} 400 - Validation error
+   * @return {ValidationResponse} 400 - Validation error
    * @return {string} 500 - Internal server error
    */
   public async notifyInactiveUsers(req: RequestWithToken, res: Response): Promise<void> {
     const body = req.body as HandoutInactiveAdministrativeCostsRequest;
     this.logger.trace('Notify Inactive Users', body, 'by user', req.token.user);
-
-    try {
-      if (!Array.isArray(body.userIds)) throw new Error('userIds is not an Array.');
-      
-      const users = await User.find({ where: { id: In(body.userIds) } });
-      if (users.length !== body.userIds.length) throw new Error('userIds is not a valid array of user IDs');
-    } catch (error) {
-      res.status(400).json(error.message);
-      return ;
-    }
 
     try {
       await new InactiveAdministrativeCostService().sendInactiveNotification(body);
@@ -336,23 +323,13 @@ export default class InactiveAdministrativeCostController extends BaseController
    * @security JWT
    * @param {HandoutInactiveAdministrativeCostsRequest} request.body.required -
    * The users that should be fined
-   * @return 204 - Success
-   * @return {string} 400 - Validation error
+   * @return {InactiveAdministrativeCostResponse[]} 200 - Success
+   * @return {ValidationResponse} 400 - Validation error
    * @return {string} 500 - Internal server error
    */
   public async handoutInactiveAdministrativeCost(req: RequestWithToken, res: Response): Promise<void> {
     const body = req.body as HandoutInactiveAdministrativeCostsRequest;
     this.logger.trace('Handout InactiveAdministrativeCosts', body, 'by user', req.token.user);
-
-    try {
-      if (!Array.isArray(body.userIds)) throw new Error('userIds is not an Array.');
-
-      const users = await User.find({ where: { id: In(body.userIds) } });
-      if (users.length !== body.userIds.length) throw new Error('userIds is not a valid array of user IDs');
-    } catch (error) {
-      res.status(400).json(error.message);
-      return ;
-    }
 
     try {
       const inactiveAdministrativeCosts = await new InactiveAdministrativeCostService().handOutInactiveAdministrativeCost(body);

--- a/src/controller/request/validators/inactive-administrative-cost-request-spec.ts
+++ b/src/controller/request/validators/inactive-administrative-cost-request-spec.ts
@@ -24,18 +24,61 @@
  * @module internal/spec/inactive-administrative-cost-spec
  */
 
-import { CreateInactiveAdministrativeCostRequest } from '../inactive-administrative-cost-request';
+import {
+  CreateInactiveAdministrativeCostRequest,
+  HandoutInactiveAdministrativeCostsRequest,
+} from '../inactive-administrative-cost-request';
 import { INVALID_USER_ID } from './validation-errors';
-import { toFail, toPass } from '../../../helpers/specification-validation';
+import {
+  Specification,
+  toFail,
+  toPass,
+  ValidationError,
+} from '../../../helpers/specification-validation';
 import User from '../../../entity/user/user';
+import { In } from 'typeorm';
 
 /**
- * Check whether the given user is a valid user
+ * Check whether the given forId belongs to a valid user.
  */
-export default async function verifyValidUserId<T extends CreateInactiveAdministrativeCostRequest>(p: T) {
+async function verifyValidUserId<T extends CreateInactiveAdministrativeCostRequest>(p: T) {
   if (p.forId == null) return toFail(INVALID_USER_ID());
 
   const user = await User.findOne({ where: { id: p.forId } });
 
   return user != undefined ? toPass(p) : toFail(INVALID_USER_ID());
+}
+
+/**
+ * Check whether all provided userIds belong to existing users.
+ */
+async function verifyAllUserIdsExist<T extends HandoutInactiveAdministrativeCostsRequest>(p: T) {
+  if (!Array.isArray(p.userIds)) {
+    return toFail(new ValidationError('userIds is not an Array.'));
+  }
+
+  const users = await User.find({ where: { id: In(p.userIds) } });
+  if (users.length !== p.userIds.length) {
+    return toFail(new ValidationError('userIds is not a valid array of user IDs'));
+  }
+
+  return toPass(p);
+}
+
+/**
+ * Specification for a CreateInactiveAdministrativeCostRequest.
+ * Validates that forId is a valid user.
+ */
+export function createInactiveAdministrativeCostRequestSpec():
+Specification<CreateInactiveAdministrativeCostRequest, ValidationError> {
+  return [verifyValidUserId];
+}
+
+/**
+ * Specification for a HandoutInactiveAdministrativeCostsRequest.
+ * Validates that all userIds belong to existing users.
+ */
+export function handoutInactiveAdministrativeCostsRequestSpec():
+Specification<HandoutInactiveAdministrativeCostsRequest, ValidationError> {
+  return [verifyAllUserIdsExist];
 }

--- a/test/unit/controller/inactive-administrative-cost-controller.ts
+++ b/test/unit/controller/inactive-administrative-cost-controller.ts
@@ -300,7 +300,9 @@ describe('InactiveAdministrativeCostController', async () => {
         .send(req);
 
       expect(res.status).to.eq(400);
-      expect(res.body).to.equal(INVALID_USER_ID().value);
+      expect(res.body.valid).to.be.false;
+      expect(res.body.errors).to.be.an('array').with.length.greaterThan(0);
+      expect(res.body.errors[0]).to.include(INVALID_USER_ID().value);
     });
     it('should return 400 when verifyValidUserId returns a fail object', async () => {
       // Stub the validator to simulate a fail
@@ -460,7 +462,9 @@ describe('InactiveAdministrativeCostController', async () => {
         .send({ userIds: [validId, invalidId] });
 
       expect(res.status).to.equal(400);
-      expect(res.body).to.equal('userIds is not a valid array of user IDs');
+      expect(res.body.valid).to.be.false;
+      expect(res.body.errors).to.be.an('array').with.length.greaterThan(0);
+      expect(res.body.errors[0]).to.include('userIds is not a valid array of user IDs');
     });
   });
   describe('POST /inactive-administrative-costs/handout', () => {
@@ -513,7 +517,9 @@ describe('InactiveAdministrativeCostController', async () => {
         .send({ userIds: [validId, invalidId] });
 
       expect(res.status).to.equal(400);
-      expect(res.body).to.equal('userIds is not a valid array of user IDs');
+      expect(res.body.valid).to.be.false;
+      expect(res.body.errors).to.be.an('array').with.length.greaterThan(0);
+      expect(res.body.errors[0]).to.include('userIds is not a valid array of user IDs');
     });
   });
   describe('GET /inactive-administrative-costs/report', () => {


### PR DESCRIPTION
Partial #116 (InactiveAdministrativeCostController items).

## Summary
- Register `CreateInactiveAdministrativeCostRequest` and `HandoutInactiveAdministrativeCostsRequest` specs with `globalAsyncValidatorRegistry` in the `InactiveAdministrativeCostController` constructor
- Export `createInactiveAdministrativeCostRequestSpec` and `handoutInactiveAdministrativeCostsRequestSpec` as factory functions so the registry produces a fresh spec per request
- Remove all inline `isFail`/`verifyValidUserId` checks from `createInactiveAdministrativeCost` handler
- Remove inline userIds array validation from `notifyInactiveUsers` and `handoutInactiveAdministrativeCost` handlers
- Update controller tests to assert the `{ valid: false, errors[] }` response shape instead of bare strings

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] All 44 controller tests pass
- [x] Validation tests updated to assert `{ valid: false, errors[] }` shape