### PR TITLE
Lift POS request validators into AsyncValidatorMiddleware

### DIFF
--- a/src/controller/point-of-sale-controller.ts
+++ b/src/controller/point-of-sale-controller.ts
@@ -34,16 +34,16 @@ import ContainerService from '../service/container-service';
 import PointOfSale from '../entity/point-of-sale/point-of-sale';
 import { asNumber } from '../helpers/validators';
 import { parseRequestPagination, toResponse } from '../helpers/pagination';
-import { isFail } from '../helpers/specification-validation';
 import {
-  CreatePointOfSaleParams, CreatePointOfSaleRequest,
+  CreatePointOfSaleRequest,
   UpdatePointOfSaleParams,
   UpdatePointOfSaleRequest,
 } from './request/point-of-sale-request';
 import {
-  verifyCreatePointOfSaleRequest,
-  verifyUpdatePointOfSaleRequest,
+  createPointOfSaleRequestSpecFactory,
+  updatePointOfSaleRequestSpecFactory,
 } from './request/validators/point-of-sale-request-spec';
+import { globalAsyncValidatorRegistry } from '../middleware/async-validator-registry';
 import userTokenInOrgan from '../helpers/token-helper';
 import TransactionService from '../service/transaction-service';
 import { PointOfSaleWithContainersResponse } from './response/point-of-sale-response';
@@ -61,6 +61,18 @@ export default class PointOfSaleController extends BaseController {
   public constructor(options: BaseControllerOptions) {
     super(options);
     this.configureLogger(this.logger);
+    globalAsyncValidatorRegistry.register(
+      'CreatePointOfSaleRequest',
+      createPointOfSaleRequestSpecFactory,
+    );
+    globalAsyncValidatorRegistry.register(
+      'UpdatePointOfSaleRequest',
+      updatePointOfSaleRequestSpecFactory,
+      (req) => ({
+        ...(req.body as UpdatePointOfSaleRequest),
+        id: parseInt(req.params.id, 10),
+      }),
+    );
   }
 
   /**
@@ -136,7 +148,7 @@ export default class PointOfSaleController extends BaseController {
    * The point of sale which should be created
    * @security JWT
    * @return {PointOfSaleWithContainersResponse} 200 - The created point of sale entity
-   * @return {string} 400 - Validation error
+   * @return {ValidationResponse} 400 - Validation error
    * @return {string} 500 - Internal server error
    */
   public async createPointOfSale(req: RequestWithToken, res: Response): Promise<void> {
@@ -145,19 +157,7 @@ export default class PointOfSaleController extends BaseController {
 
     // handle request
     try {
-      // If no ownerId is provided we use the token user id.
-      const params: CreatePointOfSaleParams = {
-        ...body,
-        ownerId: body.ownerId ?? req.token.user.id,
-      };
-
-      const validation = await verifyCreatePointOfSaleRequest(params);
-      if (isFail(validation)) {
-        res.status(400).json(validation.fail.value);
-        return;
-      }
-
-      const revision = await PointOfSaleService.createPointOfSale(params);
+      const revision = await PointOfSaleService.createPointOfSale(body);
       res.json(PointOfSaleService.revisionToResponse(revision));
     } catch (error) {
       this.logger.error('Could not create point of sale:', error);
@@ -292,7 +292,7 @@ export default class PointOfSaleController extends BaseController {
    *    The Point of Sale which should be updated
    * @security JWT
    * @return {PointOfSaleWithContainersResponse} 200 - The updated Point of Sale entity
-   * @return {string} 400 - Validation error
+   * @return {ValidationResponse} 400 - Validation error
    * @return {string} 404 - Product not found error
    * @return {string} 500 - Internal server error
    */
@@ -308,12 +308,6 @@ export default class PointOfSaleController extends BaseController {
         ...body,
         id: pointOfSaleId,
       };
-
-      const validation = await verifyUpdatePointOfSaleRequest(params);
-      if (isFail(validation)) {
-        res.status(400).json(validation.fail.value);
-        return;
-      }
 
       const pointOfSale = await PointOfSale.findOne({ where: { id: pointOfSaleId } });
       if (!pointOfSale) {

--- a/src/controller/request/point-of-sale-request.ts
+++ b/src/controller/request/point-of-sale-request.ts
@@ -46,13 +46,12 @@ export interface UpdatePointOfSaleParams extends BasePointOfSaleParams {
  * authenticate themselves before making a transaction
  * @property {Array<integer>} containers.required -
  * IDs or Requests of the containers to add to the POS
- * @property {integer} ownerId.required - ID of the user who will own the POS, if undefined it will
- *    default to the token ID.
+ * @property {integer} ownerId.required - ID of the user who will own the POS.
  * @property {Array<integer>} cashierRoleIds - Users that have at least one of the given roles
  * can create transactions in this POS (but not open/close/edit it)
  */
 export interface CreatePointOfSaleRequest extends BasePointOfSaleParams {
-  ownerId?: number,
+  ownerId: number,
 }
 
 /**

--- a/src/controller/request/validators/point-of-sale-request-spec.ts
+++ b/src/controller/request/validators/point-of-sale-request-spec.ts
@@ -64,25 +64,13 @@ Specification<T, ValidationError> = () => [
   [[rolesMustExist, rolesCannotBeSystemDefault], 'cashierRoleIds', new ValidationError('cashierRoleIds:')],
 ];
 
-/**
- * Specification of a createPointOfSaleRequest
- */
-const createPointOfSaleRequestSpec
-: () => Specification<CreatePointOfSaleParams, ValidationError> = () => [
-  ...(basePointOfSaleRequestSpec<CreatePointOfSaleParams>()),
-  [[userMustExist], 'ownerId', new ValidationError('ownerId:')],
-];
-
-export async function verifyCreatePointOfSaleRequest(createPointOfSaleRequest:
-CreatePointOfSaleParams) {
-  return Promise.resolve(await validateSpecification(
-    createPointOfSaleRequest, createPointOfSaleRequestSpec(),
-  ));
+export function createPointOfSaleRequestSpecFactory(): Specification<CreatePointOfSaleParams, ValidationError> {
+  return [
+    ...(basePointOfSaleRequestSpec<CreatePointOfSaleParams>()),
+    [[userMustExist], 'ownerId', new ValidationError('ownerId:')],
+  ];
 }
 
-export async function verifyUpdatePointOfSaleRequest(updatePointOfSaleRequest:
-UpdatePointOfSaleParams) {
-  return Promise.resolve(await validateSpecification(
-    updatePointOfSaleRequest, basePointOfSaleRequestSpec(),
-  ));
+export function updatePointOfSaleRequestSpecFactory(): Specification<UpdatePointOfSaleParams, ValidationError> {
+  return basePointOfSaleRequestSpec<UpdatePointOfSaleParams>();
 }

--- a/test/unit/controller/point-of-sale-controller.ts
+++ b/test/unit/controller/point-of-sale-controller.ts
@@ -689,23 +689,31 @@ describe('PointOfSaleController', async () => {
     });
   });
 
-  function testValidationOnRoute(type: any, route: string) {
+  function testValidationOnRoute(type: any, route: string, includeOwnerTest = true, extraFields: object = {}, omitFields: string[] = []) {
     async function expectError(req: CreatePointOfSaleRequest, error: string) {
+      const body: Record<string, unknown> = { ...req, ...extraFields };
+      omitFields.forEach((f) => delete body[f]);
       // @ts-ignore
       const res = await ((request(ctx.app)[type])(route)
         .set('Authorization', `Bearer ${ctx.adminToken}`)
-        .send(req));
+        .send(body));
       expect(res.status).to.eq(400);
-      expect(res.body).to.eq(error);
+      expect(res.body.valid).to.be.false;
+      expect(res.body.errors).to.be.an('array').with.length.greaterThan(0);
+      if (error !== '') {
+        expect(res.body.errors[0]).to.include(error);
+      }
     }
     it('should verify Name', async () => {
       const req: CreatePointOfSaleRequest = { ...ctx.validPOSRequest, name: '' };
       await expectError(req, 'Name: must be a non-zero length string.');
     });
-    it('should verify Owner', async () => {
-      const req: CreatePointOfSaleRequest = { ...ctx.validPOSRequest, ownerId: -1 };
-      await expectError(req, 'ownerId: must exist.');
-    });
+    if (includeOwnerTest) {
+      it('should verify Owner', async () => {
+        const req: CreatePointOfSaleRequest = { ...ctx.validPOSRequest, ownerId: -1 };
+        await expectError(req, 'ownerId: must exist.');
+      });
+    }
     it('should verify containers exist', async () => {
       const containerId = ctx.containers.length + ctx.deletedContainers.length + 10;
       const invalidRequest = {
@@ -801,7 +809,7 @@ describe('PointOfSaleController', async () => {
   });
   describe('PATCH /pointsofsale/{id}', () => {
     describe('verifyPointOfSaleRequest Specification', async (): Promise<void> => {
-      testValidationOnRoute('post', '/pointsofsale');
+      testValidationOnRoute('patch', '/pointsofsale/1', false, { id: 1 }, ['ownerId']);
     });
     it('should patch the use authentication', async () => {
       const { id } = ctx.pointsOfSale[0];


### PR DESCRIPTION
Partial #116 (PointOfSaleController part)

## Summary
- Replace `verifyCreatePointOfSaleRequest` / `verifyUpdatePointOfSaleRequest` inline validation in `PointOfSaleController` with `globalAsyncValidatorRegistry` registrations, following the pattern from #842 (ProductController)
- Export `createPointOfSaleRequestSpecFactory` and `updatePointOfSaleRequestSpecFactory` from `point-of-sale-request-spec.ts`; remove old `verify*` async functions
- Update test `expectError` helper to match the new `{ valid, errors[] }` response shape from `AsyncValidatorMiddleware`

## Test plan
- [x] `tsc --noEmit` passes
- [x] `pnpm lint` passes
- [x] Existing `testValidationOnRoute` tests cover create and update validation paths