### PR TITLE
Fix UserType enum JSDoc

### DIFF
--- a/src/controller/balance-controller.ts
+++ b/src/controller/balance-controller.ts
@@ -113,7 +113,7 @@ export default class BalanceController extends BaseController {
    * @param {boolean} hasFine.query - Only users with(out) fines
    * @param {integer} minFine.query - Minimum fine
    * @param {integer} maxFine.query - Maximum fine
-   * @param {Array<string>} userTypes.query - enum:MEMBER,ORGAN,VOUCHER,LOCAL_USER,LOCAL_ADMIN,INVOICE,AUTOMATIC_INVOICE - Filter based on user type.
+   * @param {Array<UserType>} userTypes.query - Filter based on user type.
    * @param {string} orderBy.query - Column to order balance by - eg: id,amount
    * @param {string} orderDirection.query - enum:ASC,DESC - Order direction
    * @param {boolean} allowDeleted.query - Whether to include deleted users

--- a/src/controller/response/user-response.ts
+++ b/src/controller/response/user-response.ts
@@ -31,6 +31,11 @@ import { BasePointOfSaleInfoResponse } from './point-of-sale-response';
 import { SupportedLanguage } from '../../entity/user-setting';
 
 /**
+ * enum:MEMBER,ORGAN,VOUCHER,LOCAL_USER,LOCAL_ADMIN,INVOICE,POINT_OF_SALE,INTEGRATION - The type of a user
+ * @typedef {string} UserType
+ */
+
+/**
  * @typedef {allOf|BaseResponse} BaseUserResponse
  * @property {string} firstName.required - The name of the user.
  * @property {string} lastName.required - The last name of the user

--- a/src/start/swagger.ts
+++ b/src/start/swagger.ts
@@ -78,6 +78,21 @@ export default class Swagger {
 
       instance.on('finish', async (swaggerObject) => {
         Swagger.logger.trace('Swagger specification generation finished');
+
+        // Fix express-jsdoc-swagger bug: enum is emitted on the array schema instead of on items,
+        // which causes openapi-generator-cli to ignore the enum values for array item typing.
+        for (const swaggerPath of Object.values(swaggerObject.paths ?? {})) {
+          for (const operation of Object.values(swaggerPath)) {
+            for (const param of (operation as any)?.parameters ?? []) {
+              const schema = param?.schema;
+              if (schema?.type === 'array' && schema.enum && schema.items && !schema.items.enum) {
+                schema.items.enum = schema.enum;
+                delete schema.enum;
+              }
+            }
+          }
+        }
+
         new Validator(swaggerObject);
         await fs.writeFile(
           path.join(process.cwd(), 'out/swagger.json'),


### PR DESCRIPTION
Creates UserType enum
Adds UserType enum to swagger spec
Patches swagger spec to propagate enum values down one level

# Description
Makes sure the client now actually generates the arrays with enum values correctly. This now also shows up correctly in the Swagger UI

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_

## ✅ PR Checklist

- [X] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [X] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [X] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB
