### PR TITLE
Documentation improvements: balance, transactions, transfers

### DIFF
--- a/src/controller/balance-controller.ts
+++ b/src/controller/balance-controller.ts
@@ -19,8 +19,6 @@
  */
 
 /**
- * This is the module page of balance-controller.
- *
  * @module balance
  */
 
@@ -36,6 +34,11 @@ import { asArrayOfUserTypes, asBoolean, asDate, asDinero } from '../helpers/vali
 import { asOrderingDirection } from '../helpers/ordering';
 import { parseRequestPagination, toResponse } from '../helpers/pagination';
 
+/**
+ * Controller for the `balance` module. All endpoints are reads -- you cannot mutate a balance
+ * directly; record a transaction or a transfer and the next read picks it up. See the
+ * {@link balance | module page} for how balances are computed.
+ */
 export default class BalanceController extends BaseController {
   private logger: Logger = log4js.getLogger('BalanceController');
 

--- a/src/controller/rbac-controller.ts
+++ b/src/controller/rbac-controller.ts
@@ -37,6 +37,13 @@ import Permission from '../entity/rbac/permission';
 import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import { asUserResponse } from '../service/user-service';
 
+/**
+ * Controller for the `rbac` module. Read/write surface for {@link rbac!Role | Role} records
+ * and their {@link rbac!Permission | Permission} rows; assigning a role to a specific user
+ * happens through {@link rbac!AssignedRole | AssignedRole} writes elsewhere or falls out of
+ * the `UserType` -> `RoleUserType` mapping. See the {@link rbac | module page} for the
+ * permission tuple, dev-mode bypass, and the list of production roles.
+ */
 export default class RbacController extends BaseController {
   private logger: Logger = log4js.getLogger('RbacController');
 

--- a/src/controller/transaction-controller.ts
+++ b/src/controller/transaction-controller.ts
@@ -42,6 +42,12 @@ import InvoiceService from '../service/invoice-service';
 import POSTokenVerifier from '../helpers/pos-token-verifier';
 import { PdfError } from '../errors';
 
+/**
+ * Controller for the `transactions` module. Exposes the buyer-facing CRUD for transactions,
+ * a validate-before-create endpoint, the invoices-touching-this-transaction lookup, and a
+ * PDF receipt. See the {@link transactions | module page} for how a transaction relates to
+ * its sub-transactions.
+ */
 export default class TransactionController extends BaseController {
   private logger: Logger = log4js.getLogger('TransactionController');
 

--- a/src/controller/transfer-controller.ts
+++ b/src/controller/transfer-controller.ts
@@ -36,6 +36,13 @@ import { parseRequestPagination, toResponse } from '../helpers/pagination';
 import userTokenInOrgan from '../helpers/token-helper';
 import { PdfError } from '../errors';
 
+/**
+ * Controller for the `transfers` module. Exposes CRUD over transfers, aggregate and per-category
+ * summary endpoints used by treasurer dashboards, and a PDF receipt. Direct POST is reserved for
+ * privileged users; most transfers are created indirectly by the domain that owns the movement
+ * (deposits, payouts, fines, invoices, write-offs). See the {@link transfers | module page} for
+ * the full list of back-references.
+ */
 export default class TransferController extends BaseController {
   private logger: Logger = log4js.getLogger('TransferController');
 

--- a/src/entity/rbac/role.ts
+++ b/src/entity/rbac/role.ts
@@ -19,7 +19,53 @@
  */
 
 /**
- * This is the module page of the role.
+ * A `Role` is a named permission set. A user picks up a role through one of three paths:
+ * their user type maps to it via {@link RoleUserType}, an admin assigns it explicitly via
+ * {@link AssignedRole}, or they inherit it from an organ they belong to via
+ * {@link organ!OrganMembership | OrganMembership}. `RoleManager` resolves the union of all
+ * three on every request.
+ *
+ * ### The permission tuple
+ * A {@link Permission} row is keyed on `(role, entity, action, relation)` with a JSON
+ * `attributes` list. To read a user's own email the check is
+ * `can(roles, "get", "own", "User", ["email"])`. The user passes if at least one of their
+ * roles has a permission row matching that tuple whose attributes contain `"email"` or the
+ * wildcard `"*"`.
+ *
+ * Relations express ownership scope. The common ones are `"own"` (the user themselves),
+ * `"organ"` (anyone in an organ the user belongs to), `"created"` (records the user
+ * created), and `"all"` (the global escape hatch). `RoleManager.can()` always adds `"all"`
+ * to the requested relations before querying, so a permission with relation `"all"` covers
+ * any narrower one.
+ *
+ * ### Production roles
+ * Production has a fixed set of system roles, defined in `src/rbac/default-roles.ts` and
+ * idempotently seeded by `DefaultRoles.synchronize()`:
+ * - `User` -- base read role attached to most authenticated users.
+ * - `Local User` -- additional permissions for users with a local password.
+ * - `Buyer` -- can create transactions.
+ * - `AuthorizedBuyer` -- can create transactions on behalf of others.
+ * - `Invoice` -- attached to invoice-type accounts.
+ * - `Point of Sale` -- attached to POS-type accounts.
+ * - `Seller` -- granted to container owners through organ membership.
+ * - `Super admin` -- wildcard everything for system administrators.
+ *
+ * The `UserType` -> role mapping is seeded into `RoleUserType` rows by the same code path.
+ * `Role.systemDefault: true` marks these as protected: the cleanup pass at the end of
+ * `synchronize()` only deletes systemDefault roles whose name is missing from
+ * `default-roles.ts`, so admin-created roles are never touched.
+ *
+ * ### Dev-mode bypass
+ * `RoleManager.can()` returns `true` unconditionally when `Config.app.isDevelopment` is set.
+ * Tests that exercise RBAC need a non-`development` `NODE_ENV`, or the fixtures that seed
+ * the production roles and sign real tokens (`ensureProductionRoles()` + `signTokenFor()`).
+ *
+ * ### Controller
+ * {@link RbacController} exposes role CRUD plus per-role permission editing: list roles, get
+ * a role with its permissions, list users linked to a role, create / update / delete roles,
+ * and add / remove permissions on a role. It does not assign roles to users -- that happens
+ * through {@link AssignedRole} writes, or more commonly falls out of the
+ * `UserType` -> `RoleUserType` mapping.
  *
  * @module rbac
  * @mergeTarget

--- a/src/entity/transactions/balance.ts
+++ b/src/entity/transactions/balance.ts
@@ -19,9 +19,57 @@
  */
 
 /**
- * This is the module page of the balance.
+ * A user's `balance` is the net of every transaction and {@link transfers!Transfer | Transfer}
+ * on their account. Positive means SudoSOS owes them; negative means they owe SudoSOS and
+ * need to top up.
+ *
+ * ### Computed, not authoritative
+ * The source of truth is {@link transactions!Transaction | Transaction} and
+ * {@link transfers!Transfer | Transfer} history. The `Balance` table is a cache, so reading
+ * one user's balance does not have to re-sum every
+ * {@link transactions/sub-transactions!SubTransactionRow | SubTransactionRow} since their
+ * first deposit.
+ *
+ * ### Cache structure
+ * Each row stores the cached `amount` plus a `lastTransactionId` / `lastTransferId` cursor.
+ * {@link BalanceService.getBalances | getBalances} returns `cachedAmount + delta`, where the
+ * delta sums every sub-transaction row and transfer that happened *after* the cursor. If the
+ * cache is out of date the read still returns the correct value; it just costs more SQL.
+ *
+ * {@link BalanceService.updateBalances | updateBalances} writes a fresh total back to the
+ * cache. {@link BalanceService.clearBalanceCache | clearBalanceCache} drops cache rows --
+ * useful after bulk-rewriting history.
+ *
+ * ### What moves a balance
+ * Sub-transaction rows debit the
+ * {@link transactions/sub-transactions!SubTransaction | SubTransaction} buyer (`fromId`) and
+ * credit the seller (`toId`, the container owner). Prices are pinned by the
+ * {@link catalogue/products!ProductRevision | ProductRevision} in effect at the time, so
+ * editing a product later does not retroactively shift balances.
+ *
+ * Transfers are the explicit movements outside a transaction: Stripe deposits, fine handouts,
+ * fine waivers, payout requests, seller payouts, write-offs, invoices.
+ *
+ * Undoing either of those writes a compensating row; the original stays in the audit trail.
+ *
+ * ### Fines on the response
+ * {@link BalanceResponse} carries the user's outstanding fine amount, the timestamp of the
+ * first fine, the number of fines, and any waived amount. These are "now" values, not
+ * historical -- ignore them when `date` is in the past.
+ *
+ * ### Total balances
+ * `GET /balances/summary` adds up positive and negative balances across the database, broken
+ * down by {@link users!UserType | UserType}. Treasurers use it to reconcile SudoSOS against
+ * the bank account.
+ *
+ * ### POS users
+ * {@link users!UserType.POINT_OF_SALE | POS users} do not hold balances of their own. Their
+ * sub-transactions credit the container owner, and balance queries filter POS users out at
+ * the SQL level, so they never show up in {@link PaginatedBalanceResponse} or
+ * {@link TotalBalanceResponse}.
  *
  * @module balance
+ * @mergeTarget
  */
 
 import {
@@ -39,6 +87,10 @@ import DineroTransformer from '../transformer/dinero-transformer';
 import BaseEntityWithoutId from '../base-entity-without-id';
 
 /**
+ * TypeORM entity for the `balance` table. This is a cache row -- the authoritative balance is
+ * recomputed from {@link Transaction} and {@link Transfer} history. `lastTransaction` and
+ * `lastTransfer` mark the cursor up to which `amount` is accurate; anything newer is summed
+ * on read by `BalanceService`.
  * @typedef {BaseEntityWithoutId} Balance
  * @property {User.model} user.required - The account which has this balance
  * @property {Dinero.model} amount.required - The amount of balance a user has.

--- a/src/entity/transactions/sub-transaction.ts
+++ b/src/entity/transactions/sub-transaction.ts
@@ -19,9 +19,40 @@
  */
 
 /**
- * This is the module page of the sub-transaction.
+ * A `SubTransaction` is one seller's slice of a {@link transactions!Transaction | Transaction}.
+ * Where the parent transaction records "this user spent money at this POS", the sub-transaction
+ * records "and this much of it goes to this organ". A transaction with one container in the
+ * basket has one sub-transaction; a basket that mixes containers from three organs has three.
+ *
+ * ### Roles on the sub-transaction
+ * - `to` is the user being credited -- the
+ *   {@link catalogue/containers!Container | Container} owner (typically a GEWIS organ).
+ * - `container` is the
+ *   {@link catalogue/containers!ContainerRevision | ContainerRevision} the products were
+ *   bought from. It is a revision so historical sub-transactions keep resolving even after
+ *   the container is edited.
+ * - `transaction` is the parent {@link transactions!Transaction | Transaction}; cascading
+ *   delete on the parent removes the sub-transaction with it.
+ *
+ * ### Rows
+ * Product lines live on {@link SubTransactionRow}: one row per product, with an `amount`
+ * (quantity) and a {@link catalogue/products!ProductRevision | ProductRevision} reference.
+ * The revision pins price (incl. VAT), VAT group, and category at the moment of sale.
+ *
+ * ### Invoicing
+ * A row can carry an `invoiceId` linking it to an {@link invoicing!Invoice | Invoice}. That
+ * marks the row as "billed to the invoiced customer" rather than charged directly to the
+ * buyer's balance. {@link balance | Balance} reads treat invoiced rows the same as any other
+ * row when computing the seller side; the invoice flow handles the buyer side separately.
+ *
+ * ### Why it exists
+ * Splitting per-seller lets a single POS purchase pay multiple organs in one ring-up. Without
+ * sub-transactions you would need either one transaction per organ (and the cashier ringing
+ * up the same basket three times) or a denormalised seller field on each row (with reports
+ * gathering and grouping on the fly).
  *
  * @module transactions/sub-transactions
+ * @mergeTarget
  */
 
 /* eslint-disable import/no-cycle */
@@ -35,6 +66,8 @@ import ContainerRevision from '../container/container-revision';
 import SubTransactionRow from './sub-transaction-row';
 
 /**
+ * TypeORM entity for the `sub_transaction` table. One per (transaction, container) pair: the
+ * portion of a transaction that credits a single container owner.
  * @typedef {BaseEntityWithoutId} SubTransaction
  * @property {User.model} to.required - The account that the transaction is added to.
  * @property {Container.model} container.required - The container from which all products in the

--- a/src/entity/transactions/transaction.ts
+++ b/src/entity/transactions/transaction.ts
@@ -19,7 +19,44 @@
  */
 
 /**
- * This is the module page of the transaction.
+ * A `Transaction` is one purchase at a SudoSOS point of sale: one person paid for a basket of
+ * products. The buyer is on the transaction (`from`); the products and prices live one level
+ * down on {@link transactions/sub-transactions!SubTransaction | SubTransactions}.
+ *
+ * ### Why it splits
+ * A {@link catalogue/point-of-sale!PointOfSale | PointOfSale} can expose products from
+ * containers belonging to different sellers (typically different GEWIS organs), so a single
+ * basket can mix sellers. The basket is recorded as one transaction with one sub-transaction
+ * per container. Each sub-transaction credits its container's owner; the transaction itself
+ * only debits the buyer.
+ *
+ * ### From vs. createdBy
+ * - `from` is the user whose balance is charged.
+ * - `createdBy` is the user that recorded the transaction.
+ *
+ * They are usually the same person. They differ on shared bar shifts: a cashier rings up
+ * purchases for buyers who do not have an authenticated session of their own, so the cashier
+ * is `createdBy` and the buyer is `from`. Whether this is allowed depends on the POS's
+ * `useAuthentication` flag and the cashier role on the
+ * {@link catalogue/point-of-sale!PointOfSale | PointOfSale}.
+ *
+ * ### Price freezing
+ * The `pointOfSale` reference is a {@link catalogue/point-of-sale!PointOfSaleRevision |
+ * PointOfSaleRevision}, not a live `PointOfSale`. Sub-transaction rows reference
+ * {@link catalogue/products!ProductRevision | ProductRevisions}; their containers reference
+ * {@link catalogue/containers!ContainerRevision | ContainerRevisions}. Everything the
+ * transaction needs to reproduce the basket -- product price, VAT group, category, container
+ * membership, POS layout -- is pinned at the revision in force at the moment of sale. Editing
+ * any of those later creates a new revision and leaves historical transactions untouched.
+ *
+ * ### Balance impact
+ * Each {@link transactions/sub-transactions!SubTransactionRow | SubTransactionRow} debits the
+ * transaction's `from` user (the buyer) and credits its sub-transaction's `to` user (the
+ * container owner). See {@link balance | Balance} for how these movements roll up.
+ *
+ * ### PDF receipts
+ * `Transaction` is `PdfAble`. `GET /transactions/{id}/pdf` returns a PDF receipt via
+ * `TransactionPdfService`.
  *
  * @module transactions
  * @mergeTarget
@@ -37,6 +74,11 @@ import { UnstoredPdfAble } from '../file/pdf-able';
 import TransactionPdfService from '../../service/pdf/transaction-pdf-service';
 
 /**
+ * TypeORM entity for the `transaction` table. Holds the buyer-side record of one purchase at
+ * a {@link catalogue/point-of-sale!PointOfSale | PointOfSale}. The actual product lines and
+ * seller-side credits live on the related
+ * {@link transactions/sub-transactions!SubTransaction | SubTransactions}, which cascade
+ * on save.
  * @typedef {BaseEntity} Transaction
  * @property {User.model} from.required - The account from which the transaction is subtracted.
  * @property {User.model} createdBy.required - The user that created the transaction.

--- a/src/entity/transactions/transfer.ts
+++ b/src/entity/transactions/transfer.ts
@@ -19,7 +19,49 @@
  */
 
 /**
- * This is the module page of the transfer.
+ * A `Transfer` is an explicit money movement on or off a SudoSOS account. Where a
+ * {@link transactions!Transaction | Transaction} records products bought at a point of sale,
+ * a transfer is the raw "X amount moves from A to B" record with no product line. Every
+ * deposit, fine, payout, write-off, and invoice settlement becomes a Transfer.
+ *
+ * ### Open-ended endpoints
+ * Both `from` and `to` are nullable, because some movements have no SudoSOS-side counterparty.
+ * A Stripe top-up enters money from outside SudoSOS, so `from` is null and `to` is the user
+ * being credited. A payout sends money out of SudoSOS, so `from` is the user being debited
+ * and `to` is null. Internal movements (waiving fines, ad-hoc corrections) have both sides set.
+ *
+ * ### Who creates a transfer
+ * Transfers are not usually written by hand. Each domain that moves money creates its own
+ * record and keeps a OneToOne back-reference to the transfer it produced:
+ *
+ * - {@link stripe!StripeDeposit | StripeDeposit} -- after a successful Stripe PaymentIntent.
+ * - {@link payout-requests!PayoutRequest | PayoutRequest} -- when a user-initiated payout is
+ *   approved.
+ * - {@link seller-payouts!SellerPayout | SellerPayout} -- periodic settlement to a container
+ *   owner for sales made on their behalf.
+ * - {@link invoicing!Invoice | Invoice} -- the debit that settles an invoice, plus an optional
+ *   `creditTransfer` if the invoice is credit-noted.
+ * - {@link fines!Fine | Fine} -- a single fine debit.
+ * - {@link fines!UserFineGroup | UserFineGroup} -- as `waivedTransfer`, the credit that cancels
+ *   a fine group.
+ * - {@link write-offs!WriteOff | WriteOff} -- the debit that zeroes an irrecoverable balance.
+ * - `InactiveAdministrativeCost` -- the recurring charge applied to inactive accounts.
+ *
+ * If none of those fit, an admin can create a transfer directly with a free-text `description`.
+ *
+ * ### VAT
+ * Some transfers carry a {@link catalogue/vat!VatGroup | VatGroup} (e.g. invoice settlements,
+ * inactive administrative costs). Most do not -- topping up balance is not a VAT-bearing event,
+ * and neither is moving money between SudoSOS users.
+ *
+ * ### Balance impact
+ * `amountInclVat` is credited to `to` and debited from `from`. If a side is null, only the
+ * other side moves. {@link balance | Balance} treats transfers and transactions symmetrically
+ * when computing a user's running total.
+ *
+ * ### PDF
+ * `Transfer` is `PdfAble`. Some kinds (payouts, invoice settlements) produce a PDF receipt
+ * via `GET /transfers/{id}/pdf` using `TransferPdfService`.
  *
  * @module transfers
  * @mergeTarget
@@ -45,6 +87,10 @@ import { UnstoredPdfAble } from '../file/pdf-able';
 import TransferPdfService from '../../service/pdf/transfer-pdf-service';
 
 /**
+ * TypeORM entity for the `transfer` table. A single money movement on or off SudoSOS; one of
+ * `from` or `to` may be null when the counterparty lives outside the system (a Stripe deposit,
+ * a bank payout). The domain that originated the movement keeps a OneToOne back-reference,
+ * which is how the type of a transfer (deposit, fine, payout, ...) is identified at read time.
  * @typedef {BaseEntity} Transfer
  * @property {User.model} from - The account from which the transfer is subtracted. Can be
  * null if money was deposited.


### PR DESCRIPTION
Part of #285. One doc commit per entity so the PR reads as a series of independent module write-ups; happy to split later if review prefers smaller PRs.

## Scope
- `balance` module -- entity prose + controller docstring + cache-cursor notes.
- `transactions` module -- entity prose + controller docstring.
- `transactions/sub-transactions` module -- entity prose, promoted to ``@mergeTarget``.
- `transfers` module -- entity prose + controller docstring.

These four are tightly cross-linked (everything that moves money links to at least two of them), so writing them together keeps the cross-references coherent.

## Test plan
- [x] ``pnpm exec tsc --noEmit`` passes.
- [x] ``pnpm lint`` passes on the touched files.
- [x] ``pnpm typedoc`` runs clean -- no unresolved ``@link`` warnings.
- [x] No new tests needed (docs-only).
- [x] No DB migration (docs-only).