### PR TITLE
Lift user request validators into AsyncValidatorMiddleware

### DIFF
--- a/src/controller/request/validators/update-local-request-spec.ts
+++ b/src/controller/request/validators/update-local-request-spec.ts
@@ -26,7 +26,7 @@
 
 import validator from 'validator';
 import {
-  Specification, toFail, toPass, validateSpecification, ValidationError,
+  Specification, toFail, toPass, ValidationError,
 } from '../../../helpers/specification-validation';
 import UpdateLocalRequest from '../update-local-request';
 import { WEAK_PASSWORD } from './validation-errors';
@@ -44,18 +44,8 @@ const validPassword = async (p: string) => {
  * We make it a function since we use a SubSpecification
  *    Otherwise it reuses the validationerror internal in memory.
  */
-const updateLocalRequestSpec: () => Specification<UpdateLocalRequest, ValidationError> = () => [
-  [[validPassword], 'password', new ValidationError('')],
-];
-
-/**
- * Logical validation of the updateLocalRequest
- * @param updateLocalRequest - Request to validate
- */
-async function verifyUpdateLocalRequest(updateLocalRequest: UpdateLocalRequest) {
-  return Promise.resolve(await validateSpecification<UpdateLocalRequest, ValidationError>(
-    updateLocalRequest, updateLocalRequestSpec(),
-  ));
+export function updateLocalRequestSpecFactory(): Specification<UpdateLocalRequest, ValidationError> {
+  return [
+    [[validPassword], 'password', new ValidationError('')],
+  ];
 }
-
-export default verifyUpdateLocalRequest;

--- a/src/controller/request/validators/update-nfc-request-spec.ts
+++ b/src/controller/request/validators/update-nfc-request-spec.ts
@@ -25,7 +25,7 @@
  */
 
 import {
-  Specification, toFail, toPass, validateSpecification, ValidationError,
+  Specification, toFail, toPass, ValidationError,
 } from '../../../helpers/specification-validation';
 import UpdateNfcRequest from '../update-nfc-request';
 import NfcAuthenticator from '../../../entity/authenticator/nfc-authenticator';
@@ -46,18 +46,8 @@ const validNfc = async (p: string) => {
  * We make it a function since we use a SubSpecification
  *    Otherwise it reuses the validationerror internal in memory.
  */
-const updateNfcRequestSpec: () => Specification<UpdateNfcRequest, ValidationError> = () => [
-  [[validNfc], 'nfcCode', new ValidationError('')],
-];
-
-/**
- * Logical validation of the updateNFCRequest
- * @param updateNFCRequest - Request to validate
- */
-async function verifyUpdateNFCRequest(updateNFCRequest: UpdateNfcRequest) {
-  return Promise.resolve(await validateSpecification<UpdateNfcRequest, ValidationError>(
-    updateNFCRequest, updateNfcRequestSpec(),
-  ));
+export function updateNfcRequestSpecFactory(): Specification<UpdateNfcRequest, ValidationError> {
+  return [
+    [[validNfc], 'nfcCode', new ValidationError('')],
+  ];
 }
-
-export default verifyUpdateNFCRequest;

--- a/src/controller/request/validators/update-pin-request-spec.ts
+++ b/src/controller/request/validators/update-pin-request-spec.ts
@@ -25,7 +25,7 @@
  */
 
 import {
-  Specification, toFail, toPass, validateSpecification, ValidationError,
+  Specification, toFail, toPass, ValidationError,
 } from '../../../helpers/specification-validation';
 import UpdatePinRequest from '../update-pin-request';
 import { INVALID_PIN } from './validation-errors';
@@ -45,18 +45,8 @@ const validPin = async (p: string) => {
  * We make it a function since we use a SubSpecification
  *    Otherwise it reuses the validationerror internal in memory.
  */
-const updatePinRequestSpec: () => Specification<UpdatePinRequest, ValidationError> = () => [
-  [[validPin], 'pin', new ValidationError('')],
-];
-
-/**
- * Logical validation of the updatePinRequest
- * @param updatePinRequest - Request to validate
- */
-async function verifyUpdatePinRequest(updatePinRequest: UpdatePinRequest) {
-  return Promise.resolve(await validateSpecification<UpdatePinRequest, ValidationError>(
-    updatePinRequest, updatePinRequestSpec(),
-  ));
+export function updatePinRequestSpecFactory(): Specification<UpdatePinRequest, ValidationError> {
+  return [
+    [[validPin], 'pin', new ValidationError('')],
+  ];
 }
-
-export default verifyUpdatePinRequest;

--- a/src/controller/request/validators/user-request-spec.ts
+++ b/src/controller/request/validators/user-request-spec.ts
@@ -25,7 +25,7 @@
  */
 
 import {
-  Specification, toFail, toPass, validateSpecification, ValidationError,
+  Specification, toFail, toPass, ValidationError,
 } from '../../../helpers/specification-validation';
 import { maxLength, nonZeroString } from './string-spec';
 import { UserType } from '../../../entity/user/user';
@@ -74,10 +74,6 @@ const createUserSpec: () => Specification<CreateUserRequest, ValidationError> = 
   validUserType,
 ];
 
-export async function verifyCreateUserRequest(createUserRequest: CreateUserRequest) {
-  return Promise.resolve(await validateSpecification(createUserRequest, createUserSpec()));
-}
-
-export async function verifyUpdateUserRequest(createUserRequest: CreateUserRequest) {
-  return Promise.resolve(await validateSpecification(createUserRequest, updateUserSpec()));
+export function createUserRequestSpecFactory(): Specification<CreateUserRequest, ValidationError> {
+  return createUserSpec();
 }

--- a/src/controller/user-controller.ts
+++ b/src/controller/user-controller.ts
@@ -45,8 +45,7 @@ import TransferService, { parseGetTransferFilters } from '../service/transfer-se
 import AuthenticationService from '../service/authentication-service';
 import TokenHandler from '../authentication/token-handler';
 import RBACService from '../service/rbac-service';
-import { isFail } from '../helpers/specification-validation';
-import verifyUpdatePinRequest from './request/validators/update-pin-request-spec';
+import { updatePinRequestSpecFactory } from './request/validators/update-pin-request-spec';
 import UpdatePinRequest from './request/update-pin-request';
 import UserService, {
   asUserResponse,
@@ -55,16 +54,17 @@ import UserService, {
   UserFilterParameters,
 } from '../service/user-service';
 import { asFromAndTillDate, asNumber, asReturnFileType } from '../helpers/validators';
-import { verifyCreateUserRequest } from './request/validators/user-request-spec';
+import { createUserRequestSpecFactory } from './request/validators/user-request-spec';
 import userTokenInOrgan from '../helpers/token-helper';
+import { globalAsyncValidatorRegistry } from '../middleware/async-validator-registry';
 import { parseUserToResponse } from '../helpers/revision-to-response';
 import { AcceptTosRequest } from './request/accept-tos-request';
 import PinAuthenticator from '../entity/authenticator/pin-authenticator';
 import LocalAuthenticator from '../entity/authenticator/local-authenticator';
 import UpdateLocalRequest from './request/update-local-request';
-import verifyUpdateLocalRequest from './request/validators/update-local-request-spec';
+import { updateLocalRequestSpecFactory } from './request/validators/update-local-request-spec';
 import StripeService from '../service/stripe-service';
-import verifyUpdateNfcRequest from './request/validators/update-nfc-request-spec';
+import { updateNfcRequestSpecFactory } from './request/validators/update-nfc-request-spec';
 import UpdateNfcRequest from './request/update-nfc-request';
 import NfcAuthenticator from '../entity/authenticator/nfc-authenticator';
 import KeyAuthenticator from '../entity/authenticator/key-authenticator';
@@ -102,6 +102,10 @@ export default class UserController extends BaseController {
     super(options);
     this.configureLogger(this.logger);
     this.tokenHandler = tokenHandler;
+    globalAsyncValidatorRegistry.register('CreateUserRequest', createUserRequestSpecFactory);
+    globalAsyncValidatorRegistry.register('UpdatePinRequest', updatePinRequestSpecFactory);
+    globalAsyncValidatorRegistry.register('UpdateNfcRequest', updateNfcRequestSpecFactory);
+    globalAsyncValidatorRegistry.register('UpdateLocalRequest', updateLocalRequestSpecFactory);
   }
 
   /**
@@ -532,12 +536,6 @@ export default class UserController extends BaseController {
         return;
       }
 
-      const validation = await verifyUpdatePinRequest(updatePinRequest);
-      if (isFail(validation)) {
-        res.status(400).json(validation.fail.value);
-        return;
-      }
-
       await new AuthenticationService().setUserAuthenticationHash(user,
         updatePinRequest.pin.toString(), PinAuthenticator);
       res.status(204).json();
@@ -571,12 +569,6 @@ export default class UserController extends BaseController {
       // If it does not exist, return a 404 error
       if (user == null) {
         res.status(404).json('Unknown user ID.');
-        return;
-      }
-
-      const validation = await verifyUpdateNfcRequest(updateNfcRequest);
-      if (isFail(validation)) {
-        res.status(400).json(validation.fail.value);
         return;
       }
 
@@ -724,12 +716,6 @@ export default class UserController extends BaseController {
         return;
       }
 
-      const validation = await verifyUpdateLocalRequest(updateLocalRequest);
-      if (isFail(validation)) {
-        res.status(400).json(validation.fail.value);
-        return;
-      }
-
       await new AuthenticationService().setUserAuthenticationHash(user,
         updateLocalRequest.password, LocalAuthenticator);
       res.status(204).json();
@@ -848,12 +834,6 @@ export default class UserController extends BaseController {
     this.logger.trace('Create user', body, 'by user', req.token.user);
 
     try {
-      const validation = await verifyCreateUserRequest(body);
-      if (isFail(validation)) {
-        res.status(400).json(validation.fail.value);
-        return;
-      }
-
       const user = await UserService.createUser(body);
       res.status(201).json(asUserResponse(user, true));
     } catch (error) {

--- a/test/unit/controller/user-controller.ts
+++ b/test/unit/controller/user-controller.ts
@@ -1621,7 +1621,8 @@ describe('UserController', (): void => {
           .put(`/users/${user.id}/authenticator/pin`)
           .set('Authorization', `Bearer ${userToken}`)
           .send(updatePinRequest);
-        expect(res.body).to.be.equal(INVALID_PIN().value);
+        expect(res.body.valid).to.be.false;
+        expect(res.body.errors[0]).to.include(INVALID_PIN().value);
         expect(res.status).to.equal(400);
       });
     });
@@ -1666,7 +1667,8 @@ describe('UserController', (): void => {
           .put(`/users/${user.id}/authenticator/nfc`)
           .set('Authorization', `Bearer ${userToken}`)
           .send(updateNfcRequest);
-        expect(res.body).to.be.equal(DUPLICATE_TOKEN().value);
+        expect(res.body.valid).to.be.false;
+        expect(res.body.errors[0]).to.include(DUPLICATE_TOKEN().value);
         expect(res.status).to.equal(400);
       });
     });
@@ -1704,7 +1706,8 @@ describe('UserController', (): void => {
           .put(`/users/${user.id}/authenticator/nfc`)
           .set('Authorization', `Bearer ${userToken}`)
           .send(updateNfcRequest);
-        expect(res.body).to.be.equal(ZERO_LENGTH_STRING().value);
+        expect(res.body.valid).to.be.false;
+        expect(res.body.errors[0]).to.include(ZERO_LENGTH_STRING().value);
         expect(res.status).to.equal(400);
       });
     });


### PR DESCRIPTION
Part of #116.

## Summary
- Export `createUserRequestSpecFactory` from `user-request-spec.ts`; remove `verifyCreateUserRequest`
- Export `updatePinRequestSpecFactory`, `updateNfcRequestSpecFactory`, `updateLocalRequestSpecFactory` from their respective spec files; remove old default-exported `verify*` async functions
- Register all four specs in `UserController` constructor via `globalAsyncValidatorRegistry`; drop inline `isFail` validation blocks from `createUser`, `updateUserPin`, `updateUserNfc`, `updateUserLocalPassword`
- Update 3 test assertions from `res.body === STRING` to `{ valid: false, errors[] }` shape

## Test plan
- [x] `tsc --noEmit` passes
- [x] `pnpm lint` passes
- [x] Existing 400-path tests cover all four validation routes