### PR TITLE
Speed up backend test suite

### DIFF
--- a/test/helpers/authentication-helpers.ts
+++ b/test/helpers/authentication-helpers.ts
@@ -1,0 +1,33 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+import { expect } from 'chai';
+import User from '../../src/entity/user/user';
+import { UserResponse } from '../../src/controller/response/user-response';
+import { isNumber } from '../../src/helpers/validators';
+
+export default function userIsAsExpected(user: User | UserResponse, ADResponse: any) {
+  expect(user.firstName).to.equal(ADResponse.givenName);
+  expect(user.lastName).to.equal(ADResponse.sn);
+  if (isNumber(user.type)) expect(user.type).to.equal(1);
+  expect(user.active).to.equal(true);
+  expect(user.deleted).to.equal(false);
+  expect(user.canGoIntoDebt).to.equal(true);
+}

--- a/test/helpers/invoice-helpers.ts
+++ b/test/helpers/invoice-helpers.ts
@@ -1,0 +1,63 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+import { expect } from 'chai';
+import { AppDataSource } from '../../src/database/database';
+import InvoiceService from '../../src/service/invoice-service';
+import BalanceService from '../../src/service/balance-service';
+import { CreateInvoiceParams } from '../../src/controller/request/invoice-request';
+import { createTransactions } from './transaction-factory';
+
+export async function createInvoiceWithTransfers(
+  debtorId: number,
+  creditorId: number,
+  transactionCount: number,
+) {
+  const { transactions, total } = await createTransactions(debtorId, creditorId, transactionCount);
+
+  const createInvoiceRequest: CreateInvoiceParams = {
+    city: 'city',
+    country: 'country',
+    postalCode: 'postalCode',
+    street: 'street',
+    reference: 'BAC-41',
+    byId: creditorId,
+    addressee: 'Addressee',
+    description: 'Description',
+    forId: debtorId,
+    date: new Date(),
+    transactionIDs: transactions.map((t) => t.tId),
+    amount: {
+      amount: total,
+      currency: 'EUR',
+      precision: 2,
+    },
+  };
+
+  const creditorBalance = await new BalanceService().getBalance(creditorId);
+
+  const invoice = await AppDataSource.manager.transaction(async (manager) => {
+    return new InvoiceService(manager).createInvoice(createInvoiceRequest);
+  });
+  expect((await new BalanceService().getBalance(debtorId)).amount.amount).is.equal(0);
+  expect((await new BalanceService().getBalance(creditorId)).amount.amount)
+    .is.equal(creditorBalance.amount.amount);
+  return invoice;
+}

--- a/test/seed/all.ts
+++ b/test/seed/all.ts
@@ -98,8 +98,10 @@ export default async function seedDatabase(beginDate?: Date, endDate?: Date): Pr
     users.filter((u) => u.type !== UserType.ORGAN),
     [users.filter((u) => u.type === UserType.ORGAN)[0]],
   );
-  const pinUsers = await new UserSeeder().seedHashAuthenticator(users, PinAuthenticator);
-  const localUsers = await new UserSeeder().seedHashAuthenticator(users, LocalAuthenticator);
+  const [pinUsers, localUsers] = await Promise.all([
+    new UserSeeder().seedHashAuthenticator(users, PinAuthenticator),
+    new UserSeeder().seedHashAuthenticator(users, LocalAuthenticator),
+  ]);
   const gewisUsers = await seedMemberUsers(users);
   const categories = await new ProductCategorySeeder().seed();
   const vatGroups = await new VatGroupSeeder().seed();

--- a/test/seed/user-seeder.ts
+++ b/test/seed/user-seeder.ts
@@ -123,7 +123,7 @@ export default class UserSeeder extends WithManager {
     return users;
   }
 
-  private BCRYPT_ROUNDS = 12;
+  private BCRYPT_ROUNDS = 4;
 
   private async hashPassword(password: string, callback: (encrypted: string) => any) {
     return bcrypt.hash(password, this.BCRYPT_ROUNDS).then(callback);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -72,6 +72,12 @@ if (process.env.SMTP_USERNAME && !process.env.SMTP_PASSWORD) {
 if (process.env.SMTP_PASSWORD && !process.env.SMTP_USERNAME) {
   process.env.SMTP_USERNAME = 'test-user';
 }
+if (!process.env.BCRYPT_ROUNDS) {
+  process.env.BCRYPT_ROUNDS = '4';
+}
+if (!process.env.BCRYPT_ROUNDS_PIN) {
+  process.env.BCRYPT_ROUNDS_PIN = '1';
+}
 if (!process.env.JWT_KEY_PATH) {
   const { privateKey } = generateKeyPairSync('rsa', {
     modulusLength: 2048,

--- a/test/unit/controller/authentication-controller.ts
+++ b/test/unit/controller/authentication-controller.ts
@@ -37,7 +37,7 @@ import RoleManager from '../../../src/rbac/role-manager';
 import AuthenticationResponse from '../../../src/controller/response/authentication-response';
 import { AuthenticationResult } from '../../../src/service/authentication-service';
 import AuthenticationLDAPRequest from '../../../src/controller/request/authentication-ldap-request';
-import userIsAsExpected from '../service/authentication-service';
+import userIsAsExpected from '../../helpers/authentication-helpers';
 import AuthenticationLocalRequest from '../../../src/controller/request/authentication-local-request';
 import LocalAuthenticator from '../../../src/entity/authenticator/local-authenticator';
 import ResetLocalRequest from '../../../src/controller/request/reset-local-request';

--- a/test/unit/gewis/controller/gewis-authentication-controller.ts
+++ b/test/unit/gewis/controller/gewis-authentication-controller.ts
@@ -38,7 +38,7 @@ import GewisAuthenticationController from '../../../../src/gewis/controller/gewi
 import GewiswebToken from '../../../../src/gewis/gewisweb-token';
 import MemberUser from '../../../../src/entity/user/member-user';
 import AuthenticationLDAPRequest from '../../../../src/controller/request/authentication-ldap-request';
-import userIsAsExpected from '../../service/authentication-service';
+import userIsAsExpected from '../../../helpers/authentication-helpers';
 import AuthenticationService from '../../../../src/service/authentication-service';
 import PinAuthenticator from '../../../../src/entity/authenticator/pin-authenticator';
 import { truncateAllTables } from '../../../setup';

--- a/test/unit/gewis/gewis.ts
+++ b/test/unit/gewis/gewis.ts
@@ -30,7 +30,7 @@ import User, { UserType } from '../../../src/entity/user/user';
 import Database from '../../../src/database/database';
 import seedDatabase from '../../seed';
 import Swagger from '../../../src/start/swagger';
-import userIsAsExpected from '../service/authentication-service';
+import userIsAsExpected from '../../helpers/authentication-helpers';
 import { inUserContext, UserFactory } from '../../helpers/user-factory';
 import MemberUser from '../../../src/entity/user/member-user';
 import Gewis from '../../../src/gewis/gewis';

--- a/test/unit/service/ad-service.ts
+++ b/test/unit/service/ad-service.ts
@@ -30,7 +30,7 @@ import Swagger from '../../../src/start/swagger';
 import ADService from '../../../src/service/ad-service';
 import LDAPAuthenticator from '../../../src/entity/authenticator/ldap-authenticator';
 import { LDAPGroup, LDAPUser } from '../../../src/helpers/ad';
-import userIsAsExpected from './authentication-service';
+import userIsAsExpected from '../../helpers/authentication-helpers';
 import { finishTestDB, restoreLDAPEnv, setDefaultLDAPEnv, storeLDAPEnv } from '../../helpers/test-helpers';
 import { truncateAllTables } from '../../setup';
 import { UserSeeder } from '../../seed';

--- a/test/unit/service/authentication-service.ts
+++ b/test/unit/service/authentication-service.ts
@@ -31,8 +31,7 @@ import Swagger from '../../../src/start/swagger';
 import AuthenticationService from '../../../src/service/authentication-service';
 import { inUserContext, UserFactory } from '../../helpers/user-factory';
 import PinAuthenticator from '../../../src/entity/authenticator/pin-authenticator';
-import { UserResponse } from '../../../src/controller/response/user-response';
-import { isNumber } from '../../../src/helpers/validators';
+import userIsAsExpected from '../../helpers/authentication-helpers';
 import { finishTestDB, restoreLDAPEnv, storeLDAPEnv } from '../../helpers/test-helpers';
 import HashBasedAuthenticationMethod from '../../../src/entity/authenticator/hash-based-authentication-method';
 import LocalAuthenticator from '../../../src/entity/authenticator/local-authenticator';
@@ -44,15 +43,6 @@ import TokenHandler from '../../../src/authentication/token-handler';
 import DefaultRoles from '../../../src/rbac/default-roles';
 import ServerSettingsStore from '../../../src/server-settings/server-settings-store';
 import bcrypt from 'bcrypt';
-
-export default function userIsAsExpected(user: User | UserResponse, ADResponse: any) {
-  expect(user.firstName).to.equal(ADResponse.givenName);
-  expect(user.lastName).to.equal(ADResponse.sn);
-  if (isNumber(user.type)) expect(user.type).to.equal(1);
-  expect(user.active).to.equal(true);
-  expect(user.deleted).to.equal(false);
-  expect(user.canGoIntoDebt).to.equal(true);
-}
 
 describe('AuthenticationService', (): void => {
   let ctx: {

--- a/test/unit/service/invoice-pdf-service.ts
+++ b/test/unit/service/invoice-pdf-service.ts
@@ -38,7 +38,7 @@ import { finishTestDB } from '../../helpers/test-helpers';
 import { INVOICE_PDF_LOCATION } from '../../../src/files/storage';
 import { InvoiceSeeder, TransactionSeeder, UserSeeder } from '../../seed';
 import InvoiceService from '../../../src/service/invoice-service';
-import { createInvoiceWithTransfers } from './invoice-service';
+import { createInvoiceWithTransfers } from '../../helpers/invoice-helpers';
 import { inUserContext, UserFactory } from '../../helpers/user-factory';
 import { InvoiceState } from '../../../src/entity/invoices/invoice-status';
 import { subTransactionRowToProduct } from '../../../src/helpers/pdf';

--- a/test/unit/service/invoice-service.ts
+++ b/test/unit/service/invoice-service.ts
@@ -45,6 +45,7 @@ import Transaction from '../../../src/entity/transactions/transaction';
 import InvoiceUser from '../../../src/entity/user/invoice-user';
 import { truncateAllTables } from '../../setup';
 import { finishTestDB } from '../../helpers/test-helpers';
+import { createInvoiceWithTransfers } from '../../helpers/invoice-helpers';
 import { InvoiceSeeder, TransactionSeeder, UserSeeder } from '../../seed';
 import Transfer from '../../../src/entity/transactions/transfer';
 import DineroTransformer from '../../../src/entity/transformer/dinero-transformer';
@@ -64,40 +65,6 @@ export type T = InvoiceResponse | BaseInvoiceResponse | Invoice;
 
 function returnsAll(response: T[], superset: Invoice[], mapping: any) {
   expect(response.map(mapping)).to.deep.equalInAnyOrder(superset.map(mapping));
-}
-
-export async function
-createInvoiceWithTransfers(debtorId: number, creditorId: number,
-  transactionCount: number) {
-  const { transactions, total } = await createTransactions(debtorId, creditorId, transactionCount);
-
-  const createInvoiceRequest: CreateInvoiceParams = {
-    city: 'city',
-    country: 'country',
-    postalCode: 'postalCode',
-    street: 'street',
-    reference: 'BAC-41',
-    byId: creditorId,
-    addressee: 'Addressee',
-    description: 'Description',
-    forId: debtorId,
-    date: new Date(),
-    transactionIDs: transactions.map((t) => t.tId),
-    amount: {
-      amount: total,
-      currency: 'EUR',
-      precision: 2,
-    },
-  };
-
-  const creditorBalance = await new BalanceService().getBalance(creditorId);
-
-  const invoice = await AppDataSource.manager.transaction(async (manager) => {
-    return new InvoiceService(manager).createInvoice(createInvoiceRequest);
-  });
-  expect((await new BalanceService().getBalance(debtorId)).amount.amount).is.equal(0);
-  expect((await new BalanceService().getBalance(creditorId)).amount.amount).is.equal(creditorBalance.amount.amount);
-  return invoice;
 }
 
 describe('InvoiceService', () => {

--- a/test/unit/service/transaction-service.ts
+++ b/test/unit/service/transaction-service.ts
@@ -46,7 +46,7 @@ import PointOfSaleRevision from '../../../src/entity/point-of-sale/point-of-sale
 import ContainerRevision from '../../../src/entity/container/container-revision';
 import generateBalance, { finishTestDB } from '../../helpers/test-helpers';
 import { inUserContext, UserFactory } from '../../helpers/user-factory';
-import { createInvoiceWithTransfers } from './invoice-service';
+import { createInvoiceWithTransfers } from '../../helpers/invoice-helpers';
 import { truncateAllTables } from '../../setup';
 import ProductRevision from '../../../src/entity/product/product-revision';
 import { calculateBalance } from '../../helpers/balance';

--- a/test/unit/subscribe/transfer-subscriber.ts
+++ b/test/unit/subscribe/transfer-subscriber.ts
@@ -50,7 +50,7 @@ describe('TransferSubscriber', (): void => {
     await truncateAllTables(connection);
 
     const users = await new UserSeeder().seed();
-    const { transactions } = await new TransactionSeeder().seed(users, undefined, new Date('2020-02-12'), new Date('2021-11-30'), 10);
+    const { transactions } = await new TransactionSeeder().seed(users, undefined, new Date('2020-02-12'), new Date('2021-11-30'), 1);
     const transfers = await new TransferSeeder().seed(users, new Date('2020-02-12'), new Date('2021-11-30'));
     const subTransactions: SubTransaction[] = Array.prototype.concat(...transactions
       .map((t) => t.subTransactions));


### PR DESCRIPTION
# Description

The backend test suite ran in ~6m 29s. This PR removes three avoidable hot spots in test setup. No production code changes; no behavior changes.

**1. Stop re-registering `describe` blocks via cross-test imports.** Six test files imported helpers (`userIsAsExpected`, `createInvoiceWithTransfers`) from other test files. Because those test files also had top-level `describe()` calls, vitest re-ran those suites in every importer. `AuthenticationService > Hash Authentication > ...` was running in 5 files; `InvoiceService > createInvoice > ...` in 3. The helpers now live in `test/helpers/`, which is excluded from the vitest include glob.

**2. Lower bcrypt rounds for test seeding.** `UserSeeder` hardcoded 12 rounds (production strength) and ran the PIN + Local hash batches sequentially. Dropped to 4 rounds, parallelized the two batches, and set `BCRYPT_ROUNDS=4` / `BCRYPT_ROUNDS_PIN=1` defaults in `test/setup.ts` so code that hashes through `AuthenticationService` also uses test-mode rounds.

**3. Remove unnecessary seed volume in `transfer-subscriber.ts`.** The 3 tests passed `nrMultiplier=10` to `TransactionSeeder`, producing 10x the default transactions for trivial assertions.

## Results (CI, `test-better-sqlite3` job)

| | Duration |
|---|---|
| Baseline | ~389s (6m 29s) |
| This PR | ~293s (4m 53s) |

~96 seconds saved (~25%). All 2 250 tests pass (27 pre-existing skips).

A follow-up iteration tried a modular `seedDatabase` refactor with `Promise.all` across seed layers and a `singleFork: true` vitest config. The seed refactor netted out roughly even on better-sqlite3 (CI runs of synchronous SQLite don't benefit from `Promise.all` across DB-bound seeders); `singleFork: true` exposed pre-existing state leakage in `root-hooks.ts`. Both reverted to keep this PR focused on the clean wins.

## Related issues/external references
None.

## Types of changes
- Test infrastructure / performance

---

## PR Checklist

- [x] **Test Coverage**: No new functionality; existing tests still pass. Verified the affected files run green.
- [x] **Documentation**: No API or feature changes.
- [x] **Database Changes**: None.

## Additional Notes

Follow-ups (not in this PR):

- Fix the `users.slice(count)` bug in `UserSeeder.seedHashAuthenticator` (should be `slice(0, count)`) -- semantic change, needs its own pass.
- Modular `seedDatabase` (exports for `seedUsers`, `seedCatalogue`, etc.) so heavy callers can opt into subsets -- biggest win is for tests that only need users.
- Rework `root-hooks.ts` to tolerate shared module state, then flip `singleFork: true` (~70s potential savings if test pollution can be fixed).