### PR TITLE
fix(transfer-service): credit invoice being counted twice

### DIFF
--- a/src/service/transfer-service.ts
+++ b/src/service/transfer-service.ts
@@ -319,9 +319,6 @@ export default class TransferService extends WithManager {
           const rel = categoryRelationMap[filters.category];
           if (!rel) throw new Error(`Unsupported transfer category: ${filters.category}`);
           query = query.innerJoin(`transfer.${rel}`, rel);
-          if (filters.category === TransferCategory.INVOICE) {
-            query = query.andWhere('invoice.creditTransferId IS NULL');
-          }
         }
       }
     }

--- a/test/unit/controller/transfer-controller.ts
+++ b/test/unit/controller/transfer-controller.ts
@@ -984,10 +984,9 @@ describe('TransferController', async (): Promise<void> => {
       expect(res.body.total.amount).to.equal(expectedTotal);
     });
 
-    it('should not count the credited invoice transfer under the invoice category', async () => {
+    it('should return all invoice transfers under the invoice category', async () => {
       const invoiceTransfers = await Transfer.createQueryBuilder('transfer')
         .innerJoin('transfer.invoice', 'invoice')
-        .where('invoice.creditTransferId IS NULL')
         .getMany();
 
       const res = await request(app)
@@ -1057,10 +1056,9 @@ describe('TransferController', async (): Promise<void> => {
       expect(res.body.total.total.amount).to.equal(expectedTotal);
     });
 
-    it('should report credited invoices under creditInvoices, not invoices', async () => {
+    it('should report all invoice transfers under invoices and credit transfers under creditInvoices', async () => {
       const invoiceTransfers = await Transfer.createQueryBuilder('transfer')
         .innerJoin('transfer.invoice', 'invoice')
-        .where('invoice.creditTransferId IS NULL')
         .getMany();
       const creditInvoiceTransfers = await Transfer.createQueryBuilder('transfer')
         .innerJoin('transfer.creditInvoice', 'creditInvoice')

--- a/test/unit/service/transfer-service.ts
+++ b/test/unit/service/transfer-service.ts
@@ -485,10 +485,9 @@ describe('TransferService', async (): Promise<void> => {
       expect(result.total.getAmount()).to.equal(expectedTotal);
     });
 
-    it('should exclude credited invoice transfers from the INVOICE category', async () => {
+    it('should return all invoice transfers for the INVOICE category', async () => {
       const invoiceTransfers = await Transfer.createQueryBuilder('transfer')
         .innerJoin('transfer.invoice', 'invoice')
-        .where('invoice.creditTransferId IS NULL')
         .getMany();
 
       const result = await new TransferService().getTransferAggregate({ category: TransferCategory.INVOICE });


### PR DESCRIPTION
Makes sure invoice does not get removed from transfers if a credit transfer for it exists

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_
---

## ✅ PR Checklist

- [X] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [X] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [X] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB