### PR TITLE
Add PaymentRequest schema and migration

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -109,6 +109,11 @@ import {
   RemoveCreditTransferFromInactiveAdministrativeCost1769005123365,
 } from '../migrations/1769005123365-remove-credit-transfer-from-inactive-administrative-cost';
 import { AddLastSeenToUser1769000095806 } from '../migrations/1769000095806-add-last-seen-to-user';
+import PaymentRequest from '../entity/payment-request/payment-request';
+import { PaymentRequest1777010230727 } from '../migrations/1777010230727-payment-request';
+import {
+  StripePaymentIntentPaymentRequest1777010230751,
+} from '../migrations/1777010230751-stripe-payment-intent-payment-request';
 import Config from '../config';
 
 function getDataSourceOptions(): DataSourceOptions {
@@ -145,6 +150,8 @@ function getDataSourceOptions(): DataSourceOptions {
       UserSetting1768697568707,
       RemoveCreditTransferFromInactiveAdministrativeCost1769005123365,
       AddLastSeenToUser1769000095806,
+      PaymentRequest1777010230727,
+      StripePaymentIntentPaymentRequest1777010230751,
     ],
     extra: {
       authPlugins: {
@@ -216,6 +223,7 @@ function getDataSourceOptions(): DataSourceOptions {
       NotificationLog,
       UserNotificationPreference,
       UserSetting,
+      PaymentRequest,
     ],
     subscribers: [
       TransactionSubscriber,

--- a/src/entity/payment-request/payment-request-status.ts
+++ b/src/entity/payment-request/payment-request-status.ts
@@ -1,0 +1,41 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * @module stripe/payment-request
+ */
+
+/**
+ * Derived status of a {@link PaymentRequest}.
+ *
+ * The status is **not stored** on the entity — it is computed from the
+ * combination of `paidAt`, `cancelledAt`, and `expiresAt` against the
+ * current clock. See {@link PaymentRequest.status}.
+ */
+export enum PaymentRequestStatus {
+  /** Awaiting payment, not yet expired or cancelled. */
+  PENDING = 'PENDING',
+  /** A linked StripeDeposit succeeded and the credit Transfer was created. */
+  PAID = 'PAID',
+  /** `expiresAt` has passed without payment. */
+  EXPIRED = 'EXPIRED',
+  /** Explicitly cancelled by an authorized user. */
+  CANCELLED = 'CANCELLED',
+}

--- a/src/entity/payment-request/payment-request.ts
+++ b/src/entity/payment-request/payment-request.ts
@@ -1,0 +1,222 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * This is the module page of the payment-request.
+ *
+ * A `PaymentRequest` is an immutable, unauthenticated, shareable request to
+ * top up a specific user's balance with a specific amount before a specific
+ * deadline. It is the domain primitive behind what end-users perceive as a
+ * "payment link".
+ *
+ * ## Lifecycle
+ *
+ * A request is created in `PENDING` state with an `expiresAt` and a fixed
+ * `amount`. From there it transitions to exactly one of:
+ *
+ * - `PAID` — a linked {@link stripe!StripePaymentIntent | StripePaymentIntent}
+ *   succeeded and the corresponding void->user `Transfer` was created.
+ * - `CANCELLED` — explicitly cancelled by an authorized user (e.g. a wrong
+ *   amount was issued and a fresh request will be created instead).
+ * - `EXPIRED` — `expiresAt` has passed without payment.
+ *
+ * Status is **derived**, not stored — see {@link PaymentRequest.status}. The
+ * only stored state is `paidAt`, `cancelledAt`, and `expiresAt`.
+ *
+ * ## Stripe relationship (one-to-many on the inverse side)
+ *
+ * A request may have many {@link stripe!StripePaymentIntent | StripePaymentIntent}
+ * rows over its lifetime — each call to `startPayment` mints a fresh intent
+ * (the user can abandon a session and try again). The request becomes "paid"
+ * when at least one of those intents reaches `SUCCEEDED` and its
+ * `StripeDeposit.transfer` exists.
+ *
+ * ## Amount immutability
+ *
+ * The `amount` is fixed at creation time and cannot be mutated. The user-
+ * facing email/PDF mentions a specific euro figure; if SudoSOS were to
+ * recompute the figure at pay-time (against a moving balance), the email
+ * and the actual charge would diverge. To correct a wrong amount, cancel
+ * the request and create a new one — never mutate.
+ *
+ * ## Always credits balance on success
+ *
+ * A successful payment **always** results in a standard void->user `Transfer`
+ * that credits the recipient's balance. `PaymentRequest` is a top-up
+ * primitive — callers that do not want a balance credit (e.g. a future
+ * "invoice via payment link" flow) must not pre-create their own credit
+ * Transfer; the Stripe deposit is the single settlement event.
+ *
+ * ## Admin escape hatch
+ *
+ * Reality intrudes: occasionally a user pays a payment-link's invoice via
+ * bank transfer instead of iDeal. The admin endpoint
+ * `POST /payment-requests/:id/mark-fulfilled` creates the credit Transfer
+ * manually (with a reason for audit) — this credits the recipient's balance
+ * exactly the same way a Stripe payment would — and flips the request to
+ * `PAID` without a Stripe deposit existing.
+ *
+ * ## Out of scope (tracked elsewhere)
+ *
+ * - Linking back to {@link invoicing!Invoice | Invoice}
+ *   (`Invoice.paymentRequest?` lives on the invoice side).
+ * - Settlement (positive-balance payouts) for disabled users — a separate
+ *   primitive, not this one.
+ * - Stripe refund handling.
+ *
+ * @module stripe/payment-request
+ * @mergeTarget
+ */
+
+import {
+  Column, Entity, JoinColumn, ManyToOne, PrimaryColumn,
+} from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+import { Dinero } from 'dinero.js';
+import BaseEntityWithoutId from '../base-entity-without-id';
+import User from '../user/user';
+import DineroTransformer from '../transformer/dinero-transformer';
+import { PaymentRequestStatus } from './payment-request-status';
+
+/**
+ * A shareable, fixed-amount request to top up a specific user's SudoSOS
+ * balance. See the module page for full lifecycle and integration notes.
+ *
+ * @typedef {BaseEntityWithoutId} PaymentRequest
+ * @property {string} id.required - UUID v4, also the public identifier shared in the link.
+ * @property {User.model} for.required - The user whose balance will be credited on payment.
+ * @property {User.model} createdBy.required - The user that issued this request (audit).
+ * @property {integer} amount.required - Fixed amount in cents (Dinero); immutable.
+ * @property {string} expiresAt.required - When the request stops accepting payments.
+ * @property {string} cancelledAt - When the request was cancelled (null if not cancelled).
+ * @property {User.model} cancelledBy - The user that cancelled this request (null if not cancelled).
+ * @property {string} paidAt - When the request was marked paid (null if pending/cancelled/expired).
+ * @property {User.model} fulfilledBy - The admin that marked the request paid out-of-band via the escape hatch (null otherwise).
+ * @property {string} description - Human-readable description (e.g. "Drinks at Walhalla naborrel 2026-04-12").
+ *
+ * @promote
+ */
+@Entity()
+export default class PaymentRequest extends BaseEntityWithoutId {
+  /** UUID v4. Also the public-facing identifier shared in payment links. */
+  @PrimaryColumn({
+    type: 'varchar',
+    length: 36,
+  })
+  public id: string;
+
+  /** The user whose balance will be credited on successful payment. */
+  @ManyToOne(() => User, { nullable: false, eager: true, onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'forId' })
+  // Keep the domain term: `for` reads naturally as "PaymentRequest for a user".
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public for: User;
+
+  /** Audit: who issued this request. */
+  @ManyToOne(() => User, { nullable: false, onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'createdById' })
+  public createdBy: User;
+
+  /** Fixed, immutable amount. */
+  @Column({
+    type: 'integer',
+    transformer: DineroTransformer.Instance,
+  })
+  public amount: Dinero;
+
+  /**
+   * After this moment the request stops accepting payments. Once
+   * `expiresAt` has passed, the derived `status` flips to `EXPIRED`
+   * (unless the request had already been paid or cancelled, which take
+   * precedence — see {@link PaymentRequest.status}).
+   */
+  @Column({
+    type: 'datetime',
+  })
+  public expiresAt: Date;
+
+  /** When the request was cancelled, null if not cancelled. */
+  @Column({
+    type: 'datetime',
+    nullable: true,
+  })
+  public cancelledAt: Date | null;
+
+  /** Who cancelled the request (audit), null if not cancelled. */
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'cancelledById' })
+  public cancelledBy: User | null;
+
+  /** When the request was marked paid (Stripe success or admin override). */
+  @Column({
+    type: 'datetime',
+    nullable: true,
+  })
+  public paidAt: Date | null;
+
+  /**
+   * Audit: the admin that flipped this request to PAID via the out-of-band
+   * escape hatch (`markFulfilledExternally`). `null` for Stripe-settled
+   * requests — those are unambiguously attributed via the linked
+   * `StripePaymentIntent`.
+   */
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'fulfilledById' })
+  public fulfilledBy: User | null;
+
+  /** Optional human-readable description for context (e.g. invoice reference). */
+  @Column({
+    type: 'varchar',
+    length: 255,
+    nullable: true,
+  })
+  public description: string | null;
+
+  /**
+   * Derived status — not persisted. Order of precedence:
+   * `PAID` > `CANCELLED` > `EXPIRED` > `PENDING`.
+   */
+  public get status(): PaymentRequestStatus {
+    if (!!this.paidAt) {
+      return PaymentRequestStatus.PAID;
+    }
+    if (!!this.cancelledAt) {
+      return PaymentRequestStatus.CANCELLED;
+    }
+    if (this.expiresAt < new Date()) {
+      return PaymentRequestStatus.EXPIRED;
+    }
+    return PaymentRequestStatus.PENDING;
+  }
+
+  async getOwner(): Promise<User> {
+    return this.for;
+  }
+
+  constructor() {
+    super();
+    this.id = uuidv4();
+    this.cancelledAt = null;
+    this.cancelledBy = null;
+    this.paidAt = null;
+    this.fulfilledBy = null;
+    this.description = null;
+  }
+}

--- a/src/entity/stripe/stripe-payment-intent.ts
+++ b/src/entity/stripe/stripe-payment-intent.ts
@@ -25,11 +25,12 @@
  */
 
 import BaseEntity from '../base-entity';
-import { Column, Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne } from 'typeorm';
 import StripePaymentIntentStatus from './stripe-payment-intent-status';
 import DineroTransformer from '../transformer/dinero-transformer';
 import { Dinero } from 'dinero.js';
 import StripeDeposit from './stripe-deposit';
+import PaymentRequest from '../payment-request/payment-request';
 
 @Entity()
 export default class StripePaymentIntent extends BaseEntity {
@@ -50,4 +51,19 @@ export default class StripePaymentIntent extends BaseEntity {
 
   @OneToOne(() => StripeDeposit, (s) => s.stripePaymentIntent, { nullable: true })
   public deposit: StripeDeposit | null;
+
+  /**
+   * Optional back-reference to a {@link stripe/payment-request!PaymentRequest | PaymentRequest}
+   * that initiated this intent. Populated when the intent is created via
+   * the PaymentRequest start flow (authenticated or public share-link).
+   *
+   * The data-model contract is: a single PaymentRequest may have many
+   * StripePaymentIntents (retries), but only one of them ever reaches
+   * `SUCCEEDED`. The webhook ingestion path in the service layer reads
+   * this back-reference to mark the linked request as paid; the wiring
+   * itself lives outside this entity (see the service-layer changes).
+   */
+  @ManyToOne(() => PaymentRequest, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'paymentRequestId' })
+  public paymentRequest?: PaymentRequest | null;
 }

--- a/src/migrations/1777010230727-payment-request.ts
+++ b/src/migrations/1777010230727-payment-request.ts
@@ -1,0 +1,206 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * @module
+ * @hidden
+ */
+
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+export class PaymentRequest1777010230727 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(new Table({
+      name: 'payment_request',
+      columns: [
+        {
+          name: 'id',
+          type: 'varchar',
+          length: '36',
+          isPrimary: true,
+          isNullable: false,
+        },
+        {
+          name: 'forId',
+          type: 'integer',
+          isNullable: false,
+        },
+        {
+          name: 'createdById',
+          type: 'integer',
+          isNullable: false,
+        },
+        {
+          name: 'amount',
+          type: 'integer',
+          isNullable: false,
+        },
+        {
+          name: 'expiresAt',
+          type: 'datetime',
+          isNullable: false,
+        },
+        {
+          name: 'cancelledAt',
+          type: 'datetime',
+          isNullable: true,
+        },
+        {
+          name: 'cancelledById',
+          type: 'integer',
+          isNullable: true,
+        },
+        {
+          name: 'paidAt',
+          type: 'datetime',
+          isNullable: true,
+        },
+        {
+          name: 'fulfilledById',
+          type: 'integer',
+          isNullable: true,
+        },
+        {
+          name: 'description',
+          type: 'varchar',
+          length: '255',
+          isNullable: true,
+        },
+        {
+          name: 'createdAt',
+          type: 'datetime',
+          default: 'current_timestamp',
+          isNullable: false,
+        },
+        {
+          name: 'updatedAt',
+          type: 'datetime',
+          default: 'current_timestamp',
+          onUpdate: 'current_timestamp',
+          isNullable: false,
+        },
+        {
+          name: 'version',
+          type: 'integer',
+          isNullable: false,
+          default: 1,
+        },
+      ],
+    }), true);
+
+    // Foreign keys
+    await queryRunner.createForeignKey('payment_request', new TableForeignKey({
+      columnNames: ['forId'],
+      referencedColumnNames: ['id'],
+      referencedTableName: 'user',
+      onDelete: 'RESTRICT',
+      onUpdate: 'NO ACTION',
+    }));
+
+    await queryRunner.createForeignKey('payment_request', new TableForeignKey({
+      columnNames: ['createdById'],
+      referencedColumnNames: ['id'],
+      referencedTableName: 'user',
+      onDelete: 'RESTRICT',
+      onUpdate: 'NO ACTION',
+    }));
+
+    await queryRunner.createForeignKey('payment_request', new TableForeignKey({
+      columnNames: ['cancelledById'],
+      referencedColumnNames: ['id'],
+      referencedTableName: 'user',
+      onDelete: 'SET NULL',
+      onUpdate: 'NO ACTION',
+    }));
+
+    await queryRunner.createForeignKey('payment_request', new TableForeignKey({
+      columnNames: ['fulfilledById'],
+      referencedColumnNames: ['id'],
+      referencedTableName: 'user',
+      onDelete: 'SET NULL',
+      onUpdate: 'NO ACTION',
+    }));
+
+    // Indexes
+    await queryRunner.createIndex('payment_request', new TableIndex({
+      name: 'IDX_payment_request_createdAt',
+      columnNames: ['createdAt'],
+    }));
+
+    await queryRunner.createIndex('payment_request', new TableIndex({
+      name: 'IDX_payment_request_createdById',
+      columnNames: ['createdById'],
+    }));
+
+    await queryRunner.createIndex('payment_request', new TableIndex({
+      name: 'IDX_payment_request_cancelledById',
+      columnNames: ['cancelledById'],
+    }));
+
+    await queryRunner.createIndex('payment_request', new TableIndex({
+      name: 'IDX_payment_request_fulfilledById',
+      columnNames: ['fulfilledById'],
+    }));
+
+    await queryRunner.createIndex('payment_request', new TableIndex({
+      name: 'IDX_payment_request_expiresAt',
+      columnNames: ['expiresAt'],
+    }));
+
+    await queryRunner.createIndex('payment_request', new TableIndex({
+      name: 'IDX_payment_request_paidAt',
+      columnNames: ['paidAt'],
+    }));
+
+    // Composite index for the most common query: "open requests for user X"
+    await queryRunner.createIndex('payment_request', new TableIndex({
+      name: 'IDX_payment_request_forId_paidAt',
+      columnNames: ['forId', 'paidAt'],
+    }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop indexes
+    await queryRunner.dropIndex('payment_request', 'IDX_payment_request_forId_paidAt');
+    await queryRunner.dropIndex('payment_request', 'IDX_payment_request_paidAt');
+    await queryRunner.dropIndex('payment_request', 'IDX_payment_request_expiresAt');
+    await queryRunner.dropIndex('payment_request', 'IDX_payment_request_fulfilledById');
+    await queryRunner.dropIndex('payment_request', 'IDX_payment_request_cancelledById');
+    await queryRunner.dropIndex('payment_request', 'IDX_payment_request_createdById');
+    await queryRunner.dropIndex('payment_request', 'IDX_payment_request_createdAt');
+
+    // Drop foreign keys
+    const table = await queryRunner.getTable('payment_request');
+    if (table) {
+      const fulfilledByFk = table.foreignKeys.find(f => f.columnNames.indexOf('fulfilledById') !== -1);
+      if (fulfilledByFk) await queryRunner.dropForeignKey('payment_request', fulfilledByFk);
+      const cancelledByFk = table.foreignKeys.find(f => f.columnNames.indexOf('cancelledById') !== -1);
+      if (cancelledByFk) await queryRunner.dropForeignKey('payment_request', cancelledByFk);
+      const createdByFk = table.foreignKeys.find(f => f.columnNames.indexOf('createdById') !== -1);
+      if (createdByFk) await queryRunner.dropForeignKey('payment_request', createdByFk);
+      const forFk = table.foreignKeys.find(f => f.columnNames.indexOf('forId') !== -1);
+      if (forFk) await queryRunner.dropForeignKey('payment_request', forFk);
+    }
+
+    await queryRunner.dropTable('payment_request');
+  }
+
+}

--- a/src/migrations/1777010230751-stripe-payment-intent-payment-request.ts
+++ b/src/migrations/1777010230751-stripe-payment-intent-payment-request.ts
@@ -1,0 +1,64 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * @module
+ * @hidden
+ */
+
+import { MigrationInterface, QueryRunner, TableColumn, TableForeignKey, TableIndex } from 'typeorm';
+
+export class StripePaymentIntentPaymentRequest1777010230751 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn('stripe_payment_intent', new TableColumn({
+      name: 'paymentRequestId',
+      type: 'varchar',
+      length: '36',
+      isNullable: true,
+    }));
+
+    await queryRunner.createForeignKey('stripe_payment_intent', new TableForeignKey({
+      columnNames: ['paymentRequestId'],
+      referencedColumnNames: ['id'],
+      referencedTableName: 'payment_request',
+      onDelete: 'SET NULL',
+      onUpdate: 'NO ACTION',
+    }));
+
+    await queryRunner.createIndex('stripe_payment_intent', new TableIndex({
+      name: 'IDX_stripe_payment_intent_paymentRequestId',
+      columnNames: ['paymentRequestId'],
+    }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('stripe_payment_intent', 'IDX_stripe_payment_intent_paymentRequestId');
+
+    const table = await queryRunner.getTable('stripe_payment_intent');
+    if (table) {
+      const paymentRequestFk = table.foreignKeys.find(f => f.columnNames.indexOf('paymentRequestId') !== -1);
+      if (paymentRequestFk) await queryRunner.dropForeignKey('stripe_payment_intent', paymentRequestFk);
+    }
+
+    await queryRunner.dropColumn('stripe_payment_intent', 'paymentRequestId');
+  }
+
+}


### PR DESCRIPTION
# Description

**Stack: 1 of 3** — schema layer of the [PaymentRequest primitive (#639)](https://github.com/GEWIS/sudosos-backend/issues/639). This PR ships only the entity and migration; the service and HTTP layers follow in dependent PRs.

A PaymentRequest is an unauthenticated, fixed-amount, expiring request to top up a specific user's SudoSOS balance. End-users see it as a shareable "payment link"; in the domain it is a request entity with derived status (`PENDING | PAID | EXPIRED | CANCELLED`).

## What this PR adds

- **`PaymentRequest` entity** — UUID PK (QR-authenticator pattern), immutable `amount` (Dinero), `expiresAt`, `paidAt` / `cancelledAt` / `cancelledBy` / `fulfilledBy` for state, `for` / `createdBy` for audit. Derived `status` getter computed from stored timestamp columns.
- **Migration `1777010230727-payment-request.ts`** — creates the `payment_request` table with indexes on `forId`, `createdById`, `cancelledById`, `fulfilledById`, and `expiresAt`; alters `stripe_payment_intent` to add the optional `paymentRequestId` FK so a single request can be retried across many intents.
- **Stripe relation inverted** — `StripePaymentIntent.paymentRequest?` lives on the intent side, so retries are first-class. "Paid" is derived from a successful intent's existing `StripeDeposit.transfer` (no parallel ledger).

The columns are dormant in this PR — the next stack PR adds the service that reads/writes them.

## Related issues/external references

Part of #639. Continues in:
- PR #2: `Add PaymentRequest service layer` (depends on this)
- PR #3: `Add PaymentRequest HTTP API` (depends on #2)

## Types of changes

- New feature

---

## ✅ PR Checklist

- [x] **Test Coverage**: schema-only PR — entity behavior is exercised by service tests in the next stack PR. Migration up/down both run cleanly under `pnpm run schema`.
- [x] **Documentation**: TypeDoc prose on the entity module + per-field JSDoc.
- [x] **Database Changes**: migration included, tested with both SQLite (vitest) and MariaDB (CI coverage job).

## 🔗 Additional Notes

This is the first PR in a 3-way stack splitting [#890](https://github.com/GEWIS/sudosos-backend/pull/890). The original combined PR will be closed once the stack lands.