### PR TITLE
Stop coverage comment from exceeding char limit

### DIFF
--- a/.github/coverage-template.md
+++ b/.github/coverage-template.md
@@ -14,7 +14,5 @@ Base: [{{base_ref}}@{{base_short_commit_sha}}]({{base_commit_link}})
 <summary>Details (changed files)</summary>
 {{changed_files_coverage_table}}
 </details>
-<details>
-<summary>Details (all files)</summary>
-{{files_coverage_table}}
-</details>
+
+The full per-file breakdown is omitted to stay under GitHub's 65,536-character comment limit. Download the `coverage` artifact from this workflow run for the complete report, or view it on [Coveralls](https://coveralls.io/github/GEWIS/sudosos-backend).


### PR DESCRIPTION
## Summary

The `coverage-mariadb` CI job has been failing on large PRs with:

> Error: HttpError: Validation Failed: {"resource":"IssueComment","code":"custom","field":"body","message":"body is too long (maximum is 65536 characters)"}

`sidx1024/report-nyc-coverage-github-action` posts the rendered comment template as a single PR comment, which is bounded by GitHub's 65,536-character limit on `IssueComment.body`. Our template included `{{files_coverage_table}}` -- a row per file in the entire repo -- which routinely overflows that limit.

Fix: drop the all-files section. Reviewers care about the summary numbers and the changed-files breakdown; the per-file table for the whole repo is rarely read in a PR comment anyway. The complete per-file report is still:

- uploaded as the `coverage` workflow artifact (7-day retention), and
- pushed to Coveralls.

The template now links to both, so nothing is actually lost -- just relocated.

## Test plan

- [x] CI on this PR runs the coverage job without the validation error.
- [x] The PR comment still shows summary stats and changed-files coverage.
- [x] The `coverage` artifact and Coveralls run reflect the full breakdown.