### PR TITLE
Lift RBAC request validators into AsyncValidatorMiddleware

### DIFF
--- a/src/controller/rbac-controller.ts
+++ b/src/controller/rbac-controller.ts
@@ -31,8 +31,8 @@ import Policy from './policy';
 import RBACService from '../service/rbac-service';
 import { RequestWithToken } from '../middleware/token-middleware';
 import { CreatePermissionParams, UpdateRoleRequest } from './request/rbac-request';
-import { verifyCreatePermissionRequest, verifyUpdateRoleRequest } from './request/validators/rbac-request-spec';
-import { isFail } from '../helpers/specification-validation';
+import { createPermissionsRequestSpecFactory, updateRoleRequestSpecFactory } from './request/validators/rbac-request-spec';
+import { globalAsyncValidatorRegistry } from '../middleware/async-validator-registry';
 import Permission from '../entity/rbac/permission';
 import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import { asUserResponse } from '../service/user-service';
@@ -47,6 +47,8 @@ export default class RbacController extends BaseController {
   public constructor(options: BaseControllerOptions) {
     super(options);
     this.configureLogger(this.logger);
+    globalAsyncValidatorRegistry.register('UpdateRoleRequest', updateRoleRequestSpecFactory);
+    globalAsyncValidatorRegistry.register('CreatePermissionsRequest', createPermissionsRequestSpecFactory);
   }
 
   /**
@@ -209,12 +211,6 @@ export default class RbacController extends BaseController {
     try {
       const request = { ...body } as UpdateRoleRequest;
 
-      const validation = await verifyUpdateRoleRequest(request);
-      if (isFail(validation)) {
-        res.status(400).json(validation.fail.value);
-        return;
-      }
-
       const role = await RBACService.createRole(request);
       const response = RBACService.asRoleResponse(role);
       res.json(response);
@@ -245,12 +241,6 @@ export default class RbacController extends BaseController {
     try {
       const roleId = Number(id);
       const request = { ...body } as UpdateRoleRequest;
-
-      const validation = await verifyUpdateRoleRequest(request);
-      if (isFail(validation)) {
-        res.status(400).json(validation.fail.value);
-        return;
-      }
 
       let [[role]] = await RBACService.getRoles({ roleId }, { take: 1 });
       if (!role) {
@@ -338,19 +328,7 @@ export default class RbacController extends BaseController {
         return;
       }
 
-      if (!Array.isArray(body)) {
-        res.status(404).json('Body should be an array.');
-        return;
-      }
-
       const params: CreatePermissionParams[] = [...body];
-      const validations = await Promise.all(params.map((p) => verifyCreatePermissionRequest(p)));
-      for (let validation of validations) {
-        if (isFail(validation)) {
-          res.status(404).json(validation.fail.value);
-          return;
-        }
-      }
 
       // Check for duplicates in the request body / existing permissions
       const invalidPermissions = params.filter((p, index) => {

--- a/src/controller/request/validators/rbac-request-spec.ts
+++ b/src/controller/request/validators/rbac-request-spec.ts
@@ -25,6 +25,7 @@
  */
 
 import {
+  isFail,
   Specification,
   toFail,
   toPass,
@@ -44,18 +45,25 @@ const validRoleName = async (name: string) => {
   return toPass(name);
 };
 
-const updateRoleRequestSpec: () => Specification<UpdateRoleRequest, ValidationError> = () => [
-  [[...stringSpec(), validRoleName], 'name', new ValidationError('name:')],
-];
-
-export async function verifyUpdateRoleRequest(roleRequest: UpdateRoleRequest) {
-  return validateSpecification<UpdateRoleRequest, ValidationError>(roleRequest, updateRoleRequestSpec());
+export function updateRoleRequestSpecFactory(): Specification<UpdateRoleRequest, ValidationError> {
+  return [
+    [[...stringSpec(), validRoleName], 'name', new ValidationError('name:')],
+  ];
 }
 
-const createPermissionRequestSpec: Specification<CreatePermissionParams, ValidationError> = [
+const createPermissionItemSpec: () => Specification<CreatePermissionParams, ValidationError> = () => [
   [[nonEmptyArray], 'attributes', new ValidationError('attributes:')],
 ];
 
-export async function verifyCreatePermissionRequest(permRequest: CreatePermissionParams) {
-  return validateSpecification(permRequest, createPermissionRequestSpec);
+const validateAllPermissions = async (arr: CreatePermissionParams[]) => {
+  if (!Array.isArray(arr)) return toFail(new ValidationError('Body must be an array.'));
+  for (const item of arr) {
+    const result = await validateSpecification(item, createPermissionItemSpec());
+    if (isFail(result)) return toFail(result.fail);
+  }
+  return toPass(arr);
+};
+
+export function createPermissionsRequestSpecFactory(): Specification<CreatePermissionParams[], ValidationError> {
+  return [validateAllPermissions];
 }


### PR DESCRIPTION
Closes #116.

## Summary
- Export `updateRoleRequestSpecFactory` and `createPermissionsRequestSpecFactory` from `rbac-request-spec.ts`; remove old `verify*` async wrappers
- Register both in `RbacController` constructor via `globalAsyncValidatorRegistry`; drop inline `isFail` blocks from `createRole`, `updateRole`, and `addPermissions`
- `CreatePermissionsRequest` is an array body — handled by a top-level array validator inside the spec factory that iterates per-item validation; the middleware now owns this logic entirely
- Side-effect fix: `addPermissions` was returning `404` for item-level validation failures — moving to middleware corrects this to `400`

## Test plan
- [x] `tsc --noEmit` passes
- [x] `pnpm lint` passes
- [x] Existing 400-path tests cover name validation and non-array body cases; no body-string assertions needed updating (tests only check `res.status`)