### PR TITLE
ci: remove namespace definitions from k8s overlays

### DIFF
--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -1,11 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: sudosos-prod
-
 resources:
   - ../../base
-  - namespace.yaml
   - sealed-backend-env.yaml
 
 patches:

--- a/k8s/overlays/production/namespace.yaml
+++ b/k8s/overlays/production/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: sudosos-prod

--- a/k8s/overlays/test/kustomization.yaml
+++ b/k8s/overlays/test/kustomization.yaml
@@ -1,11 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: sudosos-test
-
 resources:
   - ../../base
-  - namespace.yaml
   - sealed-backend-env.yaml
 
 patches:

--- a/k8s/overlays/test/namespace.yaml
+++ b/k8s/overlays/test/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: sudosos-test


### PR DESCRIPTION
## Summary
- CBC controls namespace creation — SudoSOS should not define \`Namespace\` objects or stamp a \`namespace:\` field in overlays
- Removed \`namespace.yaml\` from both overlays
- Removed \`namespace:\` field from both overlay \`kustomization.yaml\` files
- Namespaces will be injected via \`spec.targetNamespace\` in the Flux Kustomization resources in k8s-infra

## Test plan
- [x] No new tests needed (infra config only)
- [x] No DB migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)