### PR TITLE
Drop -secure suffix from PIN/NFC/EAN auth endpoints

### DIFF
--- a/src/controller/authentication-secure-controller.ts
+++ b/src/controller/authentication-secure-controller.ts
@@ -36,9 +36,9 @@ import { ISettings } from '../entity/server-setting';
 import { QRAuthenticatorStatus } from '../entity/authenticator/qr-authenticator';
 import WebSocketService from '../service/websocket-service';
 import QRService from '../service/qr-service';
-import AuthenticationSecurePinRequest from './request/authentication-secure-pin-request';
-import AuthenticationSecureNfcRequest from './request/authentication-secure-nfc-request';
-import AuthenticationSecureEanRequest from './request/authentication-secure-ean-request';
+import AuthenticationPinRequest from './request/authentication-pin-request';
+import AuthenticationNfcRequest from './request/authentication-nfc-request';
+import AuthenticationEanRequest from './request/authentication-ean-request';
 import { UserType } from '../entity/user/user';
 import AuthenticationController from './authentication-controller';
 import AuthenticationService from '../service/authentication-service';
@@ -103,24 +103,24 @@ export default class AuthenticationSecureController extends BaseController {
           restrictions: { lesser: false },
         },
       },
-      '/pin-secure': {
+      '/pin': {
         POST: {
           policy: async () => Promise.resolve(true),
-          handler: this.securePINLogin.bind(this),
+          handler: this.pinLogin.bind(this),
           restrictions: { lesser: false },
         },
       },
-      '/nfc-secure': {
+      '/nfc': {
         POST: {
           policy: async () => Promise.resolve(true),
-          handler: this.secureNfcLogin.bind(this),
+          handler: this.nfcLogin.bind(this),
           restrictions: { lesser: false },
         },
       },
-      '/ean-secure': {
+      '/ean': {
         POST: {
           policy: async () => Promise.resolve(true),
-          handler: this.secureEanLogin.bind(this),
+          handler: this.eanLogin.bind(this),
           restrictions: { lesser: false },
         },
       },
@@ -270,25 +270,25 @@ export default class AuthenticationSecureController extends BaseController {
   }
 
   /**
-   * POST /authentication/pin-secure
-   * @summary Secure PIN authentication that requires POS user authentication
-   * @operationId securePINAuthentication
+   * POST /authentication/pin
+   * @summary PIN authentication that requires POS user authentication
+   * @operationId pinAuthentication
    * @tags authenticate - Operations of authentication controller
    * @security JWT
-   * @param {AuthenticationSecurePinRequest} request.body.required - The PIN login request with posId
+   * @param {AuthenticationPinRequest} request.body.required - The PIN login request with posId
    * @return {AuthenticationResponse} 200 - The created json web token
    * @return {string} 403 - Authentication error (invalid POS user or credentials)
    * @return {string} 500 - Internal server error
    */
-  private async securePINLogin(req: RequestWithToken, res: Response): Promise<void> {
-    const body = req.body as AuthenticationSecurePinRequest;
-    this.logger.trace('Secure PIN authentication for user', body.userId, 'by POS user', req.token.user.id);
+  private async pinLogin(req: RequestWithToken, res: Response): Promise<void> {
+    const body = req.body as AuthenticationPinRequest;
+    this.logger.trace('PIN authentication for user', body.userId, 'by POS user', req.token.user.id);
 
     try {
       // Verify the caller is a POS user
       const tokenUser = await User.findOne(UserService.getOptions({ id: req.token.user.id, allowPos: true }));
       if (!tokenUser || tokenUser.type !== UserType.POINT_OF_SALE) {
-        res.status(403).json('Only POS users can use secure PIN authentication.');
+        res.status(403).json('Only POS users can use PIN authentication.');
         return;
       }
 
@@ -303,31 +303,31 @@ export default class AuthenticationSecureController extends BaseController {
       await (AuthenticationController.PINLoginConstructor(this.roleManager,
         this.tokenHandler, body.pin, body.userId, body.posId))(req, res);
     } catch (error) {
-      this.logger.error('Could not authenticate using secure PIN:', error);
+      this.logger.error('Could not authenticate using PIN:', error);
       res.status(500).json('Internal server error.');
     }
   }
 
   /**
-   * POST /authentication/nfc-secure
-   * @summary Secure NFC authentication that requires POS user authentication
-   * @operationId secureNfcAuthentication
+   * POST /authentication/nfc
+   * @summary NFC authentication that requires POS user authentication
+   * @operationId nfcAuthentication
    * @tags authenticate - Operations of authentication controller
    * @security JWT
-   * @param {AuthenticationSecureNfcRequest} request.body.required - The NFC login request with posId
+   * @param {AuthenticationNfcRequest} request.body.required - The NFC login request with posId
    * @return {AuthenticationResponse} 200 - The created json web token
    * @return {string} 403 - Authentication error (invalid POS user or credentials)
    * @return {string} 500 - Internal server error
    */
-  private async secureNfcLogin(req: RequestWithToken, res: Response): Promise<void> {
-    const body = req.body as AuthenticationSecureNfcRequest;
-    this.logger.trace('Secure NFC authentication for nfcCode', body.nfcCode, 'by POS user', req.token.user.id);
+  private async nfcLogin(req: RequestWithToken, res: Response): Promise<void> {
+    const body = req.body as AuthenticationNfcRequest;
+    this.logger.trace('NFC authentication for nfcCode', body.nfcCode, 'by POS user', req.token.user.id);
 
     try {
       // Verify the caller is a POS user
       const tokenUser = await User.findOne(UserService.getOptions({ id: req.token.user.id, allowPos: true }));
       if (!tokenUser || tokenUser.type !== UserType.POINT_OF_SALE) {
-        res.status(403).json('Only POS users can use secure NFC authentication.');
+        res.status(403).json('Only POS users can use NFC authentication.');
         return;
       }
 
@@ -355,7 +355,7 @@ export default class AuthenticationSecureController extends BaseController {
         tokenHandler: this.tokenHandler,
       };
 
-      this.logger.trace('Successful secure NFC authentication for user', authenticator.user);
+      this.logger.trace('Successful NFC authentication for user', authenticator.user);
 
       const result = await new AuthenticationService().getSaltedToken({
         user: authenticator.user,
@@ -364,31 +364,31 @@ export default class AuthenticationSecureController extends BaseController {
       });
       res.json(AuthenticationService.asAuthenticationResponse(result.user, result.roles, result.organs, result.token));
     } catch (error) {
-      this.logger.error('Could not authenticate using secure NFC:', error);
+      this.logger.error('Could not authenticate using NFC:', error);
       res.status(500).json('Internal server error.');
     }
   }
 
   /**
-   * POST /authentication/ean-secure
-   * @summary Secure EAN authentication that requires POS user authentication
-   * @operationId secureEanAuthentication
+   * POST /authentication/ean
+   * @summary EAN authentication that requires POS user authentication
+   * @operationId eanAuthentication
    * @tags authenticate - Operations of authentication controller
    * @security JWT
-   * @param {AuthenticationSecureEanRequest} request.body.required - The EAN login request with posId
+   * @param {AuthenticationEanRequest} request.body.required - The EAN login request with posId
    * @return {AuthenticationResponse} 200 - The created json web token
    * @return {string} 403 - Authentication error (invalid POS user or credentials)
    * @return {string} 500 - Internal server error
    */
-  private async secureEanLogin(req: RequestWithToken, res: Response): Promise<void> {
-    const body = req.body as AuthenticationSecureEanRequest;
-    this.logger.trace('Secure EAN authentication for eanCode', body.eanCode, 'by POS user', req.token.user.id);
+  private async eanLogin(req: RequestWithToken, res: Response): Promise<void> {
+    const body = req.body as AuthenticationEanRequest;
+    this.logger.trace('EAN authentication for eanCode', body.eanCode, 'by POS user', req.token.user.id);
 
     try {
       // Verify the caller is a POS user
       const tokenUser = await User.findOne(UserService.getOptions({ id: req.token.user.id, allowPos: true }));
       if (!tokenUser || tokenUser.type !== UserType.POINT_OF_SALE) {
-        res.status(403).json('Only POS users can use secure EAN authentication.');
+        res.status(403).json('Only POS users can use EAN authentication.');
         return;
       }
 
@@ -416,7 +416,7 @@ export default class AuthenticationSecureController extends BaseController {
         tokenHandler: this.tokenHandler,
       };
 
-      this.logger.trace('Successful secure EAN authentication for user', authenticator.user);
+      this.logger.trace('Successful EAN authentication for user', authenticator.user);
 
       const result = await new AuthenticationService().getSaltedToken({
         user: authenticator.user,
@@ -425,7 +425,7 @@ export default class AuthenticationSecureController extends BaseController {
       });
       res.json(AuthenticationService.asAuthenticationResponse(result.user, result.roles, result.organs, result.token));
     } catch (error) {
-      this.logger.error('Could not authenticate using secure EAN:', error);
+      this.logger.error('Could not authenticate using EAN:', error);
       res.status(500).json('Internal server error.');
     }
   }

--- a/src/controller/member-authentication-secure-controller.ts
+++ b/src/controller/member-authentication-secure-controller.ts
@@ -34,12 +34,12 @@ import User from '../entity/user/user';
 import PointOfSale from '../entity/point-of-sale/point-of-sale';
 import { UserType } from '../entity/user/user';
 import AuthenticationController from './authentication-controller';
-import MemberAuthenticationSecurePinRequest from './request/member-authentication-secure-pin-request';
+import MemberAuthenticationPinRequest from './request/member-authentication-pin-request';
 import MemberUser from '../entity/user/member-user';
 import UserService from '../service/user-service';
 
 /**
- * Handles authenticated-only member authentication endpoints for secure PIN authentication.
+ * Handles authenticated-only member authentication endpoints for PIN authentication.
  * All endpoints require valid JWT tokens and build upon existing authentication.
  *
  * @promote
@@ -68,10 +68,10 @@ export default class MemberAuthenticationSecureController extends BaseController
    */
   public getPolicy(): Policy {
     return {
-      '/member/pin-secure': {
+      '/member/pin': {
         POST: {
           policy: async () => Promise.resolve(true),
-          handler: this.secureMemberPINLogin.bind(this),
+          handler: this.memberPINLogin.bind(this),
           restrictions: { lesser: false },
         },
       },
@@ -79,25 +79,25 @@ export default class MemberAuthenticationSecureController extends BaseController
   }
 
   /**
-   * POST /authentication/member/pin-secure
-   * @summary Secure member PIN authentication that requires POS user authentication
-   * @operationId secureMemberPINAuthentication
+   * POST /authentication/member/pin
+   * @summary Member PIN authentication that requires POS user authentication
+   * @operationId memberPINAuthentication
    * @tags authenticate - Operations of authentication controller
    * @security JWT
-   * @param {MemberAuthenticationSecurePinRequest} request.body.required - The PIN login request with posId
+   * @param {MemberAuthenticationPinRequest} request.body.required - The PIN login request with posId
    * @return {AuthenticationResponse} 200 - The created json web token
    * @return {string} 403 - Authentication error (invalid POS user or credentials)
    * @return {string} 500 - Internal server error
    */
-  private async secureMemberPINLogin(req: RequestWithToken, res: Response): Promise<void> {
-    const body = req.body as MemberAuthenticationSecurePinRequest;
-    this.logger.trace('Secure member PIN authentication for memberId', body.memberId, 'by POS user', req.token.user.id);
+  private async memberPINLogin(req: RequestWithToken, res: Response): Promise<void> {
+    const body = req.body as MemberAuthenticationPinRequest;
+    this.logger.trace('Member PIN authentication for memberId', body.memberId, 'by POS user', req.token.user.id);
 
     try {
       // Verify the caller is a POS user
       const tokenUser = await User.findOne(UserService.getOptions({ id: req.token.user.id, allowPos: true }));
       if (!tokenUser || tokenUser.type !== UserType.POINT_OF_SALE) {
-        res.status(403).json('Only POS users can use secure member PIN authentication.');
+        res.status(403).json('Only POS users can use member PIN authentication.');
         return;
       }
 
@@ -125,7 +125,7 @@ export default class MemberAuthenticationSecureController extends BaseController
       await (AuthenticationController.PINLoginConstructor(this.roleManager,
         this.tokenHandler, body.pin, memberUser.user.id, body.posId))(req, res);
     } catch (error) {
-      this.logger.error('Could not authenticate using secure member PIN:', error);
+      this.logger.error('Could not authenticate using member PIN:', error);
       res.status(500).json('Internal server error.');
     }
   }

--- a/src/controller/request/authentication-ean-request.ts
+++ b/src/controller/request/authentication-ean-request.ts
@@ -19,17 +19,17 @@
  */
 
 /**
- * This is the module page of the authentication-secure-ean-request.
+ * This is the module page of the authentication-ean-request.
  *
  * @module authentication
  */
 
 /**
- * @typedef {object} AuthenticationSecureEanRequest
+ * @typedef {object} AuthenticationEanRequest
  * @property {string} eanCode.required
  * @property {number} posId.required - POS identifier
  */
-export default interface AuthenticationSecureEanRequest {
+export default interface AuthenticationEanRequest {
   eanCode: string;
   posId: number;
 }

--- a/src/controller/request/authentication-nfc-request.ts
+++ b/src/controller/request/authentication-nfc-request.ts
@@ -19,17 +19,17 @@
  */
 
 /**
- * This is the module page of the authentication-secure-nfc-request.
+ * This is the module page of the authentication-nfc-request.
  *
  * @module authentication
  */
 
 /**
- * @typedef {object} AuthenticationSecureNfcRequest
+ * @typedef {object} AuthenticationNfcRequest
  * @property {string} nfcCode.required
  * @property {number} posId.required - POS identifier
  */
-export default interface AuthenticationSecureNfcRequest {
+export default interface AuthenticationNfcRequest {
   nfcCode: string;
   posId: number;
 }

--- a/src/controller/request/authentication-pin-request.ts
+++ b/src/controller/request/authentication-pin-request.ts
@@ -19,18 +19,18 @@
  */
 
 /**
- * This is the module page of the authentication-secure-pin-request.
+ * This is the module page of the authentication-pin-request.
  *
  * @module authentication
  */
 
 /**
- * @typedef {object} AuthenticationSecurePinRequest
+ * @typedef {object} AuthenticationPinRequest
  * @property {number} userId.required
  * @property {string} pin.required
- * @property {number} posId.required - POS identifier (required for secure authentication)
+ * @property {number} posId.required - POS identifier
  */
-export default interface AuthenticationSecurePinRequest {
+export default interface AuthenticationPinRequest {
   userId: number,
   pin: string,
   posId: number,

--- a/src/controller/request/member-authentication-pin-request.ts
+++ b/src/controller/request/member-authentication-pin-request.ts
@@ -19,18 +19,18 @@
  */
 
 /**
- * This is the module page of the member-authentication-secure-pin-request.
+ * This is the module page of the member-authentication-pin-request.
  *
  * @module authentication
  */
 
 /**
- * @typedef {object} MemberAuthenticationSecurePinRequest
+ * @typedef {object} MemberAuthenticationPinRequest
  * @property {number} memberId.required
  * @property {string} pin.required
  * @property {number} posId.required - POS identifier
  */
-export default interface MemberAuthenticationSecurePinRequest {
+export default interface MemberAuthenticationPinRequest {
   memberId: number,
   pin: string,
   posId: number,

--- a/src/entity/authenticator/nfc-authenticator.ts
+++ b/src/entity/authenticator/nfc-authenticator.ts
@@ -38,7 +38,7 @@ import AuthenticationMethod from './authentication-method';
  *
  * ## NFC Authentication Flow
  * 1. **User** taps their NFC card against an NFC reader at a point of sale.
- * 2. **POS client** captures the NFC UID and calls `/authentication/nfc-secure` as an
+ * 2. **POS client** captures the NFC UID and calls `/authentication/nfc` as an
  *    authenticated POS user, including its POS JWT and the target `posId`.
  * 3. **Authentication Controller** validates the POS JWT/`posId` context and looks up the
  *    NfcAuthenticator by the provided UID.

--- a/test/integration/pos-token-flow.ts
+++ b/test/integration/pos-token-flow.ts
@@ -224,10 +224,10 @@ describe('POS Token Flow Integration Tests', (): void => {
     ctx.app.use(json());
     // Register authentication controller first (no token required)
     ctx.app.use('/authentication', authController.getRouter());
-    // Register token middleware for secure endpoints and other routes
+    // Register token middleware for JWT-protected endpoints and other routes
     const tokenMiddleware = new TokenMiddleware({ tokenHandler: ctx.tokenHandler, refreshFactor: 0.5 });
     ctx.app.use(tokenMiddleware.getMiddleware());
-    // Register secure controller (routes like /pin-secure won't conflict with /pin)
+    // Register the JWT-protected authentication controller
     ctx.app.use('/authentication', authSecureController.getRouter());
     ctx.app.use('/transactions', transactionController.getRouter());
   });
@@ -237,7 +237,7 @@ describe('POS Token Flow Integration Tests', (): void => {
   });
 
   describe('Complete POS Token Flow', () => {
-    it('should allow secure PIN authentication with posId and create transaction', async () => {
+    it('should allow PIN authentication with posId and create transaction', async () => {
       // Set up PIN authenticator
       const pinAuth = new PinAuthenticator();
       pinAuth.user = ctx.users[1];
@@ -247,9 +247,9 @@ describe('POS Token Flow Integration Tests', (): void => {
       // Set strict mode
       await ServerSettingsStore.getInstance().setSetting('strictPosToken', true);
 
-      // Authenticate with secure PIN endpoint and posId
+      // Authenticate with PIN endpoint and posId
       const authRes = await request(ctx.app)
-        .post('/authentication/pin-secure')
+        .post('/authentication/pin')
         .set('Authorization', `Bearer ${ctx.posUserToken}`)
         .send({
           userId: ctx.users[1].id,
@@ -269,7 +269,7 @@ describe('POS Token Flow Integration Tests', (): void => {
       expect(transRes.status).to.equal(200);
     });
 
-    it('should allow secure NFC authentication with posId and create transaction', async () => {
+    it('should allow NFC authentication with posId and create transaction', async () => {
       // Set up NFC authenticator
       const nfcAuth = new NfcAuthenticator();
       nfcAuth.user = ctx.users[1];
@@ -279,9 +279,9 @@ describe('POS Token Flow Integration Tests', (): void => {
       // Set strict mode
       await ServerSettingsStore.getInstance().setSetting('strictPosToken', true);
 
-      // Authenticate with secure NFC endpoint and posId
+      // Authenticate with NFC endpoint and posId
       const authRes = await request(ctx.app)
-        .post('/authentication/nfc-secure')
+        .post('/authentication/nfc')
         .set('Authorization', `Bearer ${ctx.posUserToken}`)
         .send({
           nfcCode: 'test-nfc-code',
@@ -300,7 +300,7 @@ describe('POS Token Flow Integration Tests', (): void => {
       expect(transRes.status).to.equal(200);
     });
 
-    it('should reject transaction when secure PIN posId does not match', async () => {
+    it('should reject transaction when PIN posId does not match', async () => {
       // Set up PIN authenticator
       const pinAuth = new PinAuthenticator();
       pinAuth.user = ctx.users[1];
@@ -310,9 +310,9 @@ describe('POS Token Flow Integration Tests', (): void => {
       // Set strict mode
       await ServerSettingsStore.getInstance().setSetting('strictPosToken', true);
 
-      // Authenticate with secure PIN and wrong posId - should fail at authentication
+      // Authenticate with PIN and wrong posId - should fail at authentication
       const authRes = await request(ctx.app)
-        .post('/authentication/pin-secure')
+        .post('/authentication/pin')
         .set('Authorization', `Bearer ${ctx.posUserToken}`)
         .send({
           userId: ctx.users[1].id,
@@ -324,7 +324,7 @@ describe('POS Token Flow Integration Tests', (): void => {
       expect(authRes.body).to.equal('POS user ID does not match the requested posId.');
     });
 
-    it('should allow transaction in non-strict mode with secure PIN matching posId', async () => {
+    it('should allow transaction in non-strict mode with PIN matching posId', async () => {
       // Set up PIN authenticator
       const pinAuth = new PinAuthenticator();
       pinAuth.user = ctx.users[1];
@@ -334,9 +334,9 @@ describe('POS Token Flow Integration Tests', (): void => {
       // Set non-strict mode
       await ServerSettingsStore.getInstance().setSetting('strictPosToken', false);
 
-      // Authenticate with secure PIN and matching posId
+      // Authenticate with PIN and matching posId
       const authRes = await request(ctx.app)
-        .post('/authentication/pin-secure')
+        .post('/authentication/pin')
         .set('Authorization', `Bearer ${ctx.posUserToken}`)
         .send({
           userId: ctx.users[1].id,
@@ -356,7 +356,7 @@ describe('POS Token Flow Integration Tests', (): void => {
       expect(transRes.status).to.equal(200);
     });
 
-    it('should reject secure PIN authentication when posId does not match in non-strict mode', async () => {
+    it('should reject PIN authentication when posId does not match in non-strict mode', async () => {
       // Set up PIN authenticator
       const pinAuth = new PinAuthenticator();
       pinAuth.user = ctx.users[1];
@@ -366,9 +366,9 @@ describe('POS Token Flow Integration Tests', (): void => {
       // Set non-strict mode
       await ServerSettingsStore.getInstance().setSetting('strictPosToken', false);
 
-      // Authenticate with secure PIN and wrong posId - should fail at authentication
+      // Authenticate with PIN and wrong posId - should fail at authentication
       const authRes = await request(ctx.app)
-        .post('/authentication/pin-secure')
+        .post('/authentication/pin')
         .set('Authorization', `Bearer ${ctx.posUserToken}`)
         .send({
           userId: ctx.users[1].id,

--- a/test/unit/controller/authentication-secure-controller.ts
+++ b/test/unit/controller/authentication-secure-controller.ts
@@ -47,9 +47,9 @@ import WebSocketService from '../../../src/service/websocket-service';
 import QRService from '../../../src/service/qr-service';
 import AuthenticationService from '../../../src/service/authentication-service';
 import sinon from 'sinon';
-import AuthenticationSecurePinRequest from '../../../src/controller/request/authentication-secure-pin-request';
-import AuthenticationSecureNfcRequest from '../../../src/controller/request/authentication-secure-nfc-request';
-import AuthenticationSecureEanRequest from '../../../src/controller/request/authentication-secure-ean-request';
+import AuthenticationPinRequest from '../../../src/controller/request/authentication-pin-request';
+import AuthenticationNfcRequest from '../../../src/controller/request/authentication-nfc-request';
+import AuthenticationEanRequest from '../../../src/controller/request/authentication-ean-request';
 import PinAuthenticator from '../../../src/entity/authenticator/pin-authenticator';
 import NfcAuthenticator from '../../../src/entity/authenticator/nfc-authenticator';
 import EanAuthenticator from '../../../src/entity/authenticator/ean-authenticator';
@@ -620,7 +620,7 @@ describe('AuthenticationSecureController', () => {
     });
   });
 
-  describe('POST /authentication/pin-secure', () => {
+  describe('POST /authentication/pin', () => {
     let posUserToken: string;
     let memberUserWithPin: User;
 
@@ -634,7 +634,7 @@ describe('AuthenticationSecureController', () => {
       posUserToken = await signTokenFor(posUser, ctx.tokenHandler);
     });
 
-    const validSecurePinRequest: AuthenticationSecurePinRequest = {
+    const validPinRequest: AuthenticationPinRequest = {
       userId: 0, // Will be set in tests
       pin: '1234',
       posId: 0, // Will be set to actual POS ID in tests
@@ -643,13 +643,13 @@ describe('AuthenticationSecureController', () => {
     it('should return HTTP 200 and token when valid POS user authenticates with correct PIN', async () => {
       const pos = ctx.pointsOfSale.find((p) => p.user.id === ctx.pointOfSaleUsers[0].id);
       const requestBody = {
-        ...validSecurePinRequest,
+        ...validPinRequest,
         userId: memberUserWithPin.id,
         posId: pos.id,
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/pin-secure')
+        .post('/authentication/pin')
         .set('Authorization', `Bearer ${posUserToken}`)
         .send(requestBody);
 
@@ -673,30 +673,30 @@ describe('AuthenticationSecureController', () => {
     it('should return HTTP 403 when caller is not a POS user', async () => {
       const pos = ctx.pointsOfSale[0];
       const requestBody = {
-        ...validSecurePinRequest,
+        ...validPinRequest,
         userId: memberUserWithPin.id,
         posId: pos.id,
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/pin-secure')
+        .post('/authentication/pin')
         .set('Authorization', `Bearer ${ctx.userToken}`)
         .send(requestBody);
 
       expect(res.status).to.equal(403);
-      expect(res.body).to.equal('Only POS users can use secure PIN authentication.');
+      expect(res.body).to.equal('Only POS users can use PIN authentication.');
     });
 
     it('should return HTTP 403 when POS user ID does not match requested posId', async () => {
       const pos = ctx.pointsOfSale.find((p) => p.user.id === ctx.pointOfSaleUsers[0].id);
       const requestBody = {
-        ...validSecurePinRequest,
+        ...validPinRequest,
         userId: memberUserWithPin.id,
         posId: pos.id + 999, // Wrong POS ID
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/pin-secure')
+        .post('/authentication/pin')
         .set('Authorization', `Bearer ${posUserToken}`)
         .send(requestBody);
 
@@ -707,13 +707,13 @@ describe('AuthenticationSecureController', () => {
     it('should return HTTP 403 when user does not exist', async () => {
       const pos = ctx.pointsOfSale.find((p) => p.user.id === ctx.pointOfSaleUsers[0].id);
       const requestBody = {
-        ...validSecurePinRequest,
+        ...validPinRequest,
         userId: 99999, // Non-existent user ID
         posId: pos.id,
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/pin-secure')
+        .post('/authentication/pin')
         .set('Authorization', `Bearer ${posUserToken}`)
         .send(requestBody);
 
@@ -724,14 +724,14 @@ describe('AuthenticationSecureController', () => {
     it('should return HTTP 403 when PIN is incorrect', async () => {
       const pos = ctx.pointsOfSale.find((p) => p.user.id === ctx.pointOfSaleUsers[0].id);
       const requestBody = {
-        ...validSecurePinRequest,
+        ...validPinRequest,
         userId: memberUserWithPin.id,
         pin: '9999', // Wrong PIN
         posId: pos.id,
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/pin-secure')
+        .post('/authentication/pin')
         .set('Authorization', `Bearer ${posUserToken}`)
         .send(requestBody);
 
@@ -748,13 +748,13 @@ describe('AuthenticationSecureController', () => {
 
       const pos = ctx.pointsOfSale.find((p) => p.user.id === ctx.pointOfSaleUsers[0].id);
       const requestBody = {
-        ...validSecurePinRequest,
+        ...validPinRequest,
         userId: userWithoutPin.id,
         posId: pos.id,
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/pin-secure')
+        .post('/authentication/pin')
         .set('Authorization', `Bearer ${posUserToken}`)
         .send(requestBody);
 
@@ -763,7 +763,7 @@ describe('AuthenticationSecureController', () => {
     });
   });
 
-  describe('POST /authentication/nfc-secure', () => {
+  describe('POST /authentication/nfc', () => {
     let posUserToken: string;
     let memberUserWithNfc: User;
 
@@ -780,7 +780,7 @@ describe('AuthenticationSecureController', () => {
       posUserToken = await signTokenFor(posUser, ctx.tokenHandler);
     });
 
-    const validSecureNfcRequest: AuthenticationSecureNfcRequest = {
+    const validNfcRequest: AuthenticationNfcRequest = {
       nfcCode: 'secure-nfc-code-1234',
       posId: 0, // Will be set to actual POS ID in tests
     };
@@ -788,12 +788,12 @@ describe('AuthenticationSecureController', () => {
     it('should return HTTP 200 and token when valid POS user authenticates with correct NFC', async () => {
       const pos = ctx.pointsOfSale.find((p) => p.user.id === ctx.pointOfSaleUsers[0].id);
       const requestBody = {
-        ...validSecureNfcRequest,
+        ...validNfcRequest,
         posId: pos.id,
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/nfc-secure')
+        .post('/authentication/nfc')
         .set('Authorization', `Bearer ${posUserToken}`)
         .send(requestBody);
 
@@ -817,28 +817,28 @@ describe('AuthenticationSecureController', () => {
     it('should return HTTP 403 when caller is not a POS user', async () => {
       const pos = ctx.pointsOfSale[0];
       const requestBody = {
-        ...validSecureNfcRequest,
+        ...validNfcRequest,
         posId: pos.id,
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/nfc-secure')
+        .post('/authentication/nfc')
         .set('Authorization', `Bearer ${ctx.userToken}`)
         .send(requestBody);
 
       expect(res.status).to.equal(403);
-      expect(res.body).to.equal('Only POS users can use secure NFC authentication.');
+      expect(res.body).to.equal('Only POS users can use NFC authentication.');
     });
 
     it('should return HTTP 403 when POS user ID does not match requested posId', async () => {
       const pos = ctx.pointsOfSale.find((p) => p.user.id === ctx.pointOfSaleUsers[0].id);
       const requestBody = {
-        ...validSecureNfcRequest,
+        ...validNfcRequest,
         posId: pos.id + 999, // Wrong POS ID
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/nfc-secure')
+        .post('/authentication/nfc')
         .set('Authorization', `Bearer ${posUserToken}`)
         .send(requestBody);
 
@@ -854,7 +854,7 @@ describe('AuthenticationSecureController', () => {
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/nfc-secure')
+        .post('/authentication/nfc')
         .set('Authorization', `Bearer ${posUserToken}`)
         .send(requestBody);
 
@@ -863,7 +863,7 @@ describe('AuthenticationSecureController', () => {
     });
   });
 
-  describe('POST /authentication/ean-secure', () => {
+  describe('POST /authentication/ean', () => {
     let posUserToken: string;
     let memberUserWithEan: User;
 
@@ -880,7 +880,7 @@ describe('AuthenticationSecureController', () => {
       posUserToken = await signTokenFor(posUser, ctx.tokenHandler);
     });
 
-    const validSecureEanRequest: AuthenticationSecureEanRequest = {
+    const validEanRequest: AuthenticationEanRequest = {
       eanCode: 'secure-ean-code-1234',
       posId: 0, // Will be set to actual POS ID in tests
     };
@@ -888,12 +888,12 @@ describe('AuthenticationSecureController', () => {
     it('should return HTTP 200 and token when valid POS user authenticates with correct EAN', async () => {
       const pos = ctx.pointsOfSale.find((p) => p.user.id === ctx.pointOfSaleUsers[0].id);
       const requestBody = {
-        ...validSecureEanRequest,
+        ...validEanRequest,
         posId: pos.id,
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/ean-secure')
+        .post('/authentication/ean')
         .set('Authorization', `Bearer ${posUserToken}`)
         .send(requestBody);
 
@@ -917,28 +917,28 @@ describe('AuthenticationSecureController', () => {
     it('should return HTTP 403 when caller is not a POS user', async () => {
       const pos = ctx.pointsOfSale[0];
       const requestBody = {
-        ...validSecureEanRequest,
+        ...validEanRequest,
         posId: pos.id,
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/ean-secure')
+        .post('/authentication/ean')
         .set('Authorization', `Bearer ${ctx.userToken}`)
         .send(requestBody);
 
       expect(res.status).to.equal(403);
-      expect(res.body).to.equal('Only POS users can use secure EAN authentication.');
+      expect(res.body).to.equal('Only POS users can use EAN authentication.');
     });
 
     it('should return HTTP 403 when POS user ID does not match requested posId', async () => {
       const pos = ctx.pointsOfSale.find((p) => p.user.id === ctx.pointOfSaleUsers[0].id);
       const requestBody = {
-        ...validSecureEanRequest,
+        ...validEanRequest,
         posId: pos.id + 999, // Wrong POS ID
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/ean-secure')
+        .post('/authentication/ean')
         .set('Authorization', `Bearer ${posUserToken}`)
         .send(requestBody);
 
@@ -954,7 +954,7 @@ describe('AuthenticationSecureController', () => {
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/ean-secure')
+        .post('/authentication/ean')
         .set('Authorization', `Bearer ${posUserToken}`)
         .send(requestBody);
 

--- a/test/unit/controller/member-authentication-secure-controller.ts
+++ b/test/unit/controller/member-authentication-secure-controller.ts
@@ -34,7 +34,7 @@ import AuthenticationResponse from '../../../src/controller/response/authenticat
 import MemberAuthenticationSecureController from '../../../src/controller/member-authentication-secure-controller';
 import MemberUser from '../../../src/entity/user/member-user';
 import AuthenticationService from '../../../src/service/authentication-service';
-import MemberAuthenticationSecurePinRequest from '../../../src/controller/request/member-authentication-secure-pin-request';
+import MemberAuthenticationPinRequest from '../../../src/controller/request/member-authentication-pin-request';
 import PinAuthenticator from '../../../src/entity/authenticator/pin-authenticator';
 import PointOfSale from '../../../src/entity/point-of-sale/point-of-sale';
 import { truncateAllTables } from '../../setup';
@@ -139,8 +139,8 @@ describe('MemberAuthenticationSecureController', async (): Promise<void> => {
     await finishTestDB(ctx.connection);
   });
 
-  describe('POST /authentication/member/pin-secure', () => {
-    const validSecurePinRequest: MemberAuthenticationSecurePinRequest = {
+  describe('POST /authentication/member/pin', () => {
+    const validPinRequest: MemberAuthenticationPinRequest = {
       memberId: 12345,
       pin: '1234',
       posId: 0, // Will be set to actual POS ID in tests
@@ -148,12 +148,12 @@ describe('MemberAuthenticationSecureController', async (): Promise<void> => {
 
     it('should return HTTP 200 and token when valid POS user authenticates with correct PIN', async () => {
       const requestBody = {
-        ...validSecurePinRequest,
+        ...validPinRequest,
         posId: ctx.pointOfSale.id,
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/member/pin-secure')
+        .post('/authentication/member/pin')
         .set('Authorization', `Bearer ${ctx.posUserToken}`)
         .send(requestBody);
 
@@ -176,27 +176,27 @@ describe('MemberAuthenticationSecureController', async (): Promise<void> => {
 
     it('should return HTTP 403 when caller is not a POS user', async () => {
       const requestBody = {
-        ...validSecurePinRequest,
+        ...validPinRequest,
         posId: ctx.pointOfSale.id,
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/member/pin-secure')
+        .post('/authentication/member/pin')
         .set('Authorization', `Bearer ${ctx.memberUserToken}`)
         .send(requestBody);
 
       expect(res.status).to.equal(403);
-      expect(res.body).to.equal('Only POS users can use secure member PIN authentication.');
+      expect(res.body).to.equal('Only POS users can use member PIN authentication.');
     });
 
     it('should return HTTP 403 when POS user ID does not match requested posId', async () => {
       const requestBody = {
-        ...validSecurePinRequest,
+        ...validPinRequest,
         posId: ctx.pointOfSale.id + 999, // Wrong POS ID
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/member/pin-secure')
+        .post('/authentication/member/pin')
         .set('Authorization', `Bearer ${ctx.posUserToken}`)
         .send(requestBody);
 
@@ -206,13 +206,13 @@ describe('MemberAuthenticationSecureController', async (): Promise<void> => {
 
     it('should return HTTP 403 when member user does not exist', async () => {
       const requestBody = {
-        ...validSecurePinRequest,
+        ...validPinRequest,
         memberId: 99999, // Non-existent member ID
         posId: ctx.pointOfSale.id,
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/member/pin-secure')
+        .post('/authentication/member/pin')
         .set('Authorization', `Bearer ${ctx.posUserToken}`)
         .send(requestBody);
 
@@ -222,13 +222,13 @@ describe('MemberAuthenticationSecureController', async (): Promise<void> => {
 
     it('should return HTTP 403 when PIN is incorrect', async () => {
       const requestBody = {
-        ...validSecurePinRequest,
+        ...validPinRequest,
         pin: '9999', // Wrong PIN
         posId: ctx.pointOfSale.id,
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/member/pin-secure')
+        .post('/authentication/member/pin')
         .set('Authorization', `Bearer ${ctx.posUserToken}`)
         .send(requestBody);
 
@@ -257,7 +257,7 @@ describe('MemberAuthenticationSecureController', async (): Promise<void> => {
       };
 
       const res = await request(ctx.app)
-        .post('/authentication/member/pin-secure')
+        .post('/authentication/member/pin')
         .set('Authorization', `Bearer ${ctx.posUserToken}`)
         .send(requestBody);
 


### PR DESCRIPTION
## Summary

Closes #894.

The deprecated non-secure `/pin`, `/nfc`, `/ean`, and `/member/pin` endpoints have already been removed, so the `-secure` suffix on the surviving variants is no longer meaningful. This PR drops it:

| Before | After |
| --- | --- |
| `POST /authentication/pin-secure` | `POST /authentication/pin` |
| `POST /authentication/nfc-secure` | `POST /authentication/nfc` |
| `POST /authentication/ean-secure` | `POST /authentication/ean` |
| `POST /authentication/member/pin-secure` | `POST /authentication/member/pin` |

Renamed alongside the routes:

- Request types/files: `AuthenticationSecurePinRequest` → `AuthenticationPinRequest`, and the same for NFC, EAN, and `MemberAuthenticationSecurePinRequest`.
- Handler methods: `securePINLogin` → `pinLogin`, `secureNfcLogin` → `nfcLogin`, `secureEanLogin` → `eanLogin`, `secureMemberPINLogin` → `memberPINLogin`.
- OperationIds, JSDoc, error-message strings, NFC-authenticator entity comment, integration-test descriptions.

The controller class names (`AuthenticationSecureController`, `MemberAuthenticationSecureController`) are kept — they group JWT-protected auth endpoints, which is still semantically distinct from the public `AuthenticationController`, and renaming would collide with the existing class.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `pnpm lint` clean (pre-existing `cli/dev-seed.ts` parser-config issue unchanged)
- [x] `pnpm exec vitest run test/unit/controller/authentication-secure-controller.ts` — 35 pass
- [x] `pnpm exec vitest run test/unit/controller/member-authentication-secure-controller.ts test/integration/pos-token-flow.ts` — 13 pass