### PR TITLE
fix: incorrect jsdoc return type in GET /transfers

### DIFF
--- a/src/controller/transfer-controller.ts
+++ b/src/controller/transfer-controller.ts
@@ -209,7 +209,7 @@ export default class TransferController extends BaseController {
    * @param {string} category.query - Restrict to a specific transfer category: deposit, payoutRequest, sellerPayout, invoice, creditInvoice, fine, waivedFines, writeOff, inactiveAdministrativeCost, manualCreation, manualDeletion
    * @param {integer} take.query - How many transfers the endpoint should return
    * @param {integer} skip.query - How many transfers should be skipped (for pagination)
-   * @return {Array.<TransferResponse>} 200 - All existing transfers
+   * @return {PaginatedTransferResponse} 200 - All existing transfers
    * @return {string} 400 - Validation error
    * @return {string} 500 - Internal server error
    */

--- a/test/unit/controller/transfer-controller.ts
+++ b/test/unit/controller/transfer-controller.ts
@@ -174,7 +174,7 @@ describe('TransferController', async (): Promise<void> => {
         .set('Authorization', `Bearer ${adminToken}`);
       expect(res.status).to.equal(200);
       expect(specification.validateModel(
-        'Array<TransferResponse>',
+        'PaginatedTransferResponse',
         res.body,
         false,
         true,


### PR DESCRIPTION
Removes Array<TransferResponse> as return type
Adds PaginatedTransferResponse as return type

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_
- Documentation improvement
---

## ✅ PR Checklist

- [X] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [X] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [X] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB