### PR TITLE
chore: configure traefik to use sticky sessions for the websocket endpoints

### DIFF
--- a/k8s/overlays/production/traefik/ingressroute.yaml
+++ b/k8s/overlays/production/traefik/ingressroute.yaml
@@ -29,6 +29,12 @@ spec:
       services:
         - name: backend
           port: 8080
+          sticky:
+            cookie:
+              name: sudosos_ws_sticky
+              httpOnly: true
+              secure: true
+              sameSite: lax
 
     # Docs
     - match: "Host(`sudosos.gewis.nl`) && PathPrefix(`/docs/`)"

--- a/k8s/overlays/test/traefik/ingressroute.yaml
+++ b/k8s/overlays/test/traefik/ingressroute.yaml
@@ -29,6 +29,12 @@ spec:
       services:
         - name: backend
           port: 8080
+          sticky:
+            cookie:
+              name: sudosos_ws_sticky
+              httpOnly: true
+              secure: true
+              sameSite: lax
 
     # Docs
     - match: "Host(`sudosos.test.gewis.nl`) && PathPrefix(`/docs/`)"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

- CI/CD _(Changes to the CI/CD configuration)_

---

## ✅ PR Checklist

- [x] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [x] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [x] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB

## 🔗 Additional Notes
<!-- Any additional information that reviewers should know -->