### PR TITLE
Lift ProductController validators into AsyncValidatorMiddleware

### DIFF
--- a/src/controller/product-controller.ts
+++ b/src/controller/product-controller.ts
@@ -40,8 +40,8 @@ import Product from '../entity/product/product';
 import FileService from '../service/file-service';
 import { PRODUCT_IMAGE_LOCATION } from '../files/storage';
 import { parseRequestPagination, toResponse } from '../helpers/pagination';
-import { verifyCreateProductRequest, verifyProductRequest } from './request/validators/product-request-spec';
-import { isFail } from '../helpers/specification-validation';
+import { createProductRequestSpecFactory, updateProductRequestSpecFactory } from './request/validators/product-request-spec';
+import { globalAsyncValidatorRegistry } from '../middleware/async-validator-registry';
 import { asNumber } from '../helpers/validators';
 import userTokenInOrgan from '../helpers/token-helper';
 
@@ -58,6 +58,22 @@ export default class ProductController extends BaseController {
     super(options);
     this.configureLogger(this.logger);
     this.fileService = new FileService(PRODUCT_IMAGE_LOCATION);
+    globalAsyncValidatorRegistry.register(
+      'CreateProductRequest',
+      createProductRequestSpecFactory,
+      (req) => ({
+        ...(req.body as CreateProductRequest),
+        ownerId: (req.body as CreateProductRequest).ownerId ?? req.token.user.id,
+      }),
+    );
+    globalAsyncValidatorRegistry.register(
+      'UpdateProductRequest',
+      updateProductRequestSpecFactory,
+      (req) => ({
+        ...(req.body as UpdateProductRequest),
+        id: parseInt(req.params.id, 10),
+      }),
+    );
   }
 
   /**
@@ -159,12 +175,6 @@ export default class ProductController extends BaseController {
         ownerId: body.ownerId ?? req.token.user.id,
       };
 
-      const validation = await verifyCreateProductRequest(request);
-      if (isFail(validation)) {
-        res.status(400).json(validation.fail.value);
-        return;
-      }
-
       const revision = await ProductService.createProduct(request);
       if (!revision) {
         res.status(404).json('Product owner not found.');
@@ -202,12 +212,6 @@ export default class ProductController extends BaseController {
         ...body,
         id: productId,
       };
-
-      const validation = await verifyProductRequest(params);
-      if (isFail(validation)) {
-        res.status(400).json(validation.fail.value);
-        return;
-      }
 
       const product = await Product.findOne({ where: { id: productId } });
       if (!product) {

--- a/src/controller/request/validators/product-request-spec.ts
+++ b/src/controller/request/validators/product-request-spec.ts
@@ -24,12 +24,11 @@
  * @module internal/spec/product-request-spec
  */
 
-import CreateProductParams, { BaseProductParams } from '../product-request';
+import CreateProductParams, { BaseProductParams, UpdateProductParams } from '../product-request';
 import {
   Specification,
   toFail,
   toPass,
-  validateSpecification,
   ValidationError,
 } from '../../../helpers/specification-validation';
 import ProductCategory from '../../../entity/product/product-category';
@@ -78,19 +77,13 @@ const baseProductRequestSpec: <T extends BaseProductParams>()
   [[validAlcohol], 'alcoholPercentage', new ValidationError('alcoholPercentage:')],
 ];
 
-const createProductRequestSpec: Specification<CreateProductParams, ValidationError> = [
-  ...baseProductRequestSpec<CreateProductParams>(),
-  [[ownerIsOrgan], 'ownerId', new ValidationError('ownerId:')],
-];
-
-export async function verifyProductRequest(productRequest: BaseProductParams) {
-  return Promise.resolve(await validateSpecification<BaseProductParams, ValidationError>(
-    productRequest, baseProductRequestSpec<BaseProductParams>(),
-  ));
+export function createProductRequestSpecFactory(): Specification<CreateProductParams, ValidationError> {
+  return [
+    ...baseProductRequestSpec<CreateProductParams>(),
+    [[ownerIsOrgan], 'ownerId', new ValidationError('ownerId:')],
+  ];
 }
 
-export async function verifyCreateProductRequest(productRequest: CreateProductParams) {
-  return Promise.resolve(await validateSpecification<CreateProductParams, ValidationError>(
-    productRequest, createProductRequestSpec,
-  ));
+export function updateProductRequestSpecFactory(): Specification<UpdateProductParams, ValidationError> {
+  return baseProductRequestSpec<UpdateProductParams>();
 }

--- a/test/unit/controller/product-controller.ts
+++ b/test/unit/controller/product-controller.ts
@@ -295,7 +295,11 @@ describe('ProductController', async (): Promise<void> => {
           .send(req);
       }
       expect(res.status).to.eq(400);
-      expect(res.body).to.eq(error);
+      expect(res.body.valid).to.be.false;
+      expect(res.body.errors).to.be.an('array').with.length.greaterThan(0);
+      if (error !== '') {
+        expect(res.body.errors[0]).to.include(error);
+      }
     }
     it('should verify Alcohol', async () => {
       const req: CreateProductRequest = {
@@ -409,7 +413,9 @@ describe('ProductController', async (): Promise<void> => {
         } as CreateProductRequest);
 
       expect(res.status).to.equal(400);
-      expect(res.body).to.equal('vat: 5 is an invalid VAT group.');
+      expect(res.body.valid).to.be.false;
+      expect(res.body.errors).to.be.an('array').with.length.greaterThan(0);
+      expect(res.body.errors[0]).to.include('vat: 5 is an invalid VAT group.');
     });
     it('should return an HTTP 400 if owner is not of type organ', async () => {
       const res = await request(ctx.app)
@@ -421,7 +427,9 @@ describe('ProductController', async (): Promise<void> => {
         } as CreateProductRequest);
 
       expect(res.status).to.equal(400);
-      expect(res.body).to.equal('ownerId: Owner must be of type ORGAN.');
+      expect(res.body.valid).to.be.false;
+      expect(res.body.errors).to.be.an('array').with.length.greaterThan(0);
+      expect(res.body.errors[0]).to.include('ownerId: Owner must be of type ORGAN.');
     });
   });
   describe('GET /products/:id', () => {
@@ -567,7 +575,9 @@ describe('ProductController', async (): Promise<void> => {
         } as CreateProductRequest);
 
       expect(res.status).to.equal(400);
-      expect(res.body).to.equal('vat: 5 is an invalid VAT group.');
+      expect(res.body.valid).to.be.false;
+      expect(res.body.errors).to.be.an('array').with.length.greaterThan(0);
+      expect(res.body.errors[0]).to.include('vat: 5 is an invalid VAT group.');
     });
   });
 


### PR DESCRIPTION
## Summary

Closes part of #116. Migrates the two remaining unchecked validators in `ProductController` to the `AsyncValidatorMiddleware` pattern established in #834.

- **`CreateProductRequest` → `createProductRequestSpecFactory`**: registered with a `buildTarget` that mirrors the existing `ownerId ?? req.token.user.id` defaulting logic from the handler.
- **`UpdateProductRequest` → `updateProductRequestSpecFactory`**: registered with a `buildTarget` that folds in `id: parseInt(req.params.id, 10)` so the spec runs against `UpdateProductParams` rather than the raw body.
- Removes both inline `isFail` validation blocks from `createProduct` and `updateProduct` handlers — validation now happens in middleware before the handler is reached.
- Updates test assertions from bare string equality to the standardised `{ valid: false, errors[] }` shape returned by `AsyncValidatorMiddleware`.

## Changes

| File | What changed |
|------|-------------|
| `src/controller/request/validators/product-request-spec.ts` | Replaced `verifyProductRequest` / `verifyCreateProductRequest` with `updateProductRequestSpecFactory` / `createProductRequestSpecFactory`; removed unused `validateSpecification` import |
| `src/controller/product-controller.ts` | Registered both specs in constructor; removed `isFail` blocks; swapped `verifyXxx` / `isFail` imports for registry + factory imports |
| `test/unit/controller/product-controller.ts` | Updated 3 assertion sites to `res.body.valid === false` + `res.body.errors[0].include(...)` |

## Test plan

- [x] `tsc --noEmit` — no type errors
- [x] `npm run lint` — no lint errors
- [x] `npm test` — run full suite locally to confirm all product-controller tests pass
