### PR TITLE
fix: pdf responses jsdoc not properly defined

### DIFF
--- a/src/controller/invoice-controller.ts
+++ b/src/controller/invoice-controller.ts
@@ -47,6 +47,7 @@ import InvoiceUser from '../entity/user/invoice-user';
 import { parseInvoiceUserToResponse } from '../helpers/revision-to-response';
 import { AppDataSource } from '../database/database';
 import { NotImplementedError, PdfError } from '../errors';
+import { PdfUrlResponse } from './response/simple-file-response';
 
 /**
  * The Invoice controller.
@@ -351,7 +352,7 @@ export default class InvoiceController extends BaseController {
    * @param {integer} id.path.required - The id of the invoice to return
    * @param {boolean} force.query - Force creation of pdf
    * @return {string} 404 - Invoice not found
-   * @return {string} 200 - The pdf location information.
+   * @return {PdfUrlResponse} 200 - The pdf location information.
    * @return {string} 500 - Internal server error
    */
   public async getInvoicePDF(req: RequestWithToken, res: Response): Promise<void> {
@@ -368,7 +369,7 @@ export default class InvoiceController extends BaseController {
 
       const pdf = await invoice.getOrCreatePdf(req.query.force === 'true');
 
-      res.status(200).json({ pdf: pdf.downloadName });
+      res.status(200).json({ pdf: pdf.downloadName } as PdfUrlResponse);
     } catch (error) {
       this.logger.error('Could get invoice PDF:', error);
       if (error instanceof PdfError) {

--- a/src/controller/seller-payout-controller.ts
+++ b/src/controller/seller-payout-controller.ts
@@ -35,6 +35,7 @@ import { CreateSellerPayoutRequest, UpdateSellerPayoutRequest } from './request/
 import User from '../entity/user/user';
 import ReportService, { SalesReportService } from '../service/report-service';
 import { PdfError } from '../errors';
+import { PdfUrlResponse } from './response/simple-file-response';
 
 export default class SellerPayoutController extends BaseController {
   private logger: Logger = log4js.getLogger(' SellerPayoutController');
@@ -220,7 +221,7 @@ export default class SellerPayoutController extends BaseController {
       }
 
       const pdf = await sellerPayout.getOrCreatePdf(force);
-      res.status(200).json({ pdf: pdf.downloadName });
+      res.status(200).json({ pdf: pdf.downloadName } as PdfUrlResponse);
     } catch (error) {
       this.logger.error('Could not get sales report for seller payout:', error);
       if (error instanceof PdfError) {


### PR DESCRIPTION
Uses PdfUrlResponse instead of string in JSDoc

## Types of changes

- Bug fix _(non-breaking change which fixes an issue)_
- Documentation improvement
---

## ✅ PR Checklist

- [X] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [X] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [X] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB
