### PR TITLE
fix: transfers double counting in aggregate

### DIFF
--- a/src/service/transfer-service.ts
+++ b/src/service/transfer-service.ts
@@ -295,15 +295,25 @@ export default class TransferService extends WithManager {
       [TransferCategory.INACTIVE_ADMINISTRATIVE_COST]: 'inactiveAdministrativeCost',
     };
 
+    const excludeAllCategories = (q: typeof query) => {
+      for (const category of Object.values(categoryRelationMap)) {
+        q = q.leftJoin(`transfer.${category}`, category)
+          .andWhere(`${category}.id IS NULL`);
+      }
+      return q;
+    };
+
     let query = this.manager.createQueryBuilder(Transfer, 'transfer');
 
     if (filters.category !== undefined) {
       switch (filters.category) {
         case TransferCategory.MANUAL_CREATION:
-          query = query.andWhere('transfer.fromId IS NULL');
+          query = excludeAllCategories(query)
+            .andWhere('transfer.fromId IS NULL');
           break;
         case TransferCategory.MANUAL_DELETION:
-          query = query.andWhere('transfer.toId IS NULL');
+          query = excludeAllCategories(query)
+            .andWhere('transfer.toId IS NULL');
           break;
         default: {
           const rel = categoryRelationMap[filters.category];

--- a/test/unit/service/transfer-service.ts
+++ b/test/unit/service/transfer-service.ts
@@ -524,7 +524,25 @@ describe('TransferService', async (): Promise<void> => {
 
     it('should return all transfers with null fromId for the MANUAL_CREATION category', async () => {
       const manualCreations = await Transfer.createQueryBuilder('transfer')
-        .where('transfer.fromId IS NULL')
+        .leftJoin('transfer.deposit', 'deposit')
+        .leftJoin('transfer.payoutRequest', 'payoutRequest')
+        .leftJoin('transfer.sellerPayout', 'sellerPayout')
+        .leftJoin('transfer.invoice', 'invoice')
+        .leftJoin('transfer.creditInvoice', 'creditInvoice')
+        .leftJoin('transfer.fine', 'fine')
+        .leftJoin('transfer.waivedFines', 'waivedFines')
+        .leftJoin('transfer.writeOff', 'writeOff')
+        .leftJoin('transfer.inactiveAdministrativeCost', 'inactiveAdministrativeCost')
+        .where('deposit.id IS NULL')
+        .andWhere('payoutRequest.id IS NULL')
+        .andWhere('sellerPayout.id IS NULL')
+        .andWhere('invoice.id IS NULL')
+        .andWhere('creditInvoice.id IS NULL')
+        .andWhere('fine.id IS NULL')
+        .andWhere('waivedFines.id IS NULL')
+        .andWhere('writeOff.id IS NULL')
+        .andWhere('inactiveAdministrativeCost.id IS NULL')
+        .andWhere('transfer.fromId IS NULL')
         .getMany();
 
       const result = await new TransferService().getTransferAggregate({ category: TransferCategory.MANUAL_CREATION });
@@ -537,7 +555,25 @@ describe('TransferService', async (): Promise<void> => {
 
     it('should return all transfers with null toId for the MANUAL_DELETION category', async () => {
       const manualDeletions = await Transfer.createQueryBuilder('transfer')
-        .where('transfer.toId IS NULL')
+        .leftJoin('transfer.deposit', 'deposit')
+        .leftJoin('transfer.payoutRequest', 'payoutRequest')
+        .leftJoin('transfer.sellerPayout', 'sellerPayout')
+        .leftJoin('transfer.invoice', 'invoice')
+        .leftJoin('transfer.creditInvoice', 'creditInvoice')
+        .leftJoin('transfer.fine', 'fine')
+        .leftJoin('transfer.waivedFines', 'waivedFines')
+        .leftJoin('transfer.writeOff', 'writeOff')
+        .leftJoin('transfer.inactiveAdministrativeCost', 'inactiveAdministrativeCost')
+        .where('deposit.id IS NULL')
+        .andWhere('payoutRequest.id IS NULL')
+        .andWhere('sellerPayout.id IS NULL')
+        .andWhere('invoice.id IS NULL')
+        .andWhere('creditInvoice.id IS NULL')
+        .andWhere('fine.id IS NULL')
+        .andWhere('waivedFines.id IS NULL')
+        .andWhere('writeOff.id IS NULL')
+        .andWhere('inactiveAdministrativeCost.id IS NULL')
+        .andWhere('transfer.toId IS NULL')
         .getMany();
 
       const result = await new TransferService().getTransferAggregate({ category: TransferCategory.MANUAL_DELETION });


### PR DESCRIPTION
Checks if all categories are NULL when querying manual transfers

# Description
Fixes a bug where all transfers would be counted as manually created or deleted in the transfer aggregate.
## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_
---

## ✅ PR Checklist

- [X] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [X] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [X] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB
