### PR TITLE
feat: get transfers by category

### DIFF
--- a/src/controller/transfer-controller.ts
+++ b/src/controller/transfer-controller.ts
@@ -204,9 +204,13 @@ export default class TransferController extends BaseController {
    * @security JWT
    * @param {string} fromDate.query - Start date for selected transfers (inclusive)
    * @param {string} tillDate.query - End date for selected transfers (exclusive)
+   * @param {integer} fromId.query - Filter transfers from this user ID
+   * @param {integer} toId.query - Filter transfers to this user ID
+   * @param {string} category.query - Restrict to a specific transfer category: deposit, payoutRequest, sellerPayout, invoice, creditInvoice, fine, waivedFines, writeOff, inactiveAdministrativeCost, manualCreation, manualDeletion
    * @param {integer} take.query - How many transfers the endpoint should return
    * @param {integer} skip.query - How many transfers should be skipped (for pagination)
    * @return {Array.<TransferResponse>} 200 - All existing transfers
+   * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
    */
   public async returnAllTransfers(req: RequestWithToken, res: Response): Promise<void> {

--- a/src/service/transfer-service.ts
+++ b/src/service/transfer-service.ts
@@ -25,7 +25,7 @@
  */
 
 import dinero, { Dinero } from 'dinero.js';
-import { FindManyOptions, FindOptionsWhere, Raw } from 'typeorm';
+import { FindManyOptions, FindOptionsWhere, Raw, SelectQueryBuilder } from 'typeorm';
 import DineroTransformer from '../entity/transformer/dinero-transformer';
 import Transfer from '../entity/transactions/transfer';
 import { TransferResponse } from '../controller/response/transfer-response';
@@ -54,6 +54,7 @@ export interface TransferFilterParameters {
   toId?: number
   fromDate?: Date,
   tillDate?: Date,
+  category?: TransferCategory,
 }
 
 export enum TransferCategory {
@@ -107,12 +108,17 @@ export interface TransferAggregateFilterParameters {
 }
 
 export function parseGetTransferFilters(req: RequestWithToken): TransferFilterParameters {
+  const { category } = req.query;
+  if (category !== undefined && !Object.values(TransferCategory).includes(category as TransferCategory)) {
+    throw new Error(`Invalid category '${category}'. Must be one of: ${Object.values(TransferCategory).join(', ')}`);
+  }
   return {
     id: asNumber(req.query.id),
     fromId: asNumber(req.query.fromId),
     toId: asNumber(req.query.toId),
     fromDate: asDate(req.query.fromDate),
     tillDate: asDate(req.query.tillDate),
+    category: category as TransferCategory | undefined,
   };
 }
 
@@ -219,6 +225,11 @@ export default class TransferService extends WithManager {
         ),
       };
     }
+    if (filters.category !== undefined) {
+      const subQuery = this.buildCategorySubQuery(filters.category).getQuery();
+      whereClause = { ...whereClause, id: Raw(alias => `${alias} IN (${subQuery})`) };
+    }
+
     let whereOptions: any = [];
 
     // Apparently this is how you make a and-or clause in typeorm without a query builder.
@@ -257,6 +268,48 @@ export default class TransferService extends WithManager {
     ]);
   }
 
+  private static readonly CATEGORY_RELATION_MAP: Partial<Record<TransferCategory, string>> = {
+    [TransferCategory.DEPOSIT]: 'deposit',
+    [TransferCategory.PAYOUT_REQUEST]: 'payoutRequest',
+    [TransferCategory.SELLER_PAYOUT]: 'sellerPayout',
+    [TransferCategory.INVOICE]: 'invoice',
+    [TransferCategory.CREDIT_INVOICE]: 'creditInvoice',
+    [TransferCategory.FINE]: 'fine',
+    [TransferCategory.WAIVED_FINES]: 'waivedFines',
+    [TransferCategory.WRITE_OFF]: 'writeOff',
+    [TransferCategory.INACTIVE_ADMINISTRATIVE_COST]: 'inactiveAdministrativeCost',
+  };
+
+  private static applyCategoryFilter(
+    query: SelectQueryBuilder<Transfer>,
+    alias: string,
+    category: TransferCategory,
+  ): SelectQueryBuilder<Transfer> {
+    const map = TransferService.CATEGORY_RELATION_MAP;
+    switch (category) {
+      case TransferCategory.MANUAL_CREATION:
+      case TransferCategory.MANUAL_DELETION: {
+        for (const rel of Object.values(map)) {
+          query = query.leftJoin(`${alias}.${rel}`, rel).andWhere(`${rel}.id IS NULL`);
+        }
+        return query.andWhere(
+          category === TransferCategory.MANUAL_CREATION ? `${alias}.fromId IS NULL` : `${alias}.toId IS NULL`,
+        );
+      }
+      default: {
+        const rel = map[category];
+        if (!rel) throw new Error(`Unsupported transfer category: ${category}`);
+        return query.innerJoin(`${alias}.${rel}`, rel);
+      }
+    }
+  }
+
+  private buildCategorySubQuery(category: TransferCategory): SelectQueryBuilder<Transfer> {
+    const query = this.manager.createQueryBuilder(Transfer, 'subTransfer')
+      .select('subTransfer.id');
+    return TransferService.applyCategoryFilter(query, 'subTransfer', category);
+  }
+
   public async postTransfer(request: TransferRequest) : Promise<Transfer> {
     const transfer = await this.createTransfer(request);
     if (transfer.from != undefined && transfer.from.inactiveNotificationSend == true) {
@@ -283,44 +336,10 @@ export default class TransferService extends WithManager {
    * @param filters - Optional filters to narrow the set of transfers
    */
   public async getTransferAggregate(filters: TransferAggregateFilterParameters = {}): Promise<TransferAggregateResult> {
-    const categoryRelationMap: Partial<Record<TransferCategory, string>> = {
-      [TransferCategory.DEPOSIT]: 'deposit',
-      [TransferCategory.PAYOUT_REQUEST]: 'payoutRequest',
-      [TransferCategory.SELLER_PAYOUT]: 'sellerPayout',
-      [TransferCategory.INVOICE]: 'invoice',
-      [TransferCategory.CREDIT_INVOICE]: 'creditInvoice',
-      [TransferCategory.FINE]: 'fine',
-      [TransferCategory.WAIVED_FINES]: 'waivedFines',
-      [TransferCategory.WRITE_OFF]: 'writeOff',
-      [TransferCategory.INACTIVE_ADMINISTRATIVE_COST]: 'inactiveAdministrativeCost',
-    };
-
-    const excludeAllCategories = (q: typeof query) => {
-      for (const category of Object.values(categoryRelationMap)) {
-        q = q.leftJoin(`transfer.${category}`, category)
-          .andWhere(`${category}.id IS NULL`);
-      }
-      return q;
-    };
-
     let query = this.manager.createQueryBuilder(Transfer, 'transfer');
 
     if (filters.category !== undefined) {
-      switch (filters.category) {
-        case TransferCategory.MANUAL_CREATION:
-          query = excludeAllCategories(query)
-            .andWhere('transfer.fromId IS NULL');
-          break;
-        case TransferCategory.MANUAL_DELETION:
-          query = excludeAllCategories(query)
-            .andWhere('transfer.toId IS NULL');
-          break;
-        default: {
-          const rel = categoryRelationMap[filters.category];
-          if (!rel) throw new Error(`Unsupported transfer category: ${filters.category}`);
-          query = query.innerJoin(`transfer.${rel}`, rel);
-        }
-      }
+      query = TransferService.applyCategoryFilter(query, 'transfer', filters.category);
     }
 
     if (filters.fromId !== undefined) {

--- a/test/unit/controller/transfer-controller.ts
+++ b/test/unit/controller/transfer-controller.ts
@@ -309,6 +309,66 @@ describe('TransferController', async (): Promise<void> => {
       expect(records.length).to.be.greaterThan(0);
       records.forEach((t) => expect(t.to.id).to.equal(toId));
     });
+
+    it('should return 400 for an invalid category', async () => {
+      const res = await request(app)
+        .get('/transfers')
+        .query({ category: 'notARealCategory' })
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).to.equal(400);
+    });
+
+    it('should filter transfers by deposit category', async () => {
+      const depositTransfer = await Transfer.save({
+        fromId: null,
+        toId: ctx.users[0].id,
+        amountInclVat: DineroTransformer.Instance.from(300),
+        description: 'Deposit category filter test',
+        version: 1,
+      });
+
+      const stripePaymentIntent = await StripePaymentIntent.save({
+        stripeId: 'pi_category_filter_test',
+        amount: DineroTransformer.Instance.from(300),
+        paymentIntentStatuses: [],
+        version: 1,
+      });
+
+      const deposit = await StripeDeposit.save({
+        transfer: depositTransfer,
+        to: ctx.users[0],
+        stripePaymentIntent,
+        version: 1,
+      });
+
+      depositTransfer.deposit = deposit;
+      await Transfer.save(depositTransfer);
+
+      const allDeposits = await Transfer.createQueryBuilder('transfer')
+        .innerJoin('transfer.deposit', 'deposit')
+        .getMany();
+
+      const res = await request(app)
+        .get('/transfers')
+        .query({ category: 'deposit', take: 100 })
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).to.equal(200);
+      const records = res.body.records as TransferResponse[];
+      expect(records.length).to.equal(allDeposits.length);
+      records.forEach((r) => expect(r.deposit).to.not.be.null);
+    });
+
+    it('should return empty list for a category with no matching transfers', async () => {
+      const res = await request(app)
+        .get('/transfers')
+        .query({ category: 'inactiveAdministrativeCost', take: 100 })
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).to.equal(200);
+      expect((res.body.records as TransferResponse[]).length).to.equal(0);
+    });
   });
 
   describe('GET /transfers/:id', () => {

--- a/test/unit/service/transfer-service.ts
+++ b/test/unit/service/transfer-service.ts
@@ -236,6 +236,144 @@ describe('TransferService', async (): Promise<void> => {
       expect(records[0].fine).to.not.be.null;
     });
 
+    describe('category filter', async () => {
+      it('should return only invoice transfers for INVOICE category', async () => {
+        const expected = await Transfer.createQueryBuilder('transfer')
+          .innerJoin('transfer.invoice', 'invoice')
+          .getMany();
+        const [records, count] = await new TransferService().getTransfers({ category: TransferCategory.INVOICE });
+        expect(count).to.equal(expected.length);
+        const expectedIds = new Set(expected.map((t) => t.id));
+        records.forEach((r) => expect(expectedIds.has(r.id)).to.be.true);
+      });
+
+      it('should return only deposit transfers for DEPOSIT category', async () => {
+        const expected = await Transfer.createQueryBuilder('transfer')
+          .innerJoin('transfer.deposit', 'deposit')
+          .getMany();
+        const [records, count] = await new TransferService().getTransfers({ category: TransferCategory.DEPOSIT });
+        expect(count).to.equal(expected.length);
+        expect(count).to.be.greaterThan(0);
+        records.forEach((r) => expect(r.deposit).to.not.be.null);
+      });
+
+      it('should return only payout request transfers for PAYOUT_REQUEST category', async () => {
+        const expected = await Transfer.createQueryBuilder('transfer')
+          .innerJoin('transfer.payoutRequest', 'payoutRequest')
+          .getMany();
+        const [records, count] = await new TransferService().getTransfers({ category: TransferCategory.PAYOUT_REQUEST });
+        expect(count).to.equal(expected.length);
+        expect(count).to.be.greaterThan(0);
+        records.forEach((r) => expect(r.payoutRequest).to.not.be.null);
+      });
+
+      it('should return only seller payout transfers for SELLER_PAYOUT category', async () => {
+        const expected = await Transfer.createQueryBuilder('transfer')
+          .innerJoin('transfer.sellerPayout', 'sellerPayout')
+          .getMany();
+        const [records, count] = await new TransferService().getTransfers({ category: TransferCategory.SELLER_PAYOUT });
+        expect(count).to.equal(expected.length);
+        expect(count).to.be.greaterThan(0);
+        records.forEach((r) => expect(r.sellerPayout).to.not.be.null);
+      });
+
+      it('should return only fine transfers for FINE category', async () => {
+        const expected = await Transfer.createQueryBuilder('transfer')
+          .innerJoin('transfer.fine', 'fine')
+          .getMany();
+        const [records, count] = await new TransferService().getTransfers({ category: TransferCategory.FINE });
+        expect(count).to.equal(expected.length);
+        expect(count).to.be.greaterThan(0);
+        records.forEach((r) => expect(r.fine).to.not.be.null);
+      });
+
+      it('should return only manual creation transfers for MANUAL_CREATION category', async () => {
+        const expected = await Transfer.createQueryBuilder('transfer')
+          .leftJoin('transfer.deposit', 'deposit')
+          .leftJoin('transfer.payoutRequest', 'payoutRequest')
+          .leftJoin('transfer.sellerPayout', 'sellerPayout')
+          .leftJoin('transfer.invoice', 'invoice')
+          .leftJoin('transfer.creditInvoice', 'creditInvoice')
+          .leftJoin('transfer.fine', 'fine')
+          .leftJoin('transfer.waivedFines', 'waivedFines')
+          .leftJoin('transfer.writeOff', 'writeOff')
+          .leftJoin('transfer.inactiveAdministrativeCost', 'inactiveAdministrativeCost')
+          .where('deposit.id IS NULL')
+          .andWhere('payoutRequest.id IS NULL')
+          .andWhere('sellerPayout.id IS NULL')
+          .andWhere('invoice.id IS NULL')
+          .andWhere('creditInvoice.id IS NULL')
+          .andWhere('fine.id IS NULL')
+          .andWhere('waivedFines.id IS NULL')
+          .andWhere('writeOff.id IS NULL')
+          .andWhere('inactiveAdministrativeCost.id IS NULL')
+          .andWhere('transfer.fromId IS NULL')
+          .getMany();
+        const [records, count] = await new TransferService().getTransfers({ category: TransferCategory.MANUAL_CREATION });
+        expect(count).to.equal(expected.length);
+        expect(count).to.be.greaterThan(0);
+        records.forEach((r) => {
+          expect(r.invoice).to.be.null;
+          expect(r.deposit).to.be.null;
+          expect(r.from).to.be.null;
+        });
+      });
+
+      it('should return only manual deletion transfers for MANUAL_DELETION category', async () => {
+        const expected = await Transfer.createQueryBuilder('transfer')
+          .leftJoin('transfer.deposit', 'deposit')
+          .leftJoin('transfer.payoutRequest', 'payoutRequest')
+          .leftJoin('transfer.sellerPayout', 'sellerPayout')
+          .leftJoin('transfer.invoice', 'invoice')
+          .leftJoin('transfer.creditInvoice', 'creditInvoice')
+          .leftJoin('transfer.fine', 'fine')
+          .leftJoin('transfer.waivedFines', 'waivedFines')
+          .leftJoin('transfer.writeOff', 'writeOff')
+          .leftJoin('transfer.inactiveAdministrativeCost', 'inactiveAdministrativeCost')
+          .where('deposit.id IS NULL')
+          .andWhere('payoutRequest.id IS NULL')
+          .andWhere('sellerPayout.id IS NULL')
+          .andWhere('invoice.id IS NULL')
+          .andWhere('creditInvoice.id IS NULL')
+          .andWhere('fine.id IS NULL')
+          .andWhere('waivedFines.id IS NULL')
+          .andWhere('writeOff.id IS NULL')
+          .andWhere('inactiveAdministrativeCost.id IS NULL')
+          .andWhere('transfer.toId IS NULL')
+          .getMany();
+        const [records, count] = await new TransferService().getTransfers({ category: TransferCategory.MANUAL_DELETION });
+        expect(count).to.equal(expected.length);
+        expect(count).to.be.greaterThan(0);
+        records.forEach((r) => {
+          expect(r.invoice).to.be.null;
+          expect(r.deposit).to.be.null;
+          expect(r.to).to.be.null;
+        });
+      });
+
+      it('should combine category filter with toId filter', async () => {
+        const invoiceTransfers = await Transfer.createQueryBuilder('transfer')
+          .innerJoin('transfer.invoice', 'invoice')
+          .getMany();
+        const toId = invoiceTransfers.find((t) => t.toId != null)?.toId;
+        expect(toId).to.not.be.undefined;
+        const expected = invoiceTransfers.filter((t) => t.toId === toId);
+        const [records, count] = await new TransferService().getTransfers({ category: TransferCategory.INVOICE, toId });
+        expect(count).to.equal(expected.length);
+        records.forEach((r) => {
+          expect(r.invoice).to.not.be.null;
+          expect(r.to?.id).to.equal(toId);
+        });
+      });
+
+      it('should return empty list for category with no matching transfers', async () => {
+        // Use INACTIVE_ADMINISTRATIVE_COST which seeder never creates
+        const [records, count] = await new TransferService().getTransfers({ category: TransferCategory.INACTIVE_ADMINISTRATIVE_COST });
+        expect(count).to.equal(0);
+        expect(records).to.be.empty;
+      });
+    });
+
     it('should return corresponding waived fines if transfer has any', async () => {
       const user = ctx.users.find((u) => u.currentFines != null);
       const userFineGroup = user.currentFines;


### PR DESCRIPTION
Adds optional category restriction on the GET transfers endpoint

## Types of changes
- New feature _(non-breaking change which adds functionality)_
- Documentation improvement

## ✅ PR Checklist

- [X] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [X] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [X] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB