### PR TITLE
ci: run backend directly via node in test overlay

### DIFF
--- a/k8s/overlays/test/kustomization.yaml
+++ b/k8s/overlays/test/kustomization.yaml
@@ -11,6 +11,7 @@ patches:
       kind: Ingress
       name: sudosos
   - path: patches/backend-config.yaml
+  - path: patches/backend-command.yaml
 
 # Test uses develop tags for everything
 images:

--- a/k8s/overlays/test/patches/backend-command.yaml
+++ b/k8s/overlays/test/patches/backend-command.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  template:
+    spec:
+      containers:
+        - name: backend
+          command: ["node"]
+          args: ["./out/src/index.js"]


### PR DESCRIPTION
## Summary
- Test overlay now overrides the backend container command to `node ./out/src/index.js` instead of the default `sh /app/init_scripts/start.sh`
- Skips PM2, the 4-worker cluster mode, and the separate cron process
- Simpler startup, easier log reading (single process), faster pod readiness

Production is unaffected — it still uses the PM2 start script.

## Test plan
- [x] No new tests needed (test overlay config only)
- [x] No DB migration