### PR TITLE
fix: jsdoc being incorrect on getEligibleTransactions

### DIFF
--- a/src/controller/invoice-controller.ts
+++ b/src/controller/invoice-controller.ts
@@ -508,7 +508,7 @@ export default class InvoiceController extends BaseController {
    * @param {integer} forId.query.required - Filter on Id of the debtor
    * @param {string} fromDate.query.required - Start date for selected transactions (inclusive)
    * @param {string} tillDate.query - End date for selected transactions (exclusive)
-   * @return {TransactionResponse} 200 - The eligible transactions
+   * @return {Array.<TransactionResponse>} 200 - The eligible transactions
    * @return {string} 500 - Internal server error
    */
   public async getEligibleTransactions(req: RequestWithToken, res: Response): Promise<void> {


### PR DESCRIPTION
Puts Array<TransactionResponse> instead of TransactionResponse as return type for getEligibleTransactions

## Types of changes

- Bug fix _(non-breaking change which fixes an issue)_
- Documentation improvement
---

## ✅ PR Checklist

- [X] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [X] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [X] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB