### PR TITLE
Add PaymentRequest primitive for shareable top-up links

### DIFF
--- a/docs/content/general/1-core-concepts.md
+++ b/docs/content/general/1-core-concepts.md
@@ -91,6 +91,18 @@ An **invoice** is best understood as a **top-up with a paper trail**.
 
 **VAT note**: the invoice transfer itself is **not** VAT-applicable. VAT is handled by the underlying transactions and shows up in the relevant seller payouts.
 
+## Payment requests (shareable payment links)
+
+A **payment request** is a fixed-amount, time-bounded invitation to top up a specific user's balance. End-users recognise it as a "payment link": an email with an amount and a URL that anyone (including the user themselves from a different device) can open to pay via Stripe.
+
+- The request is created in `PENDING` state and carries an `expiresAt` plus an immutable `amount`.
+- A user can retry: one request can spawn many `StripePaymentIntent` rows. The request becomes `PAID` when one of those intents succeeds.
+- A successful payment **always credits the recipient's balance** via the standard Stripe deposit transfer (void → user). It is a pure top-up primitive.
+- Cancellation is explicit and audit-tracked (`cancelledBy`, `cancelledAt`). To "change the amount", cancel and create a new one.
+- An admin escape hatch marks a request fulfilled out-of-band (e.g. bank transfer) — this creates the credit transfer manually.
+
+Payment requests and **invoices** overlap conceptually (both top up a balance) but differ in who owns settlement: invoices pre-create their own credit transfer, payment requests delegate to the Stripe deposit. A future "invoice via payment link" flow will compose them by having the invoice skip pre-creating a transfer when a payment request is attached.
+
 ## Seller payouts (settling sellers and recording VAT)
 
 A **seller payout** is a payout transfer for a seller over a time range:

--- a/docs/content/general/2-key-workflows.md
+++ b/docs/content/general/2-key-workflows.md
@@ -87,6 +87,40 @@ flowchart TD
 - event routing: only accept events intended for this service
 - idempotency: the same Stripe event may be delivered multiple times
 
+## Payment request (shareable payment link)
+
+**Trigger + actor**
+- Treasurer (or a user for themself) creates a fixed-amount top-up request with an expiry. The recipient opens a share link (no login), pays via Stripe, and the money is credited to the linked user's balance.
+
+**API surface**
+- `POST /payment-requests` (create; admin can create for anyone, regular users only for themselves)
+- `GET /payment-requests` and `GET /payment-requests/:id` (read; admin sees all, user sees own)
+- `POST /payment-requests/:id/cancel` (cancel a PENDING request)
+- `POST /payment-requests/:id/start` (authenticated: start a Stripe session)
+- `POST /payment-requests/:id/mark-fulfilled` (admin escape hatch for out-of-band payment)
+- `GET /payment-requests-public/:id` (unauthenticated: fetch a trimmed view via share link)
+- `POST /payment-requests-public/:id/start` (unauthenticated: start a Stripe session via share link)
+
+**Entities touched**
+- `PaymentRequest` (UUID pk, immutable amount, derived status)
+- `StripePaymentIntent.paymentRequest?` — one request can have many intents (retries)
+- on success: the standard Stripe deposit `Transfer` (void → user) already created by the deposit flow also settles the payment request
+
+**Lifecycle (derived status)**
+- `PENDING` → `PAID` when a linked Stripe intent succeeds.
+- `PENDING` → `CANCELLED` when an authorized user cancels.
+- `PENDING` → `EXPIRED` when `expiresAt` passes without payment.
+- Status is derived from `paidAt` / `cancelledAt` / `expiresAt`; precedence is `PAID` > `CANCELLED` > `EXPIRED` > `PENDING`.
+
+**Critical checks**
+- amount is fixed at creation — a corrected amount means cancelling and creating a fresh request
+- `startPayment` rejects non-`PENDING` requests
+- the Stripe webhook flow idempotently calls `markPaid`: already-paid requests are left unchanged, cancelled requests refuse to flip, and expired-but-settled requests still become `PAID` (the money arrived, the clock is secondary)
+
+**Invoices vs. payment requests**
+- Invoices create their own credit transfer on behalf of the user (a "paper-trail top-up").
+- Payment requests do not pre-create a credit transfer — the Stripe deposit is the single settlement event. A future "invoice via payment link" flow will compose by leaving the settlement to the payment request.
+
 ## Payout request (withdraw balance)
 
 **Trigger + actor**

--- a/src/controller/payment-request-controller.ts
+++ b/src/controller/payment-request-controller.ts
@@ -1,0 +1,414 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * This is the module page of the payment-request-controller.
+ *
+ * Authenticated endpoints for managing {@link stripe/payment-request!PaymentRequest | PaymentRequest}
+ * rows. The unauthenticated share-link surface lives in
+ * {@link PaymentRequestPublicController}.
+ *
+ * @module stripe/payment-request
+ */
+
+import { Response } from 'express';
+import log4js, { Logger } from 'log4js';
+import Dinero from 'dinero.js';
+import BaseController, { BaseControllerOptions } from './base-controller';
+import Policy from './policy';
+import { RequestWithToken } from '../middleware/token-middleware';
+import { parseRequestPagination, toResponse } from '../helpers/pagination';
+import PaymentRequestService, {
+  IllegalPaymentRequestTransitionError,
+  InvalidPaymentRequestBeneficiaryError,
+  parseGetPaymentRequestsFilters,
+} from '../service/payment-request-service';
+import PaymentRequest from '../entity/payment-request/payment-request';
+import User from '../entity/user/user';
+import { PaymentRequestStartResponse } from './response/payment-request-response';
+import {
+  CreatePaymentRequestRequest,
+  MarkFulfilledExternallyRequest,
+} from './request/payment-request-request';
+
+export default class PaymentRequestController extends BaseController {
+  private logger: Logger = log4js.getLogger('PaymentRequestController');
+
+  public constructor(options: BaseControllerOptions) {
+    super(options);
+    this.configureLogger(this.logger);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public getPolicy(): Policy {
+    return {
+      '/': {
+        GET: {
+          policy: async (req) => this.roleManager.can(
+            req.token.roles, 'get', 'all', 'PaymentRequest', ['*'],
+          ),
+          handler: this.returnAllPaymentRequests.bind(this),
+        },
+        POST: {
+          policy: async (req) => this.roleManager.can(
+            req.token.roles, 'create',
+            await PaymentRequestController.getRelation(req),
+            'PaymentRequest', ['*'],
+          ),
+          handler: this.createPaymentRequest.bind(this),
+          body: { modelName: 'CreatePaymentRequestRequest' },
+        },
+      },
+      '/:id': {
+        GET: {
+          policy: async (req) => this.roleManager.can(
+            req.token.roles, 'get',
+            await PaymentRequestController.getRelation(req),
+            'PaymentRequest', ['*'],
+          ),
+          handler: this.returnSinglePaymentRequest.bind(this),
+        },
+      },
+      '/:id/cancel': {
+        POST: {
+          policy: async (req) => this.roleManager.can(
+            req.token.roles, 'update',
+            await PaymentRequestController.getRelation(req),
+            'PaymentRequest', ['*'],
+          ),
+          handler: this.cancelPaymentRequest.bind(this),
+        },
+      },
+      '/:id/start': {
+        POST: {
+          policy: async (req) => this.roleManager.can(
+            req.token.roles, 'update',
+            await PaymentRequestController.getRelation(req),
+            'PaymentRequest', ['*'],
+          ),
+          handler: this.startPaymentAuthenticated.bind(this),
+        },
+      },
+      '/:id/mark-fulfilled': {
+        POST: {
+          policy: async (req) => this.roleManager.can(
+            req.token.roles, 'update', 'all', 'PaymentRequest', ['*'],
+          ),
+          handler: this.markFulfilledExternally.bind(this),
+          body: { modelName: 'MarkFulfilledExternallyRequest' },
+        },
+      },
+    };
+  }
+
+  /**
+   * Load the PaymentRequest for the current `/:id` request, caching on `req`
+   * so the policy + handler together only hit the DB once.
+   *
+   * The full relation set (`for`, `createdBy`, `cancelledBy`, `fulfilledBy`)
+   * is loaded so that handlers can serialize the response directly from
+   * the cached entity without re-querying.
+   *
+   * Returns `null` when there is no `:id` param or the request doesn't exist.
+   */
+  public static async loadPaymentRequest(
+    req: RequestWithToken & { paymentRequest?: PaymentRequest | null },
+  ): Promise<PaymentRequest | null> {
+    if (req.paymentRequest !== undefined) {
+      return req.paymentRequest;
+    }
+    const { id } = req.params;
+    if (!id) {
+      req.paymentRequest = null;
+      return null;
+    }
+    req.paymentRequest = await new PaymentRequestService().getPaymentRequest(id);
+    return req.paymentRequest;
+  }
+
+  /**
+   * Determine "own" vs "all" for RBAC. Creation takes the `forId` from the
+   * body; state transitions look up the request by id and compare against
+   * the caller. The lookup is cached on `req` via
+   * {@link loadPaymentRequest} so the subsequent handler does not re-query.
+   */
+  public static async getRelation(req: RequestWithToken): Promise<string> {
+    const body = req.body as Partial<CreatePaymentRequestRequest> | undefined;
+    if (body && body.forId != null) {
+      return body.forId === req.token.user.id ? 'own' : 'all';
+    }
+
+    const request = await PaymentRequestController.loadPaymentRequest(
+      req as RequestWithToken & { paymentRequest?: PaymentRequest | null },
+    );
+    return (request != null && request.for.id === req.token.user.id) ? 'own' : 'all';
+  }
+
+  /**
+   * GET /payment-requests
+   * @summary List PaymentRequests (paginated, with filtering by beneficiary, creator, and status)
+   * @operationId getAllPaymentRequests
+   * @tags paymentRequests - Operations of the payment-request controller
+   * @security JWT
+   * @param {integer} forId.query - Filter by beneficiary user id.
+   * @param {integer} createdById.query - Filter by creator user id.
+   * @param {string} status.query - enum:PENDING,PAID,EXPIRED,CANCELLED - Comma-separated list of derived statuses.
+   * @param {string} fromDate.query - Filter requests created on or after this ISO date (inclusive).
+   * @param {string} tillDate.query - Filter requests created strictly before this ISO date (exclusive).
+   * @param {integer} take.query - How many rows the endpoint should return
+   * @param {integer} skip.query - How many rows to skip (for pagination)
+   * @return {PaginatedBasePaymentRequestResponse} 200 - All existing payment requests
+   * @return {string} 400 - Validation error
+   * @return {string} 500 - Internal server error
+   */
+  public async returnAllPaymentRequests(req: RequestWithToken, res: Response): Promise<void> {
+    this.logger.trace('Get all payment requests by user', req.token.user);
+
+    let filters;
+    let pagination;
+    try {
+      filters = parseGetPaymentRequestsFilters(req);
+      pagination = parseRequestPagination(req);
+    } catch (e) {
+      res.status(400).send(e instanceof Error ? e.message : String(e));
+      return;
+    }
+
+    try {
+      const service = new PaymentRequestService();
+      const [rows, count] = await service.getPaymentRequests(filters, pagination);
+      const records = rows.map((r) => PaymentRequestService.asBasePaymentRequestResponse(r));
+      res.status(200).json(toResponse(records, count, pagination));
+    } catch (e) {
+      this.logger.error('Could not list payment requests:', e);
+      res.status(500).send('Internal server error.');
+    }
+  }
+
+  /**
+   * GET /payment-requests/{id}
+   * @summary Fetch a single PaymentRequest by id.
+   * @operationId getSinglePaymentRequest
+   * @tags paymentRequests - Operations of the payment-request controller
+   * @param {string} id.path.required - UUID v4 of the payment request.
+   * @security JWT
+   * @return {BasePaymentRequestResponse} 200 - Single payment request
+   * @return {string} 404 - Unknown id
+   */
+  public async returnSinglePaymentRequest(req: RequestWithToken, res: Response): Promise<void> {
+    this.logger.trace('Get single payment request by user', req.token.user, 'id', req.params.id);
+
+    try {
+      const request = await PaymentRequestController.loadPaymentRequest(
+        req as RequestWithToken & { paymentRequest?: PaymentRequest | null },
+      );
+      if (!request) {
+        res.status(404).send();
+        return;
+      }
+      res.status(200).json(PaymentRequestService.asBasePaymentRequestResponse(request));
+    } catch (e) {
+      this.logger.error('Could not get payment request:', e);
+      res.status(500).send('Internal server error.');
+    }
+  }
+
+  /**
+   * POST /payment-requests
+   * @summary Create a new PaymentRequest.
+   * @operationId createPaymentRequest
+   * @tags paymentRequests - Operations of the payment-request controller
+   * @param {CreatePaymentRequestRequest} request.body.required - The request to create
+   * @security JWT
+   * @return {BasePaymentRequestResponse} 200 - The created payment request
+   * @return {string} 400 - Validation error
+   * @return {string} 404 - Beneficiary user not found
+   */
+  public async createPaymentRequest(req: RequestWithToken, res: Response): Promise<void> {
+    this.logger.trace('Create payment request by user', req.token.user, 'body', req.body);
+    const body = req.body as CreatePaymentRequestRequest;
+
+    const forUser = await User.findOne({ where: { id: body.forId } });
+    if (!forUser) {
+      res.status(404).send('Beneficiary user not found.');
+      return;
+    }
+
+    let expiresAt: Date;
+    try {
+      expiresAt = new Date(body.expiresAt);
+      if (Number.isNaN(expiresAt.getTime())) throw new Error('Invalid expiresAt');
+    } catch {
+      res.status(400).send('Invalid expiresAt; must be a valid ISO-8601 timestamp.');
+      return;
+    }
+
+    try {
+      const service = new PaymentRequestService();
+      const request = await service.createPaymentRequest({
+        for: forUser,
+        createdBy: req.token.user,
+        amount: Dinero(body.amount),
+        expiresAt,
+        description: body.description ?? null,
+      });
+      res.status(200).json(PaymentRequestService.asBasePaymentRequestResponse(request));
+    } catch (e) {
+      if (e instanceof InvalidPaymentRequestBeneficiaryError) {
+        res.status(400).send(e.message);
+        return;
+      }
+      if (e instanceof Error) {
+        res.status(400).send(e.message);
+        return;
+      }
+      this.logger.error('Could not create payment request:', e);
+      res.status(500).send('Internal server error.');
+    }
+  }
+
+  /**
+   * POST /payment-requests/{id}/cancel
+   * @summary Cancel a PENDING PaymentRequest.
+   * @operationId cancelPaymentRequest
+   * @tags paymentRequests - Operations of the payment-request controller
+   * @param {string} id.path.required - UUID v4 of the payment request.
+   * @security JWT
+   * @return {BasePaymentRequestResponse} 200 - The cancelled payment request
+   * @return {string} 404 - Unknown id
+   * @return {string} 409 - Request is not in PENDING state
+   */
+  public async cancelPaymentRequest(req: RequestWithToken, res: Response): Promise<void> {
+    this.logger.trace('Cancel payment request by user', req.token.user, 'id', req.params.id);
+
+    try {
+      const request = await PaymentRequestController.loadPaymentRequest(
+        req as RequestWithToken & { paymentRequest?: PaymentRequest | null },
+      );
+      if (!request) {
+        res.status(404).send();
+        return;
+      }
+      const service = new PaymentRequestService();
+      const cancelled = await service.cancelPaymentRequest(request, req.token.user);
+      res.status(200).json(PaymentRequestService.asBasePaymentRequestResponse(cancelled));
+    } catch (e) {
+      if (e instanceof IllegalPaymentRequestTransitionError) {
+        res.status(409).send(e.message);
+        return;
+      }
+      this.logger.error('Could not cancel payment request:', e);
+      res.status(500).send('Internal server error.');
+    }
+  }
+
+  /**
+   * POST /payment-requests/{id}/start
+   * @summary Start a Stripe payment session for the given PaymentRequest while authenticated.
+   * @operationId startPaymentRequestAuthenticated
+   * @tags paymentRequests - Operations of the payment-request controller
+   * @param {string} id.path.required - UUID v4 of the payment request.
+   * @security JWT
+   * @return {PaymentRequestStartResponse} 200 - Stripe client secret
+   * @return {string} 404 - Unknown id
+   * @return {string} 409 - Request is not in PENDING state
+   */
+  public async startPaymentAuthenticated(req: RequestWithToken, res: Response): Promise<void> {
+    this.logger.trace('Start payment (authenticated) by user', req.token.user, 'id', req.params.id);
+
+    try {
+      const request = await PaymentRequestController.loadPaymentRequest(
+        req as RequestWithToken & { paymentRequest?: PaymentRequest | null },
+      );
+      if (!request) {
+        res.status(404).send();
+        return;
+      }
+      const service = new PaymentRequestService();
+      const { deposit, clientSecret } = await service.startPayment(request);
+      const response: PaymentRequestStartResponse = {
+        paymentRequestId: request.id,
+        stripeId: deposit.stripePaymentIntent.stripeId,
+        clientSecret,
+      };
+      res.status(200).json(response);
+    } catch (e) {
+      if (e instanceof IllegalPaymentRequestTransitionError) {
+        res.status(409).send(e.message);
+        return;
+      }
+      if (e instanceof InvalidPaymentRequestBeneficiaryError) {
+        res.status(400).send(e.message);
+        return;
+      }
+      this.logger.error('Could not start payment for payment request:', e);
+      res.status(500).send('Internal server error.');
+    }
+  }
+
+  /**
+   * POST /payment-requests/{id}/mark-fulfilled
+   * @summary Admin escape hatch: mark a PaymentRequest paid out-of-band (e.g. bank transfer).
+   *   Creates a void->user credit Transfer manually.
+   * @operationId markPaymentRequestFulfilledExternally
+   * @tags paymentRequests - Operations of the payment-request controller
+   * @param {string} id.path.required - UUID v4 of the payment request.
+   * @param {MarkFulfilledExternallyRequest} request.body.required - The audit reason
+   * @security JWT
+   * @return {BasePaymentRequestResponse} 200 - The marked-paid payment request
+   * @return {string} 404 - Unknown id
+   * @return {string} 409 - Request is not in PENDING state
+   */
+  public async markFulfilledExternally(req: RequestWithToken, res: Response): Promise<void> {
+    this.logger.trace('Mark fulfilled externally by user', req.token.user, 'id', req.params.id);
+    const body = req.body as MarkFulfilledExternallyRequest;
+
+    if (!body?.reason || body.reason.trim().length === 0) {
+      res.status(400).send('reason is required.');
+      return;
+    }
+
+    try {
+      const request = await PaymentRequestController.loadPaymentRequest(
+        req as RequestWithToken & { paymentRequest?: PaymentRequest | null },
+      );
+      if (!request) {
+        res.status(404).send();
+        return;
+      }
+      const service = new PaymentRequestService();
+      const updated = await service.markFulfilledExternally(request, body.reason, req.token.user);
+      res.status(200).json(PaymentRequestService.asBasePaymentRequestResponse(updated));
+    } catch (e) {
+      if (e instanceof IllegalPaymentRequestTransitionError) {
+        res.status(409).send(e.message);
+        return;
+      }
+      if (e instanceof Error) {
+        res.status(400).send(e.message);
+        return;
+      }
+      this.logger.error('Could not mark payment request fulfilled:', e);
+      res.status(500).send('Internal server error.');
+    }
+  }
+}

--- a/src/controller/payment-request-public-controller.ts
+++ b/src/controller/payment-request-public-controller.ts
@@ -1,0 +1,147 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * This is the module page of the payment-request-public-controller.
+ *
+ * Unauthenticated share-link surface for {@link stripe/payment-request!PaymentRequest | PaymentRequest}.
+ * Mirrors the pattern of {@link stripe!StripeWebhookController | StripeWebhookController}:
+ * mounted *before* `setupAuthentication` in `src/index.ts`, with an
+ * `async () => true` policy on every endpoint. Do **not** reuse endpoint
+ * paths from the authenticated controller — the mount order is significant.
+ *
+ * The response shape here is {@link PublicPaymentRequestResponse}
+ * — it deliberately omits `createdBy`, `cancelledBy`, and other internal
+ * audit fields, because anyone holding the link can hit these endpoints.
+ *
+ * @module stripe/payment-request
+ */
+
+import { Response } from 'express';
+import log4js, { Logger } from 'log4js';
+import BaseController, { BaseControllerOptions } from './base-controller';
+import Policy from './policy';
+import { RequestWithToken } from '../middleware/token-middleware';
+import PaymentRequestService, {
+  IllegalPaymentRequestTransitionError,
+  InvalidPaymentRequestBeneficiaryError,
+} from '../service/payment-request-service';
+import { PaymentRequestStartResponse } from './response/payment-request-response';
+
+export default class PaymentRequestPublicController extends BaseController {
+  private logger: Logger = log4js.getLogger('PaymentRequestPublicController');
+
+  public constructor(options: BaseControllerOptions) {
+    super(options);
+    this.configureLogger(this.logger);
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * All endpoints here bypass authentication (policy is `async () => true`).
+   * The controller is mounted before `setupAuthentication` in `src/index.ts`.
+   */
+  public getPolicy(): Policy {
+    return {
+      '/:id': {
+        GET: {
+          policy: async () => true,
+          handler: this.returnSinglePaymentRequest.bind(this),
+        },
+      },
+      '/:id/start': {
+        POST: {
+          policy: async () => true,
+          handler: this.startPaymentPublic.bind(this),
+        },
+      },
+    };
+  }
+
+  /**
+   * GET /payment-requests-public/{id}
+   * @summary Fetch a PaymentRequest via the public share link. Returns a
+   *   trimmed response that omits internal audit fields.
+   * @operationId getPublicPaymentRequest
+   * @tags paymentRequestsPublic - Unauthenticated share-link surface
+   * @param {string} id.path.required - UUID v4 of the payment request.
+   * @return {PublicPaymentRequestResponse} 200 - Single payment request (trimmed shape)
+   * @return {string} 404 - Unknown id
+   */
+  public async returnSinglePaymentRequest(req: RequestWithToken, res: Response): Promise<void> {
+    this.logger.trace('Public get payment request', req.params.id);
+
+    try {
+      const service = new PaymentRequestService();
+      const request = await service.getPublicPaymentRequest(req.params.id);
+      if (!request) {
+        res.status(404).send();
+        return;
+      }
+      res.status(200).json(PaymentRequestService.asPublicPaymentRequestResponse(request));
+    } catch (e) {
+      this.logger.error('Could not get payment request (public):', e);
+      res.status(500).send('Internal server error.');
+    }
+  }
+
+  /**
+   * POST /payment-requests-public/{id}/start
+   * @summary Start a Stripe payment session for the given PaymentRequest
+   *   without authentication — the share link IS the credential.
+   * @operationId startPaymentRequestPublic
+   * @tags paymentRequestsPublic - Unauthenticated share-link surface
+   * @param {string} id.path.required - UUID v4 of the payment request.
+   * @return {PaymentRequestStartResponse} 200 - Stripe client secret
+   * @return {string} 404 - Unknown id
+   * @return {string} 409 - Request is not in PENDING state
+   */
+  public async startPaymentPublic(req: RequestWithToken, res: Response): Promise<void> {
+    this.logger.trace('Public start payment', req.params.id);
+
+    try {
+      const service = new PaymentRequestService();
+      const request = await service.getPublicPaymentRequest(req.params.id);
+      if (!request) {
+        res.status(404).send();
+        return;
+      }
+      const { deposit, clientSecret } = await service.startPayment(request);
+      const response: PaymentRequestStartResponse = {
+        paymentRequestId: request.id,
+        stripeId: deposit.stripePaymentIntent.stripeId,
+        clientSecret,
+      };
+      res.status(200).json(response);
+    } catch (e) {
+      if (e instanceof IllegalPaymentRequestTransitionError) {
+        res.status(409).send(e.message);
+        return;
+      }
+      if (e instanceof InvalidPaymentRequestBeneficiaryError) {
+        res.status(400).send(e.message);
+        return;
+      }
+      this.logger.error('Could not start public payment:', e);
+      res.status(500).send('Internal server error.');
+    }
+  }
+}

--- a/src/controller/request/payment-request-request.ts
+++ b/src/controller/request/payment-request-request.ts
@@ -1,0 +1,49 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * This is the module page of the payment-request-request.
+ *
+ * @module stripe/payment-request
+ */
+
+import { DineroObjectRequest } from './dinero-request';
+
+/**
+ * @typedef {object} CreatePaymentRequestRequest
+ * @property {integer} forId.required - The ID of the user whose balance will be credited on payment.
+ * @property {DineroObjectRequest} amount.required - Fixed, immutable amount to be paid.
+ * @property {string} expiresAt.required - ISO-8601 timestamp after which the request stops accepting payments.
+ * @property {string} description - Optional human-readable description (e.g. invoice reference).
+ */
+export interface CreatePaymentRequestRequest {
+  forId: number;
+  amount: DineroObjectRequest;
+  expiresAt: string;
+  description?: string;
+}
+
+/**
+ * @typedef {object} MarkFulfilledExternallyRequest
+ * @property {string} reason.required - Why this request is being marked paid out-of-band (audit trail).
+ */
+export interface MarkFulfilledExternallyRequest {
+  reason: string;
+}

--- a/src/controller/response/base-response-without-id.ts
+++ b/src/controller/response/base-response-without-id.ts
@@ -23,15 +23,21 @@
  * @module
  */
 
-import BaseResponseWithoutId from './base-response-without-id';
-
 /**
- * @typedef {object} BaseResponse
- * @property {integer} id.required - The unique id of the entity.
+ * Standard timestamp/version fields every response shares, without an `id`.
+ * Responses that key on a UUID (or any non-integer identifier) extend this
+ * and add their own `id` field. Responses keyed on an integer id extend
+ * `BaseResponse` instead, which adds `id: number`.
+ *
+ * Parallel to `BaseEntityWithoutId` on the entity side.
+ *
+ * @typedef {object} BaseResponseWithoutId
  * @property {string} createdAt - The creation Date of the entity.
  * @property {string} updatedAt - The last update Date of the entity.
  * @property {integer} version - The version of the entity.
  */
-export default interface BaseResponse extends BaseResponseWithoutId {
-  id: number,
+export default interface BaseResponseWithoutId {
+  createdAt?: string,
+  updatedAt?: string,
+  version?: number,
 }

--- a/src/controller/response/payment-request-response.ts
+++ b/src/controller/response/payment-request-response.ts
@@ -1,0 +1,113 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * This is the module page of the payment-request-response.
+ *
+ * @module stripe/payment-request
+ */
+
+import BaseResponseWithoutId from './base-response-without-id';
+import { BaseUserResponse } from './user-response';
+import { DineroObjectResponse } from './dinero-response';
+import { PaginationResult } from '../../helpers/pagination';
+import { PaymentRequestStatus } from '../../entity/payment-request/payment-request-status';
+
+/**
+ * PaymentRequest is keyed by UUID, not integer id, so it extends
+ * `BaseResponseWithoutId` (no id field) and declares its own `id: string`.
+ *
+ * @typedef {object} BasePaymentRequestResponse
+ * @property {string} id.required - UUID v4 identifier (also the public share-link id).
+ * @property {string} createdAt - ISO-8601 creation timestamp.
+ * @property {string} updatedAt - ISO-8601 last update timestamp.
+ * @property {integer} version - Optimistic-locking version.
+ * @property {BaseUserResponse} for.required - The user whose balance will be credited on payment.
+ * @property {BaseUserResponse} createdBy.required - The user that issued this request.
+ * @property {DineroObjectResponse} amount.required - Fixed, immutable amount.
+ * @property {string} expiresAt.required - ISO-8601 timestamp after which payments stop being accepted.
+ * @property {string} paidAt - ISO-8601 timestamp the request was marked paid (null if not paid).
+ * @property {string} cancelledAt - ISO-8601 timestamp the request was cancelled (null if not cancelled).
+ * @property {BaseUserResponse} cancelledBy - The user that cancelled the request (null if not cancelled).
+ * @property {BaseUserResponse} fulfilledBy - The admin that marked the request paid out-of-band (null for Stripe-settled or unpaid requests).
+ * @property {string} description - Optional human-readable description.
+ * @property {string} status.required - enum:PENDING,PAID,EXPIRED,CANCELLED - Derived lifecycle status.
+ */
+export interface BasePaymentRequestResponse extends BaseResponseWithoutId {
+  id: string;
+  for: BaseUserResponse;
+  createdBy: BaseUserResponse;
+  amount: DineroObjectResponse;
+  expiresAt: string;
+  paidAt: string | null;
+  cancelledAt: string | null;
+  cancelledBy: BaseUserResponse | null;
+  fulfilledBy: BaseUserResponse | null;
+  description: string | null;
+  status: PaymentRequestStatus;
+}
+
+/**
+ * Minimal response returned to unauthenticated callers of the public share
+ * link endpoint. It deliberately omits `createdBy`, `cancelledBy`, and other
+ * internal audit fields — anyone with the link can see it, so we leak as
+ * little user info as possible.
+ *
+ * @typedef {object} PublicPaymentRequestResponse
+ * @property {string} id.required - UUID v4 identifier.
+ * @property {string} forDisplayName.required - Recipient display name (e.g. "John D.").
+ * @property {DineroObjectResponse} amount.required - Fixed amount to be paid.
+ * @property {string} expiresAt.required - ISO-8601 timestamp after which payments stop being accepted.
+ * @property {string} description - Optional human-readable description.
+ * @property {string} status.required - enum:PENDING,PAID,EXPIRED,CANCELLED - Derived lifecycle status.
+ */
+export interface PublicPaymentRequestResponse {
+  id: string;
+  forDisplayName: string;
+  amount: DineroObjectResponse;
+  expiresAt: string;
+  description: string | null;
+  status: PaymentRequestStatus;
+}
+
+/**
+ * Response returned from the "start payment" endpoint. Contains just enough
+ * to let the browser redirect into the Stripe Payment Element.
+ *
+ * @typedef {object} PaymentRequestStartResponse
+ * @property {string} paymentRequestId.required - The PaymentRequest id the intent is linked to.
+ * @property {string} stripeId.required - Stripe payment intent id.
+ * @property {string} clientSecret.required - Stripe client secret for the intent.
+ */
+export interface PaymentRequestStartResponse {
+  paymentRequestId: string;
+  stripeId: string;
+  clientSecret: string;
+}
+
+/**
+ * @typedef {object} PaginatedBasePaymentRequestResponse
+ * @property {PaginationResult} _pagination.required - Pagination metadata
+ * @property {Array<BasePaymentRequestResponse>} records.required - Returned payment requests
+ */
+export interface PaginatedBasePaymentRequestResponse {
+  _pagination: PaginationResult;
+  records: BasePaymentRequestResponse[];
+}

--- a/src/controller/user-controller.ts
+++ b/src/controller/user-controller.ts
@@ -42,6 +42,7 @@ import PointOfSaleService from '../service/point-of-sale-service';
 import TransactionService, { parseGetTransactionsFilters } from '../service/transaction-service';
 import ContainerService from '../service/container-service';
 import TransferService, { parseGetTransferFilters } from '../service/transfer-service';
+import PaymentRequestService, { parseGetPaymentRequestsFilters } from '../service/payment-request-service';
 import AuthenticationService from '../service/authentication-service';
 import TokenHandler from '../authentication/token-handler';
 import RBACService from '../service/rbac-service';
@@ -339,6 +340,14 @@ export default class UserController extends BaseController {
             req.token.roles, 'get', UserController.getRelation(req), 'Transfer', ['*'],
           ),
           handler: this.getUsersTransfers.bind(this),
+        },
+      },
+      '/:id(\\d+)/payment-requests': {
+        GET: {
+          policy: async (req) => this.roleManager.can(
+            req.token.roles, 'get', UserController.getRelation(req), 'PaymentRequest', ['*'],
+          ),
+          handler: this.getUsersPaymentRequests.bind(this),
         },
       },
       '/:id(\\d+)/financialmutations': {
@@ -1446,6 +1455,58 @@ export default class UserController extends BaseController {
       res.json(toResponse(records, count, { take, skip }));
     } catch (error) {
       this.logger.error('Could not return user transfers', error);
+      res.status(500).json('Internal server error.');
+    }
+  }
+
+  /**
+   * GET /users/{id}/payment-requests
+   * @summary Get the PaymentRequests where the given user is the beneficiary.
+   *   Regular users can hit this for their own id; admins can hit it for any user.
+   * @operationId getUsersPaymentRequests
+   * @tags users - Operations of user controller
+   * @param {integer} id.path.required - The id of the beneficiary user.
+   * @param {integer} createdById.query - Filter by creator user id.
+   * @param {string} status.query - enum:PENDING,PAID,EXPIRED,CANCELLED - Comma-separated list of derived statuses.
+   * @param {string} fromDate.query - Filter requests created on or after this ISO date (inclusive).
+   * @param {string} tillDate.query - Filter requests created strictly before this ISO date (exclusive).
+   * @param {integer} take.query - How many rows the endpoint should return
+   * @param {integer} skip.query - How many rows to skip (for pagination)
+   * @security JWT
+   * @return {PaginatedBasePaymentRequestResponse} 200 - Payment requests for the user
+   * @return {string} 400 - Validation error
+   * @return {string} 404 - Unknown user id
+   */
+  public async getUsersPaymentRequests(req: RequestWithToken, res: Response): Promise<void> {
+    const { id } = req.params;
+    this.logger.trace("Get user's payment requests", id, 'by user', req.token.user);
+
+    let filters;
+    let pagination;
+    try {
+      filters = parseGetPaymentRequestsFilters(req);
+      pagination = parseRequestPagination(req);
+    } catch (e) {
+      res.status(400).send(e instanceof Error ? e.message : String(e));
+      return;
+    }
+
+    try {
+      const user = await User.findOne({ where: { id: parseInt(id, 10), deleted: false } });
+      if (user == null) {
+        res.status(404).json('Unknown user ID.');
+        return;
+      }
+
+      // forId comes from the URL — any forId in the query is ignored by design.
+      const service = new PaymentRequestService();
+      const [rows, count] = await service.getPaymentRequests(
+        { ...filters, forId: user.id }, pagination,
+      );
+      const records = rows.map((r) => PaymentRequestService.asBasePaymentRequestResponse(r));
+      res.json(toResponse(records, count, pagination));
+    } catch (e) {
+      this.logger.error('Could not return user payment requests', e);
       res.status(500).json('Internal server error.');
     }
   }

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -109,6 +109,11 @@ import {
   RemoveCreditTransferFromInactiveAdministrativeCost1769005123365,
 } from '../migrations/1769005123365-remove-credit-transfer-from-inactive-administrative-cost';
 import { AddLastSeenToUser1769000095806 } from '../migrations/1769000095806-add-last-seen-to-user';
+import PaymentRequest from '../entity/payment-request/payment-request';
+import { PaymentRequest1777010230727 } from '../migrations/1777010230727-payment-request';
+import {
+  StripePaymentIntentPaymentRequest1777010230751,
+} from '../migrations/1777010230751-stripe-payment-intent-payment-request';
 import Config from '../config';
 
 function getDataSourceOptions(): DataSourceOptions {
@@ -145,6 +150,8 @@ function getDataSourceOptions(): DataSourceOptions {
       UserSetting1768697568707,
       RemoveCreditTransferFromInactiveAdministrativeCost1769005123365,
       AddLastSeenToUser1769000095806,
+      PaymentRequest1777010230727,
+      StripePaymentIntentPaymentRequest1777010230751,
     ],
     extra: {
       authPlugins: {
@@ -216,6 +223,7 @@ function getDataSourceOptions(): DataSourceOptions {
       NotificationLog,
       UserNotificationPreference,
       UserSetting,
+      PaymentRequest,
     ],
     subscribers: [
       TransactionSubscriber,

--- a/src/entity/payment-request/payment-request-status.ts
+++ b/src/entity/payment-request/payment-request-status.ts
@@ -1,0 +1,41 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * @module stripe/payment-request
+ */
+
+/**
+ * Derived status of a {@link PaymentRequest}.
+ *
+ * The status is **not stored** on the entity — it is computed from the
+ * combination of `paidAt`, `cancelledAt`, and `expiresAt` against the
+ * current clock. See {@link PaymentRequest.status}.
+ */
+export enum PaymentRequestStatus {
+  /** Awaiting payment, not yet expired or cancelled. */
+  PENDING = 'PENDING',
+  /** A linked StripeDeposit succeeded and the credit Transfer was created. */
+  PAID = 'PAID',
+  /** `expiresAt` has passed without payment. */
+  EXPIRED = 'EXPIRED',
+  /** Explicitly cancelled by an authorized user. */
+  CANCELLED = 'CANCELLED',
+}

--- a/src/entity/payment-request/payment-request.ts
+++ b/src/entity/payment-request/payment-request.ts
@@ -1,0 +1,216 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * This is the module page of the payment-request.
+ *
+ * A `PaymentRequest` is an immutable, unauthenticated, shareable request to
+ * top up a specific user's balance with a specific amount before a specific
+ * deadline. It is the domain primitive behind what end-users perceive as a
+ * "payment link".
+ *
+ * ## Lifecycle
+ *
+ * A request is created in `PENDING` state with an `expiresAt` and a fixed
+ * `amount`. From there it transitions to exactly one of:
+ *
+ * - `PAID` — a linked {@link stripe!StripePaymentIntent | StripePaymentIntent}
+ *   succeeded and the corresponding void→user `Transfer` was created.
+ * - `CANCELLED` — explicitly cancelled by an authorized user (e.g. a wrong
+ *   amount was issued and a fresh request will be created instead).
+ * - `EXPIRED` — `expiresAt` has passed without payment.
+ *
+ * Status is **derived**, not stored — see {@link PaymentRequest.status}. The
+ * only stored state is `paidAt`, `cancelledAt`, and `expiresAt`.
+ *
+ * ## Stripe relationship (one-to-many on the inverse side)
+ *
+ * A request may have many {@link stripe!StripePaymentIntent | StripePaymentIntent}
+ * rows over its lifetime — each call to `startPayment` mints a fresh intent
+ * (the user can abandon a session and try again). The request becomes "paid"
+ * when at least one of those intents reaches `SUCCEEDED` and its
+ * `StripeDeposit.transfer` exists.
+ *
+ * ## Amount immutability
+ *
+ * The `amount` is fixed at creation time and cannot be mutated. The user-
+ * facing email/PDF mentions a specific euro figure; if SudoSOS were to
+ * recompute the figure at pay-time (against a moving balance), the email
+ * and the actual charge would diverge. To correct a wrong amount, cancel
+ * the request and create a new one — never mutate.
+ *
+ * ## Always credits balance on success
+ *
+ * A successful payment **always** results in a standard void→user `Transfer`
+ * that credits the recipient's balance. `PaymentRequest` is a top-up
+ * primitive — callers that do not want a balance credit (e.g. a future
+ * "invoice via payment link" flow) must not pre-create their own credit
+ * Transfer; the Stripe deposit is the single settlement event.
+ *
+ * ## Admin escape hatch
+ *
+ * Reality intrudes: occasionally a user pays a payment-link's invoice via
+ * bank transfer instead of iDeal. The admin endpoint
+ * `POST /payment-requests/:id/mark-fulfilled` creates the credit Transfer
+ * manually (with a reason for audit), flipping the request to `PAID` without
+ * a Stripe deposit existing.
+ *
+ * ## Out of scope (tracked elsewhere)
+ *
+ * - Linking back to {@link invoicing!Invoice | Invoice}
+ *   (`Invoice.paymentRequest?` lives on the invoice side).
+ * - Settlement (positive-balance payouts) for disabled users — a separate
+ *   primitive, not this one.
+ * - Stripe refund handling.
+ *
+ * @module stripe/payment-request
+ * @mergeTarget
+ */
+
+import {
+  Column, Entity, JoinColumn, ManyToOne, PrimaryColumn,
+} from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+import { Dinero } from 'dinero.js';
+import BaseEntityWithoutId from '../base-entity-without-id';
+import User from '../user/user';
+import DineroTransformer from '../transformer/dinero-transformer';
+import { PaymentRequestStatus } from './payment-request-status';
+
+/**
+ * A shareable, fixed-amount request to top up a specific user's SudoSOS
+ * balance. See the module page for full lifecycle and integration notes.
+ *
+ * @typedef {BaseEntityWithoutId} PaymentRequest
+ * @property {string} id.required - UUID v4, also the public identifier shared in the link.
+ * @property {User.model} for.required - The user whose balance will be credited on payment.
+ * @property {User.model} createdBy.required - The user that issued this request (audit).
+ * @property {integer} amount.required - Fixed amount in cents (Dinero); immutable.
+ * @property {string} expiresAt.required - When the request stops accepting payments.
+ * @property {string} cancelledAt - When the request was cancelled (null if not cancelled).
+ * @property {User.model} cancelledBy - The user that cancelled this request (null if not cancelled).
+ * @property {string} paidAt - When the request was marked paid (null if pending/cancelled/expired).
+ * @property {User.model} fulfilledBy - The admin that marked the request paid out-of-band via the escape hatch (null otherwise).
+ * @property {string} description - Human-readable description (e.g. "Drinks at Walhalla naborrel 2026-04-12").
+ *
+ * @promote
+ */
+@Entity()
+export default class PaymentRequest extends BaseEntityWithoutId {
+  /** UUID v4. Also the public-facing identifier shared in payment links. */
+  @PrimaryColumn({
+    type: 'varchar',
+    length: 36,
+  })
+  public id: string;
+
+  /** The user whose balance will be credited on successful payment. */
+  @ManyToOne(() => User, { nullable: false, eager: true, onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'forId' })
+  // Keep the domain term: `for` reads naturally as "PaymentRequest for a user".
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public for: User;
+
+  /** Audit: who issued this request. */
+  @ManyToOne(() => User, { nullable: false, onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'createdById' })
+  public createdBy: User;
+
+  /** Fixed, immutable amount. */
+  @Column({
+    type: 'integer',
+    transformer: DineroTransformer.Instance,
+  })
+  public amount: Dinero;
+
+  /** After this moment the request stops accepting payments. */
+  @Column({
+    type: 'datetime',
+  })
+  public expiresAt: Date;
+
+  /** When the request was cancelled, null if not cancelled. */
+  @Column({
+    type: 'datetime',
+    nullable: true,
+  })
+  public cancelledAt: Date | null;
+
+  /** Who cancelled the request (audit), null if not cancelled. */
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'cancelledById' })
+  public cancelledBy: User | null;
+
+  /** When the request was marked paid (Stripe success or admin override). */
+  @Column({
+    type: 'datetime',
+    nullable: true,
+  })
+  public paidAt: Date | null;
+
+  /**
+   * Audit: the admin that flipped this request to PAID via the out-of-band
+   * escape hatch (`markFulfilledExternally`). `null` for Stripe-settled
+   * requests — those are unambiguously attributed via the linked
+   * `StripePaymentIntent`.
+   */
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'fulfilledById' })
+  public fulfilledBy: User | null;
+
+  /** Optional human-readable description for context (e.g. invoice reference). */
+  @Column({
+    type: 'varchar',
+    length: 255,
+    nullable: true,
+  })
+  public description: string | null;
+
+  /**
+   * Derived status — not persisted. Order of precedence:
+   * `PAID` > `CANCELLED` > `EXPIRED` > `PENDING`.
+   */
+  public get status(): PaymentRequestStatus {
+    if (this.paidAt !== null && this.paidAt !== undefined) {
+      return PaymentRequestStatus.PAID;
+    }
+    if (this.cancelledAt !== null && this.cancelledAt !== undefined) {
+      return PaymentRequestStatus.CANCELLED;
+    }
+    if (this.expiresAt < new Date()) {
+      return PaymentRequestStatus.EXPIRED;
+    }
+    return PaymentRequestStatus.PENDING;
+  }
+
+  async getOwner(): Promise<User> {
+    return this.for;
+  }
+
+  constructor() {
+    super();
+    this.id = uuidv4();
+    this.cancelledAt = null;
+    this.cancelledBy = null;
+    this.paidAt = null;
+    this.fulfilledBy = null;
+    this.description = null;
+  }
+}

--- a/src/entity/stripe/stripe-payment-intent.ts
+++ b/src/entity/stripe/stripe-payment-intent.ts
@@ -25,11 +25,13 @@
  */
 
 import BaseEntity from '../base-entity';
-import { Column, Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne } from 'typeorm';
 import StripePaymentIntentStatus from './stripe-payment-intent-status';
 import DineroTransformer from '../transformer/dinero-transformer';
 import { Dinero } from 'dinero.js';
 import StripeDeposit from './stripe-deposit';
+// eslint-disable-next-line import/no-cycle
+import PaymentRequest from '../payment-request/payment-request';
 
 @Entity()
 export default class StripePaymentIntent extends BaseEntity {
@@ -50,4 +52,16 @@ export default class StripePaymentIntent extends BaseEntity {
 
   @OneToOne(() => StripeDeposit, (s) => s.stripePaymentIntent, { nullable: true })
   public deposit: StripeDeposit | null;
+
+  /**
+   * Optional back-reference to a {@link stripe/payment-request!PaymentRequest | PaymentRequest}
+   * that initiated this intent. Set when the intent is created via
+   * `PaymentRequestService.startPayment` (directly or via the public start
+   * endpoint). When set, the Stripe webhook hook in
+   * `StripeService.createNewPaymentIntentStatus` will mark the linked
+   * PaymentRequest as paid on `SUCCEEDED`.
+   */
+  @ManyToOne(() => PaymentRequest, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'paymentRequestId' })
+  public paymentRequest?: PaymentRequest | null;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,8 @@ import SimpleFileController from './controller/simple-file-controller';
 import initializeDiskStorage from './files/initialize';
 import StripeController from './controller/stripe-controller';
 import StripeWebhookController from './controller/stripe-webhook-controller';
+import PaymentRequestController from './controller/payment-request-controller';
+import PaymentRequestPublicController from './controller/payment-request-public-controller';
 import { extractRawBody } from './helpers/raw-body';
 import InvoiceController from './controller/invoice-controller';
 import PayoutRequestController from './controller/payout-request-controller';
@@ -251,6 +253,10 @@ export default async function createApp(): Promise<Application> {
   };
   if (config.stripe.enabled) {
     application.app.use('/v1/stripe', new StripeWebhookController(options).getRouter());
+    // Public share-link surface for PaymentRequest. Mounted BEFORE
+    // setupAuthentication so the `async () => true` policies are reachable
+    // without a JWT.
+    application.app.use('/v1/payment-requests-public', new PaymentRequestPublicController(options).getRouter());
   }
 
   const tokenHandler = await createTokenHandler();
@@ -378,6 +384,7 @@ export default async function createApp(): Promise<Application> {
   application.app.use('/v1/fines', new DebtorController(options).getRouter());
   if (config.stripe.enabled) {
     application.app.use('/v1/stripe', new StripeController(options).getRouter());
+    application.app.use('/v1/payment-requests', new PaymentRequestController(options).getRouter());
   }
   application.app.use('/v1/payoutrequests', new PayoutRequestController(options).getRouter());
   application.app.use('/v1/invoices', new InvoiceController(options).getRouter());

--- a/src/migrations/1777010230727-payment-request.ts
+++ b/src/migrations/1777010230727-payment-request.ts
@@ -1,0 +1,212 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * @module
+ * @hidden
+ */
+
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+export class PaymentRequest1777010230727 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(new Table({
+      name: 'payment_request',
+      columns: [
+        {
+          name: 'id',
+          type: 'varchar',
+          length: '36',
+          isPrimary: true,
+          isNullable: false,
+        },
+        {
+          name: 'forId',
+          type: 'integer',
+          isNullable: false,
+        },
+        {
+          name: 'createdById',
+          type: 'integer',
+          isNullable: false,
+        },
+        {
+          name: 'amount',
+          type: 'integer',
+          isNullable: false,
+        },
+        {
+          name: 'expiresAt',
+          type: 'datetime',
+          isNullable: false,
+        },
+        {
+          name: 'cancelledAt',
+          type: 'datetime',
+          isNullable: true,
+        },
+        {
+          name: 'cancelledById',
+          type: 'integer',
+          isNullable: true,
+        },
+        {
+          name: 'paidAt',
+          type: 'datetime',
+          isNullable: true,
+        },
+        {
+          name: 'fulfilledById',
+          type: 'integer',
+          isNullable: true,
+        },
+        {
+          name: 'description',
+          type: 'varchar',
+          length: '255',
+          isNullable: true,
+        },
+        {
+          name: 'createdAt',
+          type: 'datetime',
+          default: 'current_timestamp',
+          isNullable: false,
+        },
+        {
+          name: 'updatedAt',
+          type: 'datetime',
+          default: 'current_timestamp',
+          onUpdate: 'current_timestamp',
+          isNullable: false,
+        },
+        {
+          name: 'version',
+          type: 'integer',
+          isNullable: false,
+          default: 1,
+        },
+      ],
+    }), true);
+
+    // Foreign keys
+    await queryRunner.createForeignKey('payment_request', new TableForeignKey({
+      columnNames: ['forId'],
+      referencedColumnNames: ['id'],
+      referencedTableName: 'user',
+      onDelete: 'RESTRICT',
+      onUpdate: 'NO ACTION',
+    }));
+
+    await queryRunner.createForeignKey('payment_request', new TableForeignKey({
+      columnNames: ['createdById'],
+      referencedColumnNames: ['id'],
+      referencedTableName: 'user',
+      onDelete: 'RESTRICT',
+      onUpdate: 'NO ACTION',
+    }));
+
+    await queryRunner.createForeignKey('payment_request', new TableForeignKey({
+      columnNames: ['cancelledById'],
+      referencedColumnNames: ['id'],
+      referencedTableName: 'user',
+      onDelete: 'SET NULL',
+      onUpdate: 'NO ACTION',
+    }));
+
+    await queryRunner.createForeignKey('payment_request', new TableForeignKey({
+      columnNames: ['fulfilledById'],
+      referencedColumnNames: ['id'],
+      referencedTableName: 'user',
+      onDelete: 'SET NULL',
+      onUpdate: 'NO ACTION',
+    }));
+
+    // Indexes
+    await queryRunner.createIndex('payment_request', new TableIndex({
+      name: 'IDX_payment_request_createdAt',
+      columnNames: ['createdAt'],
+    }));
+
+    await queryRunner.createIndex('payment_request', new TableIndex({
+      name: 'IDX_payment_request_forId',
+      columnNames: ['forId'],
+    }));
+
+    await queryRunner.createIndex('payment_request', new TableIndex({
+      name: 'IDX_payment_request_createdById',
+      columnNames: ['createdById'],
+    }));
+
+    await queryRunner.createIndex('payment_request', new TableIndex({
+      name: 'IDX_payment_request_cancelledById',
+      columnNames: ['cancelledById'],
+    }));
+
+    await queryRunner.createIndex('payment_request', new TableIndex({
+      name: 'IDX_payment_request_fulfilledById',
+      columnNames: ['fulfilledById'],
+    }));
+
+    await queryRunner.createIndex('payment_request', new TableIndex({
+      name: 'IDX_payment_request_expiresAt',
+      columnNames: ['expiresAt'],
+    }));
+
+    await queryRunner.createIndex('payment_request', new TableIndex({
+      name: 'IDX_payment_request_paidAt',
+      columnNames: ['paidAt'],
+    }));
+
+    // Composite index for the most common query: "open requests for user X"
+    await queryRunner.createIndex('payment_request', new TableIndex({
+      name: 'IDX_payment_request_forId_paidAt',
+      columnNames: ['forId', 'paidAt'],
+    }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop indexes
+    await queryRunner.dropIndex('payment_request', 'IDX_payment_request_forId_paidAt');
+    await queryRunner.dropIndex('payment_request', 'IDX_payment_request_paidAt');
+    await queryRunner.dropIndex('payment_request', 'IDX_payment_request_expiresAt');
+    await queryRunner.dropIndex('payment_request', 'IDX_payment_request_fulfilledById');
+    await queryRunner.dropIndex('payment_request', 'IDX_payment_request_cancelledById');
+    await queryRunner.dropIndex('payment_request', 'IDX_payment_request_createdById');
+    await queryRunner.dropIndex('payment_request', 'IDX_payment_request_forId');
+    await queryRunner.dropIndex('payment_request', 'IDX_payment_request_createdAt');
+
+    // Drop foreign keys
+    const table = await queryRunner.getTable('payment_request');
+    if (table) {
+      const fulfilledByFk = table.foreignKeys.find(f => f.columnNames.indexOf('fulfilledById') !== -1);
+      if (fulfilledByFk) await queryRunner.dropForeignKey('payment_request', fulfilledByFk);
+      const cancelledByFk = table.foreignKeys.find(f => f.columnNames.indexOf('cancelledById') !== -1);
+      if (cancelledByFk) await queryRunner.dropForeignKey('payment_request', cancelledByFk);
+      const createdByFk = table.foreignKeys.find(f => f.columnNames.indexOf('createdById') !== -1);
+      if (createdByFk) await queryRunner.dropForeignKey('payment_request', createdByFk);
+      const forFk = table.foreignKeys.find(f => f.columnNames.indexOf('forId') !== -1);
+      if (forFk) await queryRunner.dropForeignKey('payment_request', forFk);
+    }
+
+    await queryRunner.dropTable('payment_request');
+  }
+
+}

--- a/src/migrations/1777010230751-stripe-payment-intent-payment-request.ts
+++ b/src/migrations/1777010230751-stripe-payment-intent-payment-request.ts
@@ -1,0 +1,65 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * @module
+ * @hidden
+ */
+
+import { MigrationInterface, QueryRunner, TableColumn, TableForeignKey, TableIndex } from 'typeorm';
+
+export class StripePaymentIntentPaymentRequest1777010230751 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn('stripe_payment_intent', new TableColumn({
+      name: 'paymentRequestId',
+      type: 'varchar',
+      length: '36',
+      isNullable: true,
+      default: null,
+    }));
+
+    await queryRunner.createForeignKey('stripe_payment_intent', new TableForeignKey({
+      columnNames: ['paymentRequestId'],
+      referencedColumnNames: ['id'],
+      referencedTableName: 'payment_request',
+      onDelete: 'SET NULL',
+      onUpdate: 'NO ACTION',
+    }));
+
+    await queryRunner.createIndex('stripe_payment_intent', new TableIndex({
+      name: 'IDX_stripe_payment_intent_paymentRequestId',
+      columnNames: ['paymentRequestId'],
+    }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('stripe_payment_intent', 'IDX_stripe_payment_intent_paymentRequestId');
+
+    const table = await queryRunner.getTable('stripe_payment_intent');
+    if (table) {
+      const paymentRequestFk = table.foreignKeys.find(f => f.columnNames.indexOf('paymentRequestId') !== -1);
+      if (paymentRequestFk) await queryRunner.dropForeignKey('stripe_payment_intent', paymentRequestFk);
+    }
+
+    await queryRunner.dropColumn('stripe_payment_intent', 'paymentRequestId');
+  }
+
+}

--- a/src/rbac/default-roles.ts
+++ b/src/rbac/default-roles.ts
@@ -97,6 +97,14 @@ export default class DefaultRoles {
         TermsOfService: {
           get: { own: star },
         },
+        PaymentRequest: {
+          // Any regular user can list/fetch their own PaymentRequests and
+          // create new ones for themselves. Cancelling/starting is `update`
+          // on the same relation.
+          get: { own: star },
+          create: { own: star },
+          update: { own: star },
+        },
       },
     }, {
       name: 'Local User',
@@ -215,6 +223,7 @@ export default class DefaultRoles {
           notify: { all: star },
         },
         PayoutRequest: admin,
+        PaymentRequest: admin,
         SellerPayout: admin,
         Permission: admin,
         PointOfSale: admin,

--- a/src/service/payment-request-service.ts
+++ b/src/service/payment-request-service.ts
@@ -1,0 +1,485 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * This is the module page of the payment-request-service.
+ *
+ * Service layer for {@link stripe/payment-request!PaymentRequest | PaymentRequest}.
+ * Owns creation, lookup, cancellation, payment session bootstrap, and the
+ * settlement-time hook invoked from the Stripe webhook flow in
+ * {@link stripe!StripeService | StripeService}.
+ *
+ * @module stripe/payment-request-service
+ */
+
+import { Dinero } from 'dinero.js';
+import { Brackets, EntityManager, SelectQueryBuilder } from 'typeorm';
+import PaymentRequest from '../entity/payment-request/payment-request';
+import { PaymentRequestStatus } from '../entity/payment-request/payment-request-status';
+import User, { UserType } from '../entity/user/user';
+import StripeDeposit from '../entity/stripe/stripe-deposit';
+import StripePaymentIntent from '../entity/stripe/stripe-payment-intent';
+import StripeService from './stripe-service';
+import TransferService from './transfer-service';
+import WithManager from '../database/with-manager';
+import { PaginationParameters } from '../helpers/pagination';
+import { toMySQLString } from '../helpers/timestamps';
+
+/**
+ * User types that are **never** allowed to be the beneficiary of a PaymentRequest.
+ * Soft-deleted users are rejected at runtime regardless of type.
+ *
+ * Returned via a function (not a top-level const) to sidestep the circular
+ * import chain (`stripe-service.ts` → `payment-request-service.ts` → `user.ts`
+ * → ... → `stripe-service.ts`) that leaves `UserType` temporarily undefined
+ * at module-evaluation time.
+ */
+export const invalidPaymentRequestBeneficiaryTypes = (): UserType[] => [
+  UserType.POINT_OF_SALE,
+];
+
+/**
+ * Maximum length of `PaymentRequest.description` and `Transfer.description`,
+ * both persisted as `varchar(255)`. Validated up-front in the service so the
+ * caller gets a clear error instead of a low-level DB constraint failure.
+ */
+export const PAYMENT_REQUEST_DESCRIPTION_MAX_LENGTH = 255;
+export const TRANSFER_DESCRIPTION_MAX_LENGTH = 255;
+
+export interface CreatePaymentRequestParams {
+  /** The user whose balance will be credited on successful payment. */
+  for: User;
+  /** Audit: the user issuing this request (admin or the `for` user themselves). */
+  createdBy: User;
+  /** Fixed, immutable amount (Dinero). */
+  amount: Dinero;
+  /** When the request stops accepting payments. Must be in the future. */
+  expiresAt: Date;
+  /** Optional human-readable description (e.g. invoice reference). */
+  description?: string | null;
+}
+
+export interface PaymentRequestFilterParameters {
+  id?: string;
+  forId?: number;
+  createdById?: number;
+  /**
+   * Filter by one or more derived statuses. Status is derived from
+   * `paidAt` / `cancelledAt` / `expiresAt`, but we translate each candidate
+   * status into an equivalent SQL predicate so pagination happens in the DB.
+   */
+  status?: PaymentRequestStatus[];
+  /** Only requests created on or after this date. */
+  fromDate?: Date;
+  /** Only requests created strictly before this date. */
+  tillDate?: Date;
+}
+
+/**
+ * Thrown when a PaymentRequest cannot be created or paid because the
+ * beneficiary user is ineligible (soft-deleted, point-of-sale, etc.).
+ */
+export class InvalidPaymentRequestBeneficiaryError extends Error {
+  public constructor(reason: string) {
+    super(`Invalid PaymentRequest beneficiary: ${reason}`);
+    this.name = 'InvalidPaymentRequestBeneficiaryError';
+  }
+}
+
+/**
+ * Thrown when a state transition on a PaymentRequest is illegal — e.g.
+ * cancelling an already-paid request, or starting payment on a cancelled
+ * or expired one.
+ */
+export class IllegalPaymentRequestTransitionError extends Error {
+  public constructor(reason: string) {
+    super(`Illegal PaymentRequest transition: ${reason}`);
+    this.name = 'IllegalPaymentRequestTransitionError';
+  }
+}
+
+/**
+ * Service layer for {@link stripe/payment-request!PaymentRequest | PaymentRequest}.
+ *
+ * ## Creation & validation
+ *
+ * - `createPaymentRequest` validates the beneficiary user and persists a
+ *   fresh PENDING request with a fixed amount and expiry.
+ *
+ * ## Lookup
+ *
+ * - `getPaymentRequest(id)` fetches a single request with its relations.
+ * - `getPaymentRequests(filters, pagination)` is the paginated admin listing.
+ *
+ * ## Payment session bootstrap
+ *
+ * - `startPayment(request)` creates a Stripe payment intent linked to the
+ *   request. Called by both the authenticated endpoint and the public
+ *   (unauthenticated) endpoint. The linked intent carries the back-reference
+ *   that {@link stripe!StripeService | StripeService} uses at SUCCEEDED
+ *   time to flip the request to PAID.
+ *
+ * ## State transitions
+ *
+ * - `cancelPaymentRequest` moves PENDING → CANCELLED (rejects all other source states).
+ * - `markFulfilledExternally` is the admin escape hatch when a user paid
+ *   out-of-band (e.g. bank transfer). Creates the void→user credit Transfer
+ *   manually and marks the request PAID.
+ * - `markPaid` is called from the Stripe webhook when a linked payment intent
+ *   reaches SUCCEEDED. Idempotent — already-PAID requests are left alone.
+ */
+export default class PaymentRequestService extends WithManager {
+  public constructor(manager?: EntityManager) {
+    super(manager);
+  }
+
+  /**
+   * Validate a candidate beneficiary for a PaymentRequest.
+   *
+   * Rules:
+   * - Soft-deleted users are always rejected.
+   * - `UserType.POINT_OF_SALE` is rejected (POS users are synthetic).
+   * - Inactive users and `UserType.INVOICE` users are **allowed** — the whole
+   *   point is that alumni with a debt and invoice accounts can pay off their
+   *   balance via a shareable link.
+   *
+   * @throws {InvalidPaymentRequestBeneficiaryError} when the user is ineligible.
+   */
+  public static validatePayable(user: User): void {
+    if (!user) {
+      throw new InvalidPaymentRequestBeneficiaryError('user is missing');
+    }
+    if (user.deleted) {
+      throw new InvalidPaymentRequestBeneficiaryError('user is soft-deleted');
+    }
+    if (invalidPaymentRequestBeneficiaryTypes().includes(user.type)) {
+      throw new InvalidPaymentRequestBeneficiaryError(
+        `user type ${user.type} cannot be a payment-request beneficiary`,
+      );
+    }
+  }
+
+  /**
+   * Create and persist a new PaymentRequest. Amount is immutable after this.
+   * @throws {InvalidPaymentRequestBeneficiaryError} if `params.for` is ineligible.
+   * @throws {Error} if `params.expiresAt` is not strictly in the future, if
+   *   `params.amount` is not strictly positive, or if `params.description`
+   *   exceeds {@link PAYMENT_REQUEST_DESCRIPTION_MAX_LENGTH}.
+   */
+  public async createPaymentRequest(params: CreatePaymentRequestParams): Promise<PaymentRequest> {
+    PaymentRequestService.validatePayable(params.for);
+
+    if (!params.expiresAt || params.expiresAt.getTime() <= Date.now()) {
+      throw new Error('PaymentRequest expiresAt must be strictly in the future.');
+    }
+    if (!params.amount || params.amount.getAmount() <= 0) {
+      throw new Error('PaymentRequest amount must be strictly positive.');
+    }
+    if (
+      params.description != null
+      && params.description.length > PAYMENT_REQUEST_DESCRIPTION_MAX_LENGTH
+    ) {
+      throw new Error(
+        `PaymentRequest description must be at most ${PAYMENT_REQUEST_DESCRIPTION_MAX_LENGTH} characters.`,
+      );
+    }
+
+    const request = new PaymentRequest();
+    request.for = params.for;
+    request.createdBy = params.createdBy;
+    request.amount = params.amount;
+    request.expiresAt = params.expiresAt;
+    request.description = params.description ?? null;
+
+    return this.manager.getRepository(PaymentRequest).save(request);
+  }
+
+  /**
+   * Fetch a single PaymentRequest by id, including its relations. Returns
+   * `null` when no request with that id exists.
+   */
+  public async getPaymentRequest(id: string): Promise<PaymentRequest | null> {
+    return this.manager.getRepository(PaymentRequest).findOne({
+      where: { id },
+      relations: {
+        for: true,
+        createdBy: true,
+        cancelledBy: true,
+        fulfilledBy: true,
+      },
+    });
+  }
+
+  /**
+   * Lighter-weight lookup for the public share-link surface: loads only the
+   * `for` relation (needed for `forDisplayName`) and skips the audit joins
+   * that the public response intentionally omits. Keeps the unauthenticated
+   * route lean since anyone holding a link can hit it.
+   */
+  public async getPublicPaymentRequest(id: string): Promise<PaymentRequest | null> {
+    return this.manager.getRepository(PaymentRequest).findOne({
+      where: { id },
+      relations: { for: true },
+    });
+  }
+
+  /**
+   * Paginated filtered listing of PaymentRequests. Status is a derived
+   * getter (see {@link PaymentRequest.status}), but we translate each
+   * candidate status into an equivalent SQL predicate on the stored
+   * `paidAt` / `cancelledAt` / `expiresAt` columns so pagination happens
+   * in the database.
+   *
+   * Status → predicate mapping (precedence: PAID > CANCELLED > EXPIRED > PENDING):
+   * - `PAID`      → `paidAt IS NOT NULL`
+   * - `CANCELLED` → `paidAt IS NULL AND cancelledAt IS NOT NULL`
+   * - `EXPIRED`   → `paidAt IS NULL AND cancelledAt IS NULL AND expiresAt < NOW()`
+   * - `PENDING`   → `paidAt IS NULL AND cancelledAt IS NULL AND expiresAt >= NOW()`
+   *
+   * Multiple statuses are OR-combined inside the brackets so the `AND` with
+   * the non-status predicates stays correct.
+   */
+  public async getPaymentRequests(
+    filters: PaymentRequestFilterParameters = {},
+    pagination: PaginationParameters = {},
+  ): Promise<[PaymentRequest[], number]> {
+    const { take, skip } = pagination;
+    const qb = this.manager.getRepository(PaymentRequest)
+      .createQueryBuilder('pr')
+      .leftJoinAndSelect('pr.for', 'pr_for')
+      .leftJoinAndSelect('pr.createdBy', 'pr_createdBy')
+      .leftJoinAndSelect('pr.cancelledBy', 'pr_cancelledBy')
+      .leftJoinAndSelect('pr.fulfilledBy', 'pr_fulfilledBy');
+
+    if (filters.id) qb.andWhere('pr.id = :id', { id: filters.id });
+    if (filters.forId !== undefined) qb.andWhere('pr.forId = :forId', { forId: filters.forId });
+    if (filters.createdById !== undefined) {
+      qb.andWhere('pr.createdById = :createdById', { createdById: filters.createdById });
+    }
+    if (filters.fromDate) {
+      qb.andWhere('pr.createdAt >= :fromDate', { fromDate: toMySQLString(filters.fromDate) });
+    }
+    if (filters.tillDate) {
+      qb.andWhere('pr.createdAt < :tillDate', { tillDate: toMySQLString(filters.tillDate) });
+    }
+
+    if (filters.status && filters.status.length > 0) {
+      PaymentRequestService.applyStatusFilter(qb, filters.status);
+    }
+
+    qb.orderBy('pr.createdAt', 'DESC');
+    if (take !== undefined) qb.take(take);
+    if (skip !== undefined) qb.skip(skip);
+
+    return qb.getManyAndCount();
+  }
+
+  /**
+   * Applies the OR-combined derived-status predicate group to `qb` in a
+   * single bracketed clause so it composes correctly with the outer AND
+   * filters. Each status is re-parameterised (`now_<i>`) because TypeORM
+   * requires unique parameter names within a single query.
+   */
+  private static applyStatusFilter(
+    qb: SelectQueryBuilder<PaymentRequest>,
+    statuses: PaymentRequestStatus[],
+  ): void {
+    const nowSql = toMySQLString(new Date());
+    qb.andWhere(new Brackets((inner) => {
+      statuses.forEach((status, i) => {
+        const paramKey = `now_${i}`;
+        switch (status) {
+          case PaymentRequestStatus.PAID:
+            inner.orWhere('pr.paidAt IS NOT NULL');
+            break;
+          case PaymentRequestStatus.CANCELLED:
+            inner.orWhere('(pr.paidAt IS NULL AND pr.cancelledAt IS NOT NULL)');
+            break;
+          case PaymentRequestStatus.EXPIRED:
+            inner.orWhere(
+              `(pr.paidAt IS NULL AND pr.cancelledAt IS NULL AND pr.expiresAt < :${paramKey})`,
+              { [paramKey]: nowSql },
+            );
+            break;
+          case PaymentRequestStatus.PENDING:
+            inner.orWhere(
+              `(pr.paidAt IS NULL AND pr.cancelledAt IS NULL AND pr.expiresAt >= :${paramKey})`,
+              { [paramKey]: nowSql },
+            );
+            break;
+          default:
+            // Exhaustive: a new PaymentRequestStatus value must be added above.
+            throw new Error(`Unknown PaymentRequestStatus: ${status as string}`);
+        }
+      });
+    }));
+  }
+
+  /**
+   * Bootstrap a Stripe payment session for the given request. Creates a
+   * fresh {@link stripe!StripePaymentIntent | StripePaymentIntent} tied to
+   * the request via its `paymentRequest` back-reference. Called by both the
+   * authenticated "I want to pay my own request" endpoint and the public
+   * (unauthenticated) share-link endpoint.
+   *
+   * Rejects requests not in PENDING state.
+   *
+   * @returns the created {@link stripe!StripeDeposit | StripeDeposit} and the
+   *   Stripe `client_secret` the caller forwards to the browser.
+   */
+  public async startPayment(
+    request: PaymentRequest,
+  ): Promise<{ deposit: StripeDeposit; clientSecret: string }> {
+    if (request.status !== PaymentRequestStatus.PENDING) {
+      throw new IllegalPaymentRequestTransitionError(
+        `cannot start payment on request in state ${request.status}`,
+      );
+    }
+    PaymentRequestService.validatePayable(request.for);
+
+    return new StripeService(this.manager).createStripePaymentIntent(
+      request.for,
+      request.amount,
+      request,
+    );
+  }
+
+  /**
+   * Cancel a PENDING request. Rejects any other source state (PAID, already
+   * CANCELLED, EXPIRED). Records `cancelledAt` and `cancelledBy` for audit.
+   */
+  public async cancelPaymentRequest(
+    request: PaymentRequest,
+    cancelledBy: User,
+  ): Promise<PaymentRequest> {
+    if (request.status !== PaymentRequestStatus.PENDING) {
+      throw new IllegalPaymentRequestTransitionError(
+        `cannot cancel request in state ${request.status}`,
+      );
+    }
+    request.cancelledAt = new Date();
+    request.cancelledBy = cancelledBy;
+    return this.manager.getRepository(PaymentRequest).save(request);
+  }
+
+  /**
+   * Admin escape hatch: the user paid out-of-band (e.g. bank transfer).
+   * Creates the void→user credit Transfer manually and flips the request
+   * to PAID. A `reason` is required for the audit description; the acting
+   * admin is persisted on the request as `fulfilledBy` for audit.
+   *
+   * Rejects any non-PENDING source state.
+   *
+   * @param request - The PENDING PaymentRequest to fulfill.
+   * @param reason - Non-empty audit reason (included in the Transfer description).
+   * @param actor - The admin performing the escape hatch. Persisted as
+   *   `fulfilledBy` so the audit trail shows who flipped the request.
+   */
+  public async markFulfilledExternally(
+    request: PaymentRequest,
+    reason: string,
+    actor: User,
+  ): Promise<PaymentRequest> {
+    if (request.status !== PaymentRequestStatus.PENDING) {
+      throw new IllegalPaymentRequestTransitionError(
+        `cannot mark-fulfilled request in state ${request.status}`,
+      );
+    }
+    const trimmedReason = reason?.trim();
+    if (!trimmedReason) {
+      throw new Error('markFulfilledExternally requires a non-empty reason for audit.');
+    }
+    if (!actor) {
+      throw new Error('markFulfilledExternally requires an actor (the admin performing the action).');
+    }
+
+    // Transfer.description is varchar(255). Validate up-front so the caller
+    // gets a clear error rather than a low-level DB constraint failure when
+    // a long reason combined with the audit prefix overflows the column.
+    const descriptionPrefix = `PaymentRequest ${request.id} fulfilled externally by ${actor.id}: `;
+    const maxReasonLength = TRANSFER_DESCRIPTION_MAX_LENGTH - descriptionPrefix.length;
+    if (maxReasonLength <= 0) {
+      // Defensive: would only trigger if id widths grow beyond expectation.
+      throw new Error(
+        'markFulfilledExternally audit prefix exceeds the transfer description limit.',
+      );
+    }
+    if (trimmedReason.length > maxReasonLength) {
+      throw new Error(
+        `markFulfilledExternally reason must be at most ${maxReasonLength} characters to fit within the transfer description limit.`,
+      );
+    }
+
+    await new TransferService(this.manager).createTransfer({
+      amount: request.amount.toObject(),
+      toId: request.for.id,
+      description: `${descriptionPrefix}${trimmedReason}`,
+      fromId: undefined,
+    });
+
+    request.paidAt = new Date();
+    request.fulfilledBy = actor;
+    return this.manager.getRepository(PaymentRequest).save(request);
+  }
+
+  /**
+   * Called by {@link stripe!StripeService | StripeService} from the webhook
+   * flow when a linked payment intent reaches SUCCEEDED. Idempotent:
+   * already-PAID requests are left unchanged.
+   *
+   * Does **not** create a credit Transfer — the Stripe deposit flow is the
+   * single settlement event and owns Transfer creation. This method only
+   * records the `paidAt` timestamp.
+   */
+  public async markPaid(request: PaymentRequest): Promise<PaymentRequest> {
+    if (request.status === PaymentRequestStatus.PAID) {
+      return request;
+    }
+    if (request.status === PaymentRequestStatus.CANCELLED) {
+      throw new IllegalPaymentRequestTransitionError(
+        'cannot mark paid a request that is already CANCELLED',
+      );
+    }
+    // EXPIRED requests that successfully settle via a late Stripe webhook
+    // are still marked PAID — the money arrived, ignoring the clock.
+    request.paidAt = new Date();
+    return this.manager.getRepository(PaymentRequest).save(request);
+  }
+
+  /**
+   * Helper used by the Stripe webhook ingestion path: given a payment-intent
+   * row, resolve the linked PaymentRequest (if any) and call `markPaid`.
+   * Returns `null` when no request is linked.
+   *
+   * Performs a minimal reload (no relations) — status is derived from stored
+   * columns only, and the webhook hot-path has no need for
+   * `for`/`createdBy`/`cancelledBy`/`fulfilledBy` joins.
+   */
+  public async markPaidFromStripeIntent(
+    paymentIntent: StripePaymentIntent,
+  ): Promise<PaymentRequest | null> {
+    if (!paymentIntent.paymentRequest) return null;
+    const fresh = await this.manager.getRepository(PaymentRequest).findOne({
+      where: { id: paymentIntent.paymentRequest.id },
+    });
+    if (!fresh) return null;
+    return this.markPaid(fresh);
+  }
+}

--- a/src/service/payment-request-service.ts
+++ b/src/service/payment-request-service.ts
@@ -41,6 +41,12 @@ import TransferService from './transfer-service';
 import WithManager from '../database/with-manager';
 import { PaginationParameters } from '../helpers/pagination';
 import { toMySQLString } from '../helpers/timestamps';
+import { RequestWithToken } from '../middleware/token-middleware';
+import {
+  BasePaymentRequestResponse,
+  PublicPaymentRequestResponse,
+} from '../controller/response/payment-request-response';
+import { parseUserToBaseResponse } from '../helpers/revision-to-response';
 
 /**
  * User types that are **never** allowed to be the beneficiary of a PaymentRequest.
@@ -116,6 +122,47 @@ export class IllegalPaymentRequestTransitionError extends Error {
 }
 
 /**
+ * Parse a list-PaymentRequests query into {@link PaymentRequestFilterParameters}.
+ * Throws on any malformed value so the controller can return 400 — same
+ * strictness as the inline parser this replaced.
+ */
+export function parseGetPaymentRequestsFilters(
+  req: RequestWithToken,
+): PaymentRequestFilterParameters {
+  const q = req.query || {};
+  const filters: PaymentRequestFilterParameters = {};
+  if (typeof q.forId === 'string') {
+    const forId = parseInt(q.forId, 10);
+    if (Number.isNaN(forId)) throw new Error('Invalid forId');
+    filters.forId = forId;
+  }
+  if (typeof q.createdById === 'string') {
+    const createdById = parseInt(q.createdById, 10);
+    if (Number.isNaN(createdById)) throw new Error('Invalid createdById');
+    filters.createdById = createdById;
+  }
+  if (typeof q.status === 'string' && q.status.length > 0) {
+    const allowed = Object.values(PaymentRequestStatus) as string[];
+    const tokens = q.status.split(',').map((s) => s.trim().toUpperCase());
+    for (const t of tokens) {
+      if (!allowed.includes(t)) throw new Error(`Invalid status: ${t}`);
+    }
+    filters.status = tokens as PaymentRequestStatus[];
+  }
+  if (typeof q.fromDate === 'string') {
+    const d = new Date(q.fromDate);
+    if (Number.isNaN(d.getTime())) throw new Error('Invalid fromDate');
+    filters.fromDate = d;
+  }
+  if (typeof q.tillDate === 'string') {
+    const d = new Date(q.tillDate);
+    if (Number.isNaN(d.getTime())) throw new Error('Invalid tillDate');
+    filters.tillDate = d;
+  }
+  return filters;
+}
+
+/**
  * Service layer for {@link stripe/payment-request!PaymentRequest | PaymentRequest}.
  *
  * ## Creation & validation
@@ -174,6 +221,45 @@ export default class PaymentRequestService extends WithManager {
         `user type ${user.type} cannot be a payment-request beneficiary`,
       );
     }
+  }
+
+  /**
+   * Convert a PaymentRequest entity into the standard authenticated response.
+   */
+  public static asBasePaymentRequestResponse(request: PaymentRequest): BasePaymentRequestResponse {
+    return {
+      id: request.id,
+      createdAt: request.createdAt.toISOString(),
+      updatedAt: request.updatedAt.toISOString(),
+      version: request.version,
+      for: parseUserToBaseResponse(request.for, false),
+      createdBy: parseUserToBaseResponse(request.createdBy, false),
+      amount: request.amount.toObject(),
+      expiresAt: request.expiresAt.toISOString(),
+      paidAt: request.paidAt ? request.paidAt.toISOString() : null,
+      cancelledAt: request.cancelledAt ? request.cancelledAt.toISOString() : null,
+      cancelledBy: request.cancelledBy ? parseUserToBaseResponse(request.cancelledBy, false) : null,
+      fulfilledBy: request.fulfilledBy ? parseUserToBaseResponse(request.fulfilledBy, false) : null,
+      description: request.description,
+      status: request.status,
+    };
+  }
+
+  /**
+   * Convert a PaymentRequest entity into the trimmed unauthenticated response
+   * served from the public share-link surface.
+   */
+  public static asPublicPaymentRequestResponse(
+    request: PaymentRequest,
+  ): PublicPaymentRequestResponse {
+    return {
+      id: request.id,
+      forDisplayName: User.fullName(request.for),
+      amount: request.amount.toObject(),
+      expiresAt: request.expiresAt.toISOString(),
+      description: request.description,
+      status: request.status,
+    };
   }
 
   /**

--- a/src/service/stripe-service.ts
+++ b/src/service/stripe-service.ts
@@ -41,6 +41,10 @@ import { parseUserToBaseResponse } from '../helpers/revision-to-response';
 import BalanceResponse from '../controller/response/balance-response';
 import { StripeRequest } from '../controller/request/stripe-request';
 import StripePaymentIntent from '../entity/stripe/stripe-payment-intent';
+// eslint-disable-next-line import/no-cycle
+import PaymentRequest from '../entity/payment-request/payment-request';
+// eslint-disable-next-line import/no-cycle
+import PaymentRequestService from './payment-request-service';
 import WithManager from '../database/with-manager';
 import Config from '../config';
 
@@ -154,13 +158,21 @@ export default class StripeService extends WithManager {
   }
 
   /**
-   * Create a payment intent and save it to the database
-   * @param user User that wants to deposit some money into their account
+   * Create a payment intent and save it to the database.
+   *
+   * When `paymentRequest` is supplied, the resulting {@link StripePaymentIntent}
+   * carries a back-reference to the request so that the webhook flow in
+   * {@link StripeService.createNewPaymentIntentStatus} can flip the request to
+   * `PAID` on SUCCEEDED. The Stripe-side `metadata.paymentRequestId` mirror is
+   * purely informational (helps debugging in the Stripe dashboard).
+   *
+   * @param user User that wants to deposit money into their account
    * @param amount The amount to be deposited
+   * @param paymentRequest Optional linked PaymentRequest that initiated this intent
    * @returns The created deposit entity and the Stripe client secret
    */
   public async createStripePaymentIntent(
-    user: User, amount: Dinero,
+    user: User, amount: Dinero, paymentRequest?: PaymentRequest,
   ): Promise<{ deposit: StripeDeposit, clientSecret: string }> {
     const config = Config.get();
     const paymentIntent = await this.stripe.paymentIntents.create({
@@ -171,6 +183,7 @@ export default class StripeService extends WithManager {
       metadata: {
         'service': config.app.name,
         'userId': user.id,
+        ...(paymentRequest ? { 'paymentRequestId': paymentRequest.id } : {}),
       },
     });
 
@@ -178,6 +191,7 @@ export default class StripeService extends WithManager {
       stripeId: paymentIntent.id,
       amount,
       paymentIntentStatuses: [],
+      paymentRequest: paymentRequest ?? null,
     });
     const deposit = await this.manager.getRepository(StripeDeposit).save({
       stripePaymentIntent,
@@ -215,7 +229,10 @@ export default class StripeService extends WithManager {
     paymentIntentId: number, state: StripePaymentIntentState,
   ): Promise<StripePaymentIntentStatus> {
     const paymentIntent = await this.manager.getRepository(StripePaymentIntent)
-      .findOne({ where: { id: paymentIntentId }, relations: { deposit: true } });
+      .findOne({
+        where: { id: paymentIntentId },
+        relations: { deposit: true, paymentRequest: true },
+      });
 
     const states = paymentIntent.paymentIntentStatuses?.map((status) => status.state) ?? [];
     if (states.includes(state)) throw new Error(`Status ${state} already exists.`);
@@ -238,6 +255,33 @@ export default class StripeService extends WithManager {
       });
 
       await this.manager.save(paymentIntent.deposit);
+
+      // If the intent was initiated by a PaymentRequest, flip the request to
+      // PAID. This runs *after* the credit Transfer is saved so that a
+      // successful settlement is the single observable event.
+      //
+      // Best-effort: Stripe settlement has already succeeded and the credit
+      // Transfer is persisted. A PaymentRequest state-machine conflict
+      // (e.g. admin cancelled the request after the intent was created)
+      // must not roll back the deposit — log and continue. The user is
+      // credited either way; reconciling the PaymentRequest state is a
+      // secondary concern.
+      if (paymentIntent.paymentRequest) {
+        try {
+          await new PaymentRequestService(this.manager).markPaidFromStripeIntent(paymentIntent);
+        } catch (error) {
+          this.logger.error(
+            'Failed to mark PaymentRequest as PAID for succeeded Stripe payment intent; '
+            + 'the credit Transfer was still created and the user has been credited.',
+            {
+              paymentIntentId: paymentIntent.id,
+              stripeId: paymentIntent.stripeId,
+              paymentRequestId: paymentIntent.paymentRequest.id,
+              error,
+            },
+          );
+        }
+      }
     }
 
     return depositStatus;

--- a/test/seed/ledger/index.ts
+++ b/test/seed/ledger/index.ts
@@ -21,6 +21,7 @@
 export { default as DepositSeeder } from './deposit-seeder';
 export { default as FineSeeder } from './fine-seeder';
 export { default as InvoiceSeeder } from './invoice-seeder';
+export { default as PaymentRequestSeeder } from './payment-request-seeder';
 export { default as PayoutRequestSeeder } from './payout-request-seeder';
 export { default as SellerPayoutSeeder } from './seller-payout-seeder';
 export { default as TransactionSeeder } from './transaction-seeder';

--- a/test/seed/ledger/payment-request-seeder.ts
+++ b/test/seed/ledger/payment-request-seeder.ts
@@ -1,0 +1,92 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+import WithManager from '../../../src/database/with-manager';
+import User from '../../../src/entity/user/user';
+import PaymentRequest from '../../../src/entity/payment-request/payment-request';
+import DineroTransformer from '../../../src/entity/transformer/dinero-transformer';
+
+/**
+ * Seeds a mix of PaymentRequest rows covering the four derived statuses:
+ * PENDING, PAID, CANCELLED, EXPIRED. Used by the test suite to assert
+ * filtering/pagination and by dev seeding to give the dashboard something
+ * to render.
+ *
+ * Rows are created by index % 4 so the distribution is deterministic and
+ * independent of the order `users` is passed in.
+ */
+export default class PaymentRequestSeeder extends WithManager {
+  /**
+   * Seed `count` (default 8) PaymentRequest rows spread across the given
+   * users. Each user gets at least one request when `count >= users.length`.
+   *
+   * @param users - Candidate beneficiaries that receive the seeded payment
+   *   requests (round-robined by index).
+   * @param admin - Admin user that appears as `createdBy` on every row and
+   *   as `cancelledBy` for the cancelled rows.
+   * @param count - How many rows to create. Defaults to 8.
+   */
+  public async seed(users: User[], admin: User, count = 8): Promise<PaymentRequest[]> {
+    if (users.length === 0) return [];
+
+    const now = Date.now();
+    const oneDay = 24 * 60 * 60 * 1000;
+    const rows: PaymentRequest[] = [];
+
+    for (let i = 0; i < count; i += 1) {
+      const recipient = users[i % users.length];
+      const amount = DineroTransformer.Instance.from(500 + i * 100);
+      const r = new PaymentRequest();
+      r.for = recipient;
+      r.createdBy = admin;
+      r.amount = amount;
+      r.description = `Seed PaymentRequest #${i + 1}`;
+
+      // i % 4 === 0 -> PENDING (future expiry, not paid/cancelled)
+      // i % 4 === 1 -> PAID    (paidAt set)
+      // i % 4 === 2 -> CANCELLED
+      // i % 4 === 3 -> EXPIRED (past expiry, not paid/cancelled)
+      switch (i % 4) {
+        case 0:
+          r.expiresAt = new Date(now + 7 * oneDay);
+          break;
+        case 1:
+          r.expiresAt = new Date(now + 7 * oneDay);
+          r.paidAt = new Date(now - oneDay);
+          break;
+        case 2:
+          r.expiresAt = new Date(now + 7 * oneDay);
+          r.cancelledAt = new Date(now - oneDay);
+          r.cancelledBy = admin;
+          break;
+        case 3:
+        default:
+          r.expiresAt = new Date(now - oneDay);
+          break;
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      const saved = await this.manager.getRepository(PaymentRequest).save(r);
+      rows.push(saved);
+    }
+
+    return rows;
+  }
+}

--- a/test/unit/controller/payment-request-controller.ts
+++ b/test/unit/controller/payment-request-controller.ts
@@ -1,0 +1,452 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+import { DataSource } from 'typeorm';
+import express, { Application } from 'express';
+import { SwaggerSpecification } from 'swagger-model-validator';
+import { json } from 'body-parser';
+import chai from 'chai';
+
+const { expect, request } = chai;
+import PaymentRequestController from '../../../src/controller/payment-request-controller';
+import UserController from '../../../src/controller/user-controller';
+import User, { TermsOfServiceStatus, UserType } from '../../../src/entity/user/user';
+import Database from '../../../src/database/database';
+import TokenHandler from '../../../src/authentication/token-handler';
+import Swagger from '../../../src/start/swagger';
+import RoleManager from '../../../src/rbac/role-manager';
+import TokenMiddleware from '../../../src/middleware/token-middleware';
+import { truncateAllTables } from '../../setup';
+import { finishTestDB } from '../../helpers/test-helpers';
+import { PaymentRequestSeeder } from '../../seed';
+import PaymentRequest from '../../../src/entity/payment-request/payment-request';
+import { PaymentRequestStatus } from '../../../src/entity/payment-request/payment-request-status';
+import { ensureProductionRoles, signTokenFor } from '../../helpers/user-factory';
+import { CreatePaymentRequestRequest } from '../../../src/controller/request/payment-request-request';
+import { BasePaymentRequestResponse } from '../../../src/controller/response/payment-request-response';
+
+describe('PaymentRequestController', (): void => {
+  let ctx: {
+    connection: DataSource,
+    app: Application,
+    specification: SwaggerSpecification,
+    controller: PaymentRequestController,
+    adminUser: User,
+    localUser: User,
+    otherUser: User,
+    adminToken: string,
+    userToken: string,
+    otherUserToken: string,
+    paymentRequests: PaymentRequest[],
+  };
+
+  beforeAll(async () => {
+    const connection = await Database.initialize();
+    await truncateAllTables(connection);
+
+    const adminUser = await User.save({
+      firstName: 'Admin',
+      type: UserType.LOCAL_ADMIN,
+      active: true,
+      acceptedToS: TermsOfServiceStatus.ACCEPTED,
+    });
+    const localUser = await User.save({
+      firstName: 'User',
+      type: UserType.LOCAL_USER,
+      active: true,
+      acceptedToS: TermsOfServiceStatus.ACCEPTED,
+    });
+    const otherUser = await User.save({
+      firstName: 'Other',
+      type: UserType.MEMBER,
+      active: true,
+      acceptedToS: TermsOfServiceStatus.ACCEPTED,
+    });
+
+    // Seed 8 PaymentRequests — two per status, all with localUser as beneficiary
+    // so the "own vs all" relation checks are exercisable.
+    const paymentRequests = await new PaymentRequestSeeder().seed([localUser], adminUser, 8);
+
+    // start app
+    const app = express();
+    const specification = await Swagger.initialize(app);
+
+    await ensureProductionRoles();
+    const roleManager = await new RoleManager().initialize();
+
+    // create bearer tokens
+    const tokenHandler = new TokenHandler({
+      algorithm: 'HS256', publicKey: 'test', privateKey: 'test', expiry: 3600,
+    });
+    const adminToken = await signTokenFor(adminUser, tokenHandler, 'nonce admin');
+    const userToken = await signTokenFor(localUser, tokenHandler);
+    const otherUserToken = await signTokenFor(otherUser, tokenHandler, 'nonce other');
+
+    const controller = new PaymentRequestController({ specification, roleManager });
+    const userController = new UserController({ specification, roleManager }, tokenHandler);
+    app.use(json());
+    app.use(new TokenMiddleware({ tokenHandler, refreshFactor: 0.5 }).getMiddleware());
+    app.use('/payment-requests', controller.getRouter());
+    app.use('/users', userController.getRouter());
+
+    ctx = {
+      connection,
+      app,
+      specification,
+      controller,
+      adminUser,
+      localUser,
+      otherUser,
+      adminToken,
+      userToken,
+      otherUserToken,
+      paymentRequests,
+    };
+  });
+
+  afterAll(async () => {
+    await finishTestDB(ctx.connection);
+  });
+
+  describe('GET /payment-requests', () => {
+    it('should return paginated list for admin', async () => {
+      const res = await request(ctx.app)
+        .get('/payment-requests')
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+      expect(res.status).to.equal(200);
+      expect(ctx.specification.validateModel(
+        'PaginatedBasePaymentRequestResponse',
+        res.body,
+        false,
+        true,
+      ).valid).to.be.true;
+      const records = res.body.records as BasePaymentRequestResponse[];
+      expect(records.length).to.equal(ctx.paymentRequests.length);
+    });
+
+    it('should return 403 for a regular user (admin-only listing)', async () => {
+      const res = await request(ctx.app)
+        .get('/payment-requests')
+        .set('Authorization', `Bearer ${ctx.userToken}`);
+      expect(res.status).to.equal(403);
+    });
+
+    it('should filter by forId', async () => {
+      const res = await request(ctx.app)
+        .get('/payment-requests')
+        .query({ forId: ctx.localUser.id })
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+      expect(res.status).to.equal(200);
+      const records = res.body.records as BasePaymentRequestResponse[];
+      records.forEach((r) => {
+        expect(r.for.id).to.equal(ctx.localUser.id);
+      });
+    });
+
+    it('should filter by status=PAID', async () => {
+      const res = await request(ctx.app)
+        .get('/payment-requests')
+        .query({ status: 'PAID' })
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+      expect(res.status).to.equal(200);
+      const records = res.body.records as BasePaymentRequestResponse[];
+      records.forEach((r) => {
+        expect(r.status).to.equal(PaymentRequestStatus.PAID);
+      });
+      const expected = ctx.paymentRequests.filter(
+        (p) => p.status === PaymentRequestStatus.PAID,
+      ).length;
+      expect(records.length).to.equal(expected);
+    });
+
+    it('should return 400 on unknown status token', async () => {
+      const res = await request(ctx.app)
+        .get('/payment-requests')
+        .query({ status: 'BOGUS' })
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+      expect(res.status).to.equal(400);
+    });
+
+    it('should return 401 without bearer token', async () => {
+      const res = await request(ctx.app).get('/payment-requests');
+      expect(res.status).to.equal(401);
+    });
+  });
+
+  describe('GET /users/:id/payment-requests', () => {
+    it('should return own requests for a regular user hitting their own id', async () => {
+      const res = await request(ctx.app)
+        .get(`/users/${ctx.localUser.id}/payment-requests`)
+        .set('Authorization', `Bearer ${ctx.userToken}`);
+      expect(res.status).to.equal(200);
+      expect(ctx.specification.validateModel(
+        'PaginatedBasePaymentRequestResponse',
+        res.body,
+        false,
+        true,
+      ).valid).to.be.true;
+      const records = res.body.records as BasePaymentRequestResponse[];
+      records.forEach((r) => {
+        expect(r.for.id).to.equal(ctx.localUser.id);
+      });
+      expect(records.length).to.equal(ctx.paymentRequests.length);
+    });
+
+    it('should return 403 when a regular user requests another user\'s list', async () => {
+      const res = await request(ctx.app)
+        .get(`/users/${ctx.otherUser.id}/payment-requests`)
+        .set('Authorization', `Bearer ${ctx.userToken}`);
+      expect(res.status).to.equal(403);
+    });
+
+    it('should allow an admin to list any user\'s requests', async () => {
+      const res = await request(ctx.app)
+        .get(`/users/${ctx.localUser.id}/payment-requests`)
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+      expect(res.status).to.equal(200);
+      const records = res.body.records as BasePaymentRequestResponse[];
+      records.forEach((r) => {
+        expect(r.for.id).to.equal(ctx.localUser.id);
+      });
+      expect(records.length).to.equal(ctx.paymentRequests.length);
+    });
+
+    it('should return an empty list when the user has no requests', async () => {
+      const res = await request(ctx.app)
+        .get(`/users/${ctx.otherUser.id}/payment-requests`)
+        .set('Authorization', `Bearer ${ctx.otherUserToken}`);
+      expect(res.status).to.equal(200);
+      const records = res.body.records as BasePaymentRequestResponse[];
+      expect(records.length).to.equal(0);
+    });
+
+    it('should return 404 for an unknown user id', async () => {
+      const res = await request(ctx.app)
+        .get('/users/999999/payment-requests')
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+      expect(res.status).to.equal(404);
+    });
+  });
+
+  describe('GET /payment-requests/:id', () => {
+    it('should return own PaymentRequest for regular user', async () => {
+      const own = ctx.paymentRequests[0];
+      const res = await request(ctx.app)
+        .get(`/payment-requests/${own.id}`)
+        .set('Authorization', `Bearer ${ctx.userToken}`);
+      expect(res.status).to.equal(200);
+      expect(res.body.id).to.equal(own.id);
+      expect(ctx.specification.validateModel(
+        'BasePaymentRequestResponse',
+        res.body,
+        false,
+        true,
+      ).valid).to.be.true;
+    });
+
+    it('should return 403 when another user tries to fetch someone else\'s request', async () => {
+      // otherUser is not the beneficiary and has no `get:all:PaymentRequest` permission.
+      const foreign = ctx.paymentRequests[0];
+      const res = await request(ctx.app)
+        .get(`/payment-requests/${foreign.id}`)
+        .set('Authorization', `Bearer ${ctx.otherUserToken}`);
+      expect(res.status).to.equal(403);
+    });
+
+    it('should return 200 for admin regardless of ownership', async () => {
+      const req = ctx.paymentRequests[0];
+      const res = await request(ctx.app)
+        .get(`/payment-requests/${req.id}`)
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+      expect(res.status).to.equal(200);
+      expect(res.body.id).to.equal(req.id);
+    });
+
+    it('should return 404 for unknown id', async () => {
+      const res = await request(ctx.app)
+        .get('/payment-requests/00000000-0000-0000-0000-000000000000')
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+      expect(res.status).to.equal(404);
+    });
+  });
+
+  describe('POST /payment-requests', () => {
+    const futureDate = (): string => new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+    it('should create a PaymentRequest for self (regular user)', async () => {
+      const body: CreatePaymentRequestRequest = {
+        forId: ctx.localUser.id,
+        amount: { amount: 1250, precision: 2, currency: 'EUR' },
+        expiresAt: futureDate(),
+        description: 'Unit test self-create',
+      };
+      const res = await request(ctx.app)
+        .post('/payment-requests')
+        .set('Authorization', `Bearer ${ctx.userToken}`)
+        .send(body);
+      expect(res.status).to.equal(200);
+      expect(res.body.for.id).to.equal(ctx.localUser.id);
+      expect(res.body.amount.amount).to.equal(1250);
+      expect(res.body.status).to.equal(PaymentRequestStatus.PENDING);
+      expect(ctx.specification.validateModel(
+        'BasePaymentRequestResponse',
+        res.body,
+        false,
+        true,
+      ).valid).to.be.true;
+    });
+
+    it('should return 403 when regular user tries to create for someone else', async () => {
+      const body: CreatePaymentRequestRequest = {
+        forId: ctx.otherUser.id,
+        amount: { amount: 500, precision: 2, currency: 'EUR' },
+        expiresAt: futureDate(),
+      };
+      const res = await request(ctx.app)
+        .post('/payment-requests')
+        .set('Authorization', `Bearer ${ctx.userToken}`)
+        .send(body);
+      expect(res.status).to.equal(403);
+    });
+
+    it('should allow admin to create for any user', async () => {
+      const body: CreatePaymentRequestRequest = {
+        forId: ctx.otherUser.id,
+        amount: { amount: 750, precision: 2, currency: 'EUR' },
+        expiresAt: futureDate(),
+      };
+      const res = await request(ctx.app)
+        .post('/payment-requests')
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .send(body);
+      expect(res.status).to.equal(200);
+      expect(res.body.for.id).to.equal(ctx.otherUser.id);
+    });
+
+    it('should return 404 when beneficiary user does not exist', async () => {
+      const body: CreatePaymentRequestRequest = {
+        forId: 999999,
+        amount: { amount: 500, precision: 2, currency: 'EUR' },
+        expiresAt: futureDate(),
+      };
+      const res = await request(ctx.app)
+        .post('/payment-requests')
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .send(body);
+      expect(res.status).to.equal(404);
+    });
+
+    it('should return 400 on invalid expiresAt', async () => {
+      const body = {
+        forId: ctx.localUser.id,
+        amount: { amount: 500, precision: 2, currency: 'EUR' },
+        expiresAt: 'not-a-date',
+      };
+      const res = await request(ctx.app)
+        .post('/payment-requests')
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .send(body);
+      expect(res.status).to.equal(400);
+    });
+  });
+
+  // Seeder assigns statuses by `i % 4`: 0=PENDING, 1=PAID, 2=CANCELLED, 3=EXPIRED.
+  // With count=8 we have two rows per status. We use indices explicitly (rather
+  // than `.find(status===X)`) so that tests which mutate state (cancel, mark-
+  // fulfilled) don't cause the next `.find()` to return a stale reference.
+  describe('POST /payment-requests/:id/cancel', () => {
+    it('should cancel a PENDING request (admin)', async () => {
+      const pending = ctx.paymentRequests[0]; // PENDING
+      const res = await request(ctx.app)
+        .post(`/payment-requests/${pending.id}/cancel`)
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+      expect(res.status).to.equal(200);
+      expect(res.body.status).to.equal(PaymentRequestStatus.CANCELLED);
+      expect(res.body.cancelledBy.id).to.equal(ctx.adminUser.id);
+    });
+
+    it('should return 409 when cancelling an already-cancelled request', async () => {
+      const cancelled = ctx.paymentRequests[2]; // CANCELLED
+      const res = await request(ctx.app)
+        .post(`/payment-requests/${cancelled.id}/cancel`)
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+      expect(res.status).to.equal(409);
+    });
+
+    it('should return 409 when cancelling a PAID request', async () => {
+      const paid = ctx.paymentRequests[1]; // PAID
+      const res = await request(ctx.app)
+        .post(`/payment-requests/${paid.id}/cancel`)
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+      expect(res.status).to.equal(409);
+    });
+
+    it('should return 404 for unknown id', async () => {
+      const res = await request(ctx.app)
+        .post('/payment-requests/00000000-0000-0000-0000-000000000000/cancel')
+        .set('Authorization', `Bearer ${ctx.adminToken}`);
+      expect(res.status).to.equal(404);
+    });
+  });
+
+  describe('POST /payment-requests/:id/mark-fulfilled', () => {
+    it('should mark a PENDING request as PAID with a Transfer', async () => {
+      const pending = ctx.paymentRequests[4]; // PENDING (second one, index 0 was cancelled above)
+      const res = await request(ctx.app)
+        .post(`/payment-requests/${pending.id}/mark-fulfilled`)
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .send({ reason: 'bank transfer 2026-04-23' });
+      expect(res.status).to.equal(200);
+      expect(res.body.status).to.equal(PaymentRequestStatus.PAID);
+      expect(res.body.paidAt).to.not.be.null;
+      // The admin performing the escape hatch is recorded for audit.
+      expect(res.body.fulfilledBy).to.not.be.null;
+      expect(res.body.fulfilledBy.id).to.equal(ctx.adminUser.id);
+    });
+
+    it('should return 400 on empty reason', async () => {
+      // Body check runs before state check, so any id works.
+      const target = ctx.paymentRequests[3]; // EXPIRED
+      const res = await request(ctx.app)
+        .post(`/payment-requests/${target.id}/mark-fulfilled`)
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .send({ reason: '   ' });
+      expect(res.status).to.equal(400);
+    });
+
+    it('should return 403 for non-admin (mark-fulfilled requires update:all)', async () => {
+      const target = ctx.paymentRequests[3]; // EXPIRED
+      const res = await request(ctx.app)
+        .post(`/payment-requests/${target.id}/mark-fulfilled`)
+        .set('Authorization', `Bearer ${ctx.userToken}`)
+        .send({ reason: 'trying' });
+      expect(res.status).to.equal(403);
+    });
+
+    it('should return 409 when request is already PAID', async () => {
+      const paid = ctx.paymentRequests[5]; // PAID (second one)
+      const res = await request(ctx.app)
+        .post(`/payment-requests/${paid.id}/mark-fulfilled`)
+        .set('Authorization', `Bearer ${ctx.adminToken}`)
+        .send({ reason: 'late fallback' });
+      expect(res.status).to.equal(409);
+    });
+  });
+});

--- a/test/unit/controller/payment-request-public-controller.ts
+++ b/test/unit/controller/payment-request-public-controller.ts
@@ -1,0 +1,175 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+import { DataSource } from 'typeorm';
+import express, { Application } from 'express';
+import { SwaggerSpecification } from 'swagger-model-validator';
+import { json } from 'body-parser';
+import chai from 'chai';
+
+const { expect, request } = chai;
+import PaymentRequestPublicController from '../../../src/controller/payment-request-public-controller';
+import User, { TermsOfServiceStatus, UserType } from '../../../src/entity/user/user';
+import Database from '../../../src/database/database';
+import Swagger from '../../../src/start/swagger';
+import RoleManager from '../../../src/rbac/role-manager';
+import { truncateAllTables } from '../../setup';
+import { finishTestDB } from '../../helpers/test-helpers';
+import { PaymentRequestSeeder } from '../../seed';
+import PaymentRequest from '../../../src/entity/payment-request/payment-request';
+import { PaymentRequestStatus } from '../../../src/entity/payment-request/payment-request-status';
+import { PublicPaymentRequestResponse } from '../../../src/controller/response/payment-request-response';
+
+describe('PaymentRequestPublicController', (): void => {
+  let ctx: {
+    connection: DataSource,
+    app: Application,
+    specification: SwaggerSpecification,
+    controller: PaymentRequestPublicController,
+    adminUser: User,
+    localUser: User,
+    paymentRequests: PaymentRequest[],
+  };
+
+  beforeAll(async () => {
+    const connection = await Database.initialize();
+    await truncateAllTables(connection);
+
+    const adminUser = await User.save({
+      firstName: 'Admin',
+      type: UserType.LOCAL_ADMIN,
+      active: true,
+      acceptedToS: TermsOfServiceStatus.ACCEPTED,
+    });
+    const localUser = await User.save({
+      firstName: 'User',
+      lastName: 'Doe',
+      type: UserType.LOCAL_USER,
+      active: true,
+      acceptedToS: TermsOfServiceStatus.ACCEPTED,
+    });
+
+    // 8 requests → 2 per derived status.
+    const paymentRequests = await new PaymentRequestSeeder().seed([localUser], adminUser, 8);
+
+    const app = express();
+    const specification = await Swagger.initialize(app);
+    const roleManager = await new RoleManager().initialize();
+
+    const controller = new PaymentRequestPublicController({ specification, roleManager });
+    app.use(json());
+    // Public controller bypasses token middleware — mounted before setupAuthentication in src/index.ts
+    app.use('/payment-requests-public', controller.getRouter());
+
+    ctx = {
+      connection,
+      app,
+      specification,
+      controller,
+      adminUser,
+      localUser,
+      paymentRequests,
+    };
+  });
+
+  afterAll(async () => {
+    await finishTestDB(ctx.connection);
+  });
+
+  describe('GET /payment-requests-public/:id', () => {
+    it('should return a trimmed PublicPaymentRequestResponse for a PENDING request', async () => {
+      const pending = ctx.paymentRequests[0]; // PENDING per seeder i%4 mapping
+      const res = await request(ctx.app).get(`/payment-requests-public/${pending.id}`);
+      expect(res.status).to.equal(200);
+      expect(ctx.specification.validateModel(
+        'PublicPaymentRequestResponse',
+        res.body,
+        false,
+        true,
+      ).valid).to.be.true;
+
+      const body = res.body as PublicPaymentRequestResponse;
+      expect(body.id).to.equal(pending.id);
+      expect(body.status).to.equal(PaymentRequestStatus.PENDING);
+      expect(body.forDisplayName).to.equal(User.fullName(ctx.localUser));
+    });
+
+    it('should omit createdBy/cancelledBy/paidAt audit fields', async () => {
+      const cancelled = ctx.paymentRequests[2]; // CANCELLED
+      const res = await request(ctx.app).get(`/payment-requests-public/${cancelled.id}`);
+      expect(res.status).to.equal(200);
+      // Response must NOT leak the admin that cancelled, the full createdBy, etc.
+      expect(res.body.createdBy).to.be.undefined;
+      expect(res.body.cancelledBy).to.be.undefined;
+      expect(res.body.cancelledAt).to.be.undefined;
+      expect(res.body.paidAt).to.be.undefined;
+      expect(res.body.status).to.equal(PaymentRequestStatus.CANCELLED);
+    });
+
+    it('should return 404 for unknown id', async () => {
+      const res = await request(ctx.app).get(
+        '/payment-requests-public/00000000-0000-0000-0000-000000000000',
+      );
+      expect(res.status).to.equal(404);
+    });
+
+    it('should NOT require a bearer token', async () => {
+      // Same request, no Authorization header — must still succeed.
+      const pending = ctx.paymentRequests[0];
+      const res = await request(ctx.app).get(`/payment-requests-public/${pending.id}`);
+      expect(res.status).to.equal(200);
+    });
+  });
+
+  describe('POST /payment-requests-public/:id/start', () => {
+    it('should return 404 for unknown id', async () => {
+      const res = await request(ctx.app).post(
+        '/payment-requests-public/00000000-0000-0000-0000-000000000000/start',
+      );
+      expect(res.status).to.equal(404);
+    });
+
+    // The service rejects non-PENDING requests before any Stripe call, so these
+    // 409 cases do not depend on Stripe credentials being present.
+    it('should return 409 when request is CANCELLED', async () => {
+      const cancelled = ctx.paymentRequests[2];
+      const res = await request(ctx.app).post(
+        `/payment-requests-public/${cancelled.id}/start`,
+      );
+      expect(res.status).to.equal(409);
+    });
+
+    it('should return 409 when request is PAID', async () => {
+      const paid = ctx.paymentRequests[1];
+      const res = await request(ctx.app).post(
+        `/payment-requests-public/${paid.id}/start`,
+      );
+      expect(res.status).to.equal(409);
+    });
+
+    it('should return 409 when request is EXPIRED', async () => {
+      const expired = ctx.paymentRequests[3];
+      const res = await request(ctx.app).post(
+        `/payment-requests-public/${expired.id}/start`,
+      );
+      expect(res.status).to.equal(409);
+    });
+  });
+});

--- a/test/unit/service/payment-request-service.ts
+++ b/test/unit/service/payment-request-service.ts
@@ -1,0 +1,475 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+import { DataSource } from 'typeorm';
+import chai from 'chai';
+
+const { expect } = chai;
+import User, { UserType } from '../../../src/entity/user/user';
+import Database from '../../../src/database/database';
+import { truncateAllTables } from '../../setup';
+import { finishTestDB } from '../../helpers/test-helpers';
+import PaymentRequestService, {
+  IllegalPaymentRequestTransitionError,
+  InvalidPaymentRequestBeneficiaryError,
+} from '../../../src/service/payment-request-service';
+import DineroTransformer from '../../../src/entity/transformer/dinero-transformer';
+import PaymentRequest from '../../../src/entity/payment-request/payment-request';
+import { PaymentRequestStatus } from '../../../src/entity/payment-request/payment-request-status';
+import Transfer from '../../../src/entity/transactions/transfer';
+import { PaymentRequestSeeder } from '../../seed';
+
+describe('PaymentRequestService', async (): Promise<void> => {
+  let ctx: {
+    connection: DataSource,
+    admin: User,
+    member: User,
+    inactive: User,
+    invoiceUser: User,
+    posUser: User,
+    deleted: User,
+    service: PaymentRequestService,
+  };
+
+  beforeAll(async () => {
+    const connection = await Database.initialize();
+    await truncateAllTables(connection);
+
+    const admin = await User.save({
+      firstName: 'Admin',
+      type: UserType.LOCAL_ADMIN,
+      active: true,
+    });
+    const member = await User.save({
+      firstName: 'Member',
+      type: UserType.MEMBER,
+      active: true,
+    });
+    const inactive = await User.save({
+      firstName: 'Inactive',
+      type: UserType.MEMBER,
+      active: false,
+    });
+    const invoiceUser = await User.save({
+      firstName: 'Invoice',
+      type: UserType.INVOICE,
+      active: true,
+    });
+    const posUser = await User.save({
+      firstName: 'POS',
+      type: UserType.POINT_OF_SALE,
+      active: true,
+    });
+    const deleted = await User.save({
+      firstName: 'Deleted',
+      type: UserType.MEMBER,
+      active: false,
+      deleted: true,
+    });
+
+    ctx = {
+      connection,
+      admin,
+      member,
+      inactive,
+      invoiceUser,
+      posUser,
+      deleted,
+      service: new PaymentRequestService(),
+    };
+  });
+
+  afterAll(async () => {
+    await finishTestDB(ctx.connection);
+  });
+
+  describe('validatePayable', () => {
+    it('accepts MEMBER users', () => {
+      expect(() => PaymentRequestService.validatePayable(ctx.member)).to.not.throw();
+    });
+    it('accepts inactive users (alumni with debt is the whole point)', () => {
+      expect(() => PaymentRequestService.validatePayable(ctx.inactive)).to.not.throw();
+    });
+    it('accepts INVOICE users', () => {
+      expect(() => PaymentRequestService.validatePayable(ctx.invoiceUser)).to.not.throw();
+    });
+    it('rejects POINT_OF_SALE users', () => {
+      expect(() => PaymentRequestService.validatePayable(ctx.posUser))
+        .to.throw(InvalidPaymentRequestBeneficiaryError);
+    });
+    it('rejects soft-deleted users', () => {
+      expect(() => PaymentRequestService.validatePayable(ctx.deleted))
+        .to.throw(InvalidPaymentRequestBeneficiaryError);
+    });
+    it('rejects missing user', () => {
+      expect(() => PaymentRequestService.validatePayable(null as unknown as User))
+        .to.throw(InvalidPaymentRequestBeneficiaryError);
+    });
+  });
+
+  describe('createPaymentRequest', () => {
+    const futureDate = (): Date => new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    const pastDate = (): Date => new Date(Date.now() - 1000);
+
+    it('persists a new PENDING request with immutable amount', async () => {
+      const amount = DineroTransformer.Instance.from(1234);
+      const created = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount,
+        expiresAt: futureDate(),
+        description: 'Unit-test create',
+      });
+      expect(created.id).to.be.a('string').with.lengthOf(36);
+      expect(created.amount.getAmount()).to.equal(1234);
+      expect(created.status).to.equal(PaymentRequestStatus.PENDING);
+      expect(created.paidAt).to.equal(null);
+      expect(created.cancelledAt).to.equal(null);
+      expect(created.description).to.equal('Unit-test create');
+
+      const reloaded = await ctx.service.getPaymentRequest(created.id);
+      expect(reloaded).to.not.equal(null);
+      expect(reloaded!.id).to.equal(created.id);
+    });
+
+    it('rejects past expiresAt', async () => {
+      await expect(ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(100),
+        expiresAt: pastDate(),
+      })).to.be.rejectedWith(/expiresAt/);
+    });
+
+    it('rejects zero or negative amount', async () => {
+      await expect(ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(0),
+        expiresAt: futureDate(),
+      })).to.be.rejectedWith(/amount/);
+    });
+
+    it('rejects ineligible beneficiary (POS)', async () => {
+      await expect(ctx.service.createPaymentRequest({
+        for: ctx.posUser,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(500),
+        expiresAt: futureDate(),
+      })).to.be.rejectedWith(InvalidPaymentRequestBeneficiaryError);
+    });
+
+    it('rejects a description longer than the column limit', async () => {
+      await expect(ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(500),
+        expiresAt: futureDate(),
+        description: 'x'.repeat(256),
+      })).to.be.rejectedWith(/255 characters/);
+    });
+
+    it('rejects soft-deleted beneficiary', async () => {
+      await expect(ctx.service.createPaymentRequest({
+        for: ctx.deleted,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(500),
+        expiresAt: futureDate(),
+      })).to.be.rejectedWith(InvalidPaymentRequestBeneficiaryError);
+    });
+  });
+
+  describe('getPublicPaymentRequest', () => {
+    it('returns the request with the for relation populated for the public response', async () => {
+      const created = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(500),
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+
+      const fetched = await ctx.service.getPublicPaymentRequest(created.id);
+      expect(fetched).to.not.equal(null);
+      // `for` is required by `asPublicPaymentRequestResponse` for forDisplayName.
+      expect(fetched!.for).to.not.equal(null);
+      expect(fetched!.for).to.not.equal(undefined);
+      expect(fetched!.for.id).to.equal(ctx.member.id);
+      // The trimmed lookup is enough for the public response shape.
+      expect(PaymentRequestService.asPublicPaymentRequestResponse(fetched!).forDisplayName)
+        .to.be.a('string').and.not.empty;
+    });
+
+    it('returns null for an unknown id', async () => {
+      const fetched = await ctx.service.getPublicPaymentRequest(
+        '00000000-0000-0000-0000-000000000000',
+      );
+      expect(fetched).to.equal(null);
+    });
+  });
+
+  describe('derived status', () => {
+    it('PENDING -> PAID when paidAt is set', async () => {
+      const r = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(500),
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+      expect(r.status).to.equal(PaymentRequestStatus.PENDING);
+      const paid = await ctx.service.markPaid(r);
+      expect(paid.status).to.equal(PaymentRequestStatus.PAID);
+    });
+
+    it('PENDING -> CANCELLED when cancelled', async () => {
+      const r = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(500),
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+      const cancelled = await ctx.service.cancelPaymentRequest(r, ctx.admin);
+      expect(cancelled.status).to.equal(PaymentRequestStatus.CANCELLED);
+      expect(cancelled.cancelledBy!.id).to.equal(ctx.admin.id);
+    });
+
+    it('PENDING -> EXPIRED when expiresAt passes', async () => {
+      const r = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(500),
+        expiresAt: new Date(Date.now() + 500),
+      });
+      expect(r.status).to.equal(PaymentRequestStatus.PENDING);
+      // Simulate the clock rolling past expiry.
+      r.expiresAt = new Date(Date.now() - 1000);
+      expect(r.status).to.equal(PaymentRequestStatus.EXPIRED);
+    });
+
+    it('PAID precedence beats EXPIRED', async () => {
+      const r = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(500),
+        expiresAt: new Date(Date.now() + 1000),
+      });
+      r.paidAt = new Date();
+      r.expiresAt = new Date(Date.now() - 1000);
+      expect(r.status).to.equal(PaymentRequestStatus.PAID);
+    });
+  });
+
+  describe('state machine', () => {
+    it('rejects cancelling a PAID request', async () => {
+      const r = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(500),
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+      await ctx.service.markPaid(r);
+      await expect(ctx.service.cancelPaymentRequest(r, ctx.admin))
+        .to.be.rejectedWith(IllegalPaymentRequestTransitionError);
+    });
+
+    it('rejects cancelling a CANCELLED request', async () => {
+      const r = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(500),
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+      await ctx.service.cancelPaymentRequest(r, ctx.admin);
+      await expect(ctx.service.cancelPaymentRequest(r, ctx.admin))
+        .to.be.rejectedWith(IllegalPaymentRequestTransitionError);
+    });
+
+    it('markPaid is idempotent on PAID', async () => {
+      const r = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(500),
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+      const firstPaid = await ctx.service.markPaid(r);
+      const firstPaidAt = firstPaid.paidAt;
+      const again = await ctx.service.markPaid(firstPaid);
+      expect(again.paidAt).to.deep.equal(firstPaidAt);
+    });
+
+    it('markPaid refuses CANCELLED', async () => {
+      const r = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(500),
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+      await ctx.service.cancelPaymentRequest(r, ctx.admin);
+      await expect(ctx.service.markPaid(r))
+        .to.be.rejectedWith(IllegalPaymentRequestTransitionError);
+    });
+
+    it('markPaid promotes EXPIRED requests to PAID (late webhook)', async () => {
+      const r = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(500),
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+      // Force-expire by rewriting expiry.
+      r.expiresAt = new Date(Date.now() - 1000);
+      await PaymentRequest.save(r);
+      expect(r.status).to.equal(PaymentRequestStatus.EXPIRED);
+      const paid = await ctx.service.markPaid(r);
+      expect(paid.status).to.equal(PaymentRequestStatus.PAID);
+    });
+  });
+
+  describe('markFulfilledExternally', () => {
+    it('creates a void->user Transfer and flips to PAID', async () => {
+      const r = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(2500),
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+
+      const transferCountBefore = await Transfer.count();
+      const updated = await ctx.service.markFulfilledExternally(
+        r, 'Bank transfer, ref 12345', ctx.admin,
+      );
+
+      expect(updated.status).to.equal(PaymentRequestStatus.PAID);
+      expect(updated.fulfilledBy).to.not.equal(null);
+      expect(updated.fulfilledBy!.id).to.equal(ctx.admin.id);
+      const transferCountAfter = await Transfer.count();
+      expect(transferCountAfter).to.equal(transferCountBefore + 1);
+
+      const newTransfer = (await Transfer.find({
+        relations: { to: true },
+        order: { createdAt: 'DESC' },
+        take: 1,
+      }))[0];
+      expect(newTransfer.to.id).to.equal(ctx.member.id);
+      expect(newTransfer.description).to.include(r.id);
+      expect(newTransfer.description).to.include('Bank transfer, ref 12345');
+      // Actor id is recorded in the description so the Transfer row alone
+      // identifies the admin that triggered the escape hatch.
+      expect(newTransfer.description).to.include(`by ${ctx.admin.id}`);
+      expect(newTransfer.amountInclVat.getAmount()).to.equal(2500);
+    });
+
+    it('persists fulfilledBy across a reload', async () => {
+      const r = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(400),
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+      await ctx.service.markFulfilledExternally(r, 'cash', ctx.admin);
+      const reloaded = await ctx.service.getPaymentRequest(r.id);
+      expect(reloaded).to.not.equal(null);
+      expect(reloaded!.fulfilledBy).to.not.equal(null);
+      expect(reloaded!.fulfilledBy!.id).to.equal(ctx.admin.id);
+    });
+
+    it('refuses to run without a reason', async () => {
+      const r = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(100),
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+      await expect(ctx.service.markFulfilledExternally(r, '   ', ctx.admin))
+        .to.be.rejectedWith(/reason/);
+    });
+
+    it('refuses to run without an actor', async () => {
+      const r = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(100),
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+      await expect(ctx.service.markFulfilledExternally(r, 'cash', null as unknown as User))
+        .to.be.rejectedWith(/actor/);
+    });
+
+    it('rejects a reason that would overflow the transfer description column', async () => {
+      const r = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(100),
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+      // Reason of 255 chars guarantees overflow once combined with the prefix.
+      await expect(ctx.service.markFulfilledExternally(r, 'x'.repeat(255), ctx.admin))
+        .to.be.rejectedWith(/transfer description limit/);
+    });
+
+    it('refuses a non-PENDING source', async () => {
+      const r = await ctx.service.createPaymentRequest({
+        for: ctx.member,
+        createdBy: ctx.admin,
+        amount: DineroTransformer.Instance.from(100),
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+      await ctx.service.cancelPaymentRequest(r, ctx.admin);
+      await expect(ctx.service.markFulfilledExternally(r, 'too late', ctx.admin))
+        .to.be.rejectedWith(IllegalPaymentRequestTransitionError);
+    });
+  });
+
+  describe('listing with status filter', () => {
+    beforeAll(async () => {
+      // Clear any rows from earlier tests before seeding the known distribution.
+      // TypeORM rejects `.delete({})` (empty criteria); `.clear()` uses TRUNCATE
+      // which MariaDB refuses on a table referenced by a foreign key. Use the
+      // query builder to emit a plain DELETE with no WHERE.
+      await PaymentRequest.createQueryBuilder().delete().execute();
+      await new PaymentRequestSeeder().seed([ctx.member, ctx.invoiceUser], ctx.admin, 8);
+    });
+
+    it('returns all statuses when no filter is provided', async () => {
+      const [rows, total] = await ctx.service.getPaymentRequests({});
+      expect(total).to.equal(8);
+      expect(rows.length).to.equal(8);
+    });
+
+    it('filters by derived status', async () => {
+      const [pending] = await ctx.service.getPaymentRequests({
+        status: [PaymentRequestStatus.PENDING],
+      });
+      expect(pending.every((r) => r.status === PaymentRequestStatus.PENDING)).to.equal(true);
+    });
+
+    it('paginates with derived status filter', async () => {
+      const [page] = await ctx.service.getPaymentRequests(
+        { status: [PaymentRequestStatus.PAID] },
+        { take: 1, skip: 0 },
+      );
+      expect(page.length).to.be.at.most(1);
+    });
+
+    it('filters by forId', async () => {
+      const [rows] = await ctx.service.getPaymentRequests({ forId: ctx.member.id });
+      expect(rows.every((r) => r.for.id === ctx.member.id)).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
# Description

Implements the `PaymentRequest` primitive from #639: an unauthenticated, fixed-amount, expiring request to top up a specific user's SudoSOS balance. End-users see it as a shareable "payment link"; in the domain it is a request entity with derived status.

This PR is built up commit-by-commit so the story is reviewable. The full design is captured in #639 (with two `edit:` notes documenting the consensus reached in the issue thread). High-level shape:

- **Entity**: UUID PK (QR-authenticator pattern), immutable `amount` (Dinero), `expiresAt`, `paidAt`/`cancelledAt`/`cancelledBy` for state, `for`/`createdBy` for audit. Derived `status` getter (`PENDING | PAID | EXPIRED | CANCELLED`).
- **Stripe relation inverted**: `StripePaymentIntent.paymentRequest?` — supports retries (one request, many intents). "Paid" derived from a successful intent's existing `StripeDeposit.transfer`.
- **Always credits balance on success.** Pure top-up primitive. Automagic invoices (#197) compose by *not* pre-creating their own invoice-Transfer; the Stripe deposit becomes the settlement event.
- **Public + authenticated controllers split.** Public lookup/start endpoints mounted before token middleware (StripeWebhookController pattern). Admin operations (create/list/cancel/mark-fulfilled-externally) behind RBAC.

## Phase tracker (commits)

- [x] **Phase 1**: Entity + migrations + DB registration.
- [x] **Phase 2**: `PaymentRequestService` + Stripe webhook hook.
- [x] **Phase 3**: Authenticated controller + public controller + DTOs.
- [x] **Phase 4**: RBAC default-roles wiring.
- [x] **Phase 5**: Seeder + service tests + controller tests.
- [x] **Phase 6**: Documentation (entity prose + general docs).
- [x] **Phase 7**: Final lint + tsc + full test suite (CI gate).

## Related

Closes #639. See cross-reference comments on #197 and #139.

## Types of changes

- New feature

---

## ✅ PR Checklist

- [x] **Test Coverage**: PaymentRequestService + PaymentRequestController + PaymentRequestPublicController covered.
- [x] **Documentation**: entity module prose, Core Concepts, and Key Workflows updated.
- [x] **Database Changes**: two TypeORM migrations included (create `payment_request`, alter `stripe_payment_intent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
