### PR TITLE
fix: incorrect enum definition

### DIFF
--- a/src/controller/balance-controller.ts
+++ b/src/controller/balance-controller.ts
@@ -113,7 +113,7 @@ export default class BalanceController extends BaseController {
    * @param {boolean} hasFine.query - Only users with(out) fines
    * @param {integer} minFine.query - Minimum fine
    * @param {integer} maxFine.query - Maximum fine
-   * @param {Array<string|number>} userTypes.query - enum:MEMBER,ORGAN,VOUCHER,LOCAL_USER,LOCAL_ADMIN,INVOICE,AUTOMATIC_INVOICE - Filter based on user type.
+   * @param {Array<string>} userTypes.query - enum:MEMBER,ORGAN,VOUCHER,LOCAL_USER,LOCAL_ADMIN,INVOICE,AUTOMATIC_INVOICE - Filter based on user type.
    * @param {string} orderBy.query - Column to order balance by - eg: id,amount
    * @param {string} orderDirection.query - enum:ASC,DESC - Order direction
    * @param {boolean} allowDeleted.query - Whether to include deleted users


### PR DESCRIPTION
Changes input param for the get all balances function from Array<string|number> to Array<string>

# Description
Makes sure enum is correctly defined in the balance controller JSDoc.

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_

## ✅ PR Checklist

- [X] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [X] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [X] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB