### PR TITLE
Make pnpm run seed:dev runnable under Vitest

### DIFF
--- a/cli/dev-seed.ts
+++ b/cli/dev-seed.ts
@@ -36,7 +36,6 @@ import dinero, { Currency } from 'dinero.js';
 import Database from '../src/database/database';
 import { Application } from '../src';
 import initializeDiskStorage from '../src/files/initialize';
-import { truncateAllTables } from '../test/setup';
 import DefaultRoles from '../src/rbac/default-roles';
 import UserSeeder from '../test/seed/user-seeder';
 import VatGroupSeeder from '../test/seed/catalogue/vat-group-seeder';
@@ -115,7 +114,6 @@ async function createApp() {
   application.logger.info('Starting dev seed...');
 
   application.connection = await Database.initialize();
-  await truncateAllTables(application.connection);
 
   dinero.defaultCurrency = config.currency.code as Currency;
   dinero.defaultPrecision = config.currency.precision;

--- a/cli/seed.ts
+++ b/cli/seed.ts
@@ -24,7 +24,7 @@ import Database from '../src/database/database';
 import { Application } from '../src';
 import seedDatabase from '../test/seed';
 import initializeDiskStorage from '../src/files/initialize';
-import { truncateAllTables } from '../test/setup';
+import { truncateAllTables } from '../test/helpers/database-helpers';
 import Config from '../src/config';
 import { applyConfiguredLogLevel } from '../src/helpers/logging';
 

--- a/test/helpers/crypto-helpers.ts
+++ b/test/helpers/crypto-helpers.ts
@@ -1,0 +1,47 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * Crypto-related test helpers.
+ *
+ * Lives in `test/helpers/` rather than `test/setup.ts` so it can be imported
+ * by non-Vitest callers (e.g. `cli/dev-seed.ts`) without triggering Vitest's
+ * setup-time side effects (env mutations, env Proxy, hook registration).
+ */
+
+import * as util from 'util';
+import { generateKeyPair } from 'crypto';
+
+/**
+ * Generates a basic RSA keypair.
+ */
+export async function generateKeys(): Promise<{ publicKey: string, privateKey: string }> {
+  return util.promisify(generateKeyPair).bind(null, 'rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: {
+      type: 'spki',
+      format: 'pem',
+    },
+    privateKeyEncoding: {
+      type: 'pkcs8',
+      format: 'pem',
+    },
+  })();
+}

--- a/test/helpers/database-helpers.ts
+++ b/test/helpers/database-helpers.ts
@@ -1,0 +1,67 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * Database-level test helpers.
+ *
+ * Lives in `test/helpers/` rather than `test/setup.ts` so it can be imported
+ * by non-Vitest callers (e.g. `cli/dev-seed.ts`) without triggering Vitest's
+ * setup-time side effects (env mutations, env Proxy, hook registration).
+ */
+
+import { DataSource } from 'typeorm';
+import { PERSISTENT_TEST_DATABASES } from '../../src/helpers/database';
+
+// We should only ever truncate in test.
+// For non-persistent databases (sqlite) we can just drop them.
+function shouldTruncate(): boolean {
+  if (process.env.NODE_ENV !== 'test') return false;
+  return PERSISTENT_TEST_DATABASES.has(process.env.TYPEORM_CONNECTION);
+}
+
+export async function truncateAllTables(dataSource: DataSource): Promise<void> {
+  if (!shouldTruncate()) return;
+
+  console.log('Starting truncation of all tables...');
+  const queryRunner = dataSource.createQueryRunner();
+
+  await queryRunner.connect();
+
+  try {
+    await queryRunner.query('SET FOREIGN_KEY_CHECKS = 0;'); // Disable FK checks to avoid issues
+
+    // Retrieve all table names except for system tables (if any)
+    const tables = await queryRunner.query('SHOW FULL TABLES WHERE Table_type = \'BASE TABLE\';');
+
+    for (const table of tables) {
+      const tableName = table[Object.keys(table)[0]]; // Gets table name dynamically
+      console.log(`Truncating table: ${tableName}`);
+      await queryRunner.query(`TRUNCATE TABLE \`${tableName}\`;`);
+    }
+
+    await queryRunner.query('SET FOREIGN_KEY_CHECKS = 1;'); // Re-enable FK checks
+    console.log('All tables truncated successfully.');
+  } catch (err) {
+    console.error('Failed to truncate tables:', err);
+    throw err;
+  } finally {
+    await queryRunner.release();
+  }
+}

--- a/test/helpers/test-helpers.ts
+++ b/test/helpers/test-helpers.ts
@@ -30,7 +30,7 @@ import Database from '../../src/database/database';
 import TokenHandler from '../../src/authentication/token-handler';
 import User, { UserType } from '../../src/entity/user/user';
 import { ADMIN_USER, UserFactory } from './user-factory';
-import { truncateAllTables } from '../setup';
+import { truncateAllTables } from './database-helpers';
 import ServerSettingsStore from '../../src/server-settings/server-settings-store';
 
 export interface DefaultContext {

--- a/test/integration/pos-token-flow.ts
+++ b/test/integration/pos-token-flow.ts
@@ -34,7 +34,7 @@ import RoleManager from '../../src/rbac/role-manager';
 import { TransactionRequest } from '../../src/controller/request/transaction-request';
 import { UserFactory } from '../helpers/user-factory';
 import ServerSettingsStore from '../../src/server-settings/server-settings-store';
-import { truncateAllTables } from '../setup';
+import { truncateAllTables } from '../helpers/database-helpers';
 import { finishTestDB } from '../helpers/test-helpers';
 import { RbacSeeder } from '../seed';
 import AuthenticationController from '../../src/controller/authentication-controller';

--- a/test/integration/propagation.ts
+++ b/test/integration/propagation.ts
@@ -43,7 +43,7 @@ import ProductCategory from '../../src/entity/product/product-category';
 import { CreateProductRequest, UpdateProductRequest } from '../../src/controller/request/product-request';
 import { CreateContainerRequest, UpdateContainerRequest } from '../../src/controller/request/container-request';
 import { CreatePointOfSaleRequest } from '../../src/controller/request/point-of-sale-request';
-import { truncateAllTables } from '../setup';
+import { truncateAllTables } from '../helpers/database-helpers';
 import { finishTestDB } from '../helpers/test-helpers';
 import { ProductCategorySeeder, RbacSeeder, VatGroupSeeder } from '../seed';
 

--- a/test/seed/banner-seeder.ts
+++ b/test/seed/banner-seeder.ts
@@ -39,8 +39,8 @@ export default class BannerSeeder extends WithManager {
 
     let location;
     if (process.env.NODE_ENV !== 'test') {
-      const source = path.join(__dirname, './static/banner.png');
-      location = path.join(__dirname, '../', BANNER_IMAGE_LOCATION, downloadName);
+      const source = path.join(__dirname, '../static/banner.png');
+      location = path.join(__dirname, '../../', BANNER_IMAGE_LOCATION, downloadName);
       fs.copyFileSync(source, location);
     } else {
       location = `fake/storage/${downloadName}`;

--- a/test/seed/catalogue/product-seeder.ts
+++ b/test/seed/catalogue/product-seeder.ts
@@ -56,8 +56,8 @@ export default class ProductSeeder extends WithManager {
 
     let location;
     if (process.env.NODE_ENV !== 'test') {
-      const source = path.join(__dirname, './static/product.png');
-      location = path.join(__dirname, '../', PRODUCT_IMAGE_LOCATION, downloadName);
+      const source = path.join(__dirname, '../../static/product.png');
+      location = path.join(__dirname, '../../../', PRODUCT_IMAGE_LOCATION, downloadName);
       fs.copyFileSync(source, location);
     } else {
       location = `fake/storage/${downloadName}`;

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -18,9 +18,16 @@
  *  @license
  */
 
-/* eslint-disable import/prefer-default-export */
-import * as util from 'util';
-import { generateKeyPair, generateKeyPairSync } from 'crypto';
+/**
+ * Vitest setup file.
+ *
+ * Loaded once per test run via `setupFiles` in `vitest.config.mts`. This
+ * file is intentionally side-effect-only and must NOT be imported by
+ * non-test code. Pure utilities (truncateAllTables, generateKeys) live in
+ * `test/helpers/`.
+ */
+
+import { generateKeyPairSync } from 'crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -34,8 +41,6 @@ import dinero from 'dinero.js';
 import log4js from 'log4js';
 import sinonChai from 'sinon-chai';
 import { config } from 'dotenv';
-import { DataSource } from 'typeorm';
-import { PERSISTENT_TEST_DATABASES } from '../src/helpers/database';
 import '../src/database/database';
 import Config from '../src/config';
 
@@ -131,65 +136,3 @@ dinero.defaultPrecision = 2;
 const logger = log4js.getLogger('Console');
 logger.level = process.env.LOG_LEVEL;
 console.log = (message: any, ...additional: any[]) => logger.debug(message, ...additional);
-
-/**
- * Generates a basic RSA keypair.
- */
-export async function generateKeys(): Promise<{ publicKey: string, privateKey: string }> {
-  return util.promisify(generateKeyPair).bind(null, 'rsa', {
-    modulusLength: 2048,
-    publicKeyEncoding: {
-      type: 'spki',
-      format: 'pem',
-    },
-    privateKeyEncoding: {
-      type: 'pkcs8',
-      format: 'pem',
-    },
-  })();
-}
-
-/**
- * @returns The __filename converted to the TypeScript source file
- */
-export function sourceFile(file: string) {
-  return file.replace('out/test/', 'test/').replace('.js', '.ts');
-}
-
-
-// We should only ever truncate in test.
-// For non-persistent databases (sqlite) we can just drop them.
-function shouldTruncate(): boolean {
-  if (process.env.NODE_ENV !== 'test') return false;
-  return PERSISTENT_TEST_DATABASES.has(process.env.TYPEORM_CONNECTION);
-}
-
-export async function truncateAllTables(dataSource: DataSource): Promise<void> {
-  if (!shouldTruncate()) return;
-
-  console.log('Starting truncation of all tables...');
-  const queryRunner = dataSource.createQueryRunner();
-
-  await queryRunner.connect();
-
-  try {
-    await queryRunner.query('SET FOREIGN_KEY_CHECKS = 0;'); // Disable FK checks to avoid issues
-
-    // Retrieve all table names except for system tables (if any)
-    const tables = await queryRunner.query('SHOW FULL TABLES WHERE Table_type = \'BASE TABLE\';');
-
-    for (const table of tables) {
-      const tableName = table[Object.keys(table)[0]]; // Gets table name dynamically
-      console.log(`Truncating table: ${tableName}`);
-      await queryRunner.query(`TRUNCATE TABLE \`${tableName}\`;`);
-    }
-
-    await queryRunner.query('SET FOREIGN_KEY_CHECKS = 1;'); // Re-enable FK checks
-    console.log('All tables truncated successfully.');
-  } catch (err) {
-    console.error('Failed to truncate tables:', err);
-    throw err;
-  } finally {
-    await queryRunner.release();
-  }
-}

--- a/test/unit/authentication/token-handler.ts
+++ b/test/unit/authentication/token-handler.ts
@@ -23,7 +23,7 @@ import { expect } from 'chai';
 import * as jwt from 'jsonwebtoken';
 import TokenHandler from '../../../src/authentication/token-handler';
 import User from '../../../src/entity/user/user';
-import { generateKeys } from '../../setup';
+import { generateKeys } from '../../helpers/crypto-helpers';
 
 describe('TokenHandler', (): void => {
   let ctx: {

--- a/test/unit/controller/authentication-controller.ts
+++ b/test/unit/controller/authentication-controller.ts
@@ -46,7 +46,7 @@ import AuthenticationService from '../../../src/service/authentication-service';
 import AuthenticationResetTokenRequest from '../../../src/controller/request/authentication-reset-token-request';
 import KeyAuthenticator from '../../../src/entity/authenticator/key-authenticator';
 import AuthenticationKeyRequest from '../../../src/controller/request/authentication-key-request';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { UserSeeder } from '../../seed';
 import { ensureProductionRoles } from '../../helpers/user-factory';

--- a/test/unit/controller/authentication-qr-controller.ts
+++ b/test/unit/controller/authentication-qr-controller.ts
@@ -19,7 +19,7 @@
  */
 
 import { DefaultContext, defaultContext, finishTestDB } from '../../helpers/test-helpers';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import QRAuthenticator, { QRAuthenticatorStatus } from '../../../src/entity/authenticator/qr-authenticator';
 import chai from 'chai';
 

--- a/test/unit/controller/authentication-secure-controller.ts
+++ b/test/unit/controller/authentication-secure-controller.ts
@@ -31,7 +31,7 @@ import Database from '../../../src/database/database';
 import Swagger from '../../../src/start/swagger';
 import RoleManager from '../../../src/rbac/role-manager';
 import TokenMiddleware from '../../../src/middleware/token-middleware';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import PointOfSale from '../../../src/entity/point-of-sale/point-of-sale';
 import OrganMembership from '../../../src/entity/organ/organ-membership';

--- a/test/unit/controller/balance-controller.ts
+++ b/test/unit/controller/balance-controller.ts
@@ -43,7 +43,7 @@ import { OrderingDirection } from '../../../src/helpers/ordering';
 import { PaginationResult } from '../../../src/helpers/pagination';
 import Fine from '../../../src/entity/fine/fine';
 import UserFineGroup from '../../../src/entity/fine/userFineGroup';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { FineSeeder, TransactionSeeder, TransferSeeder, UserSeeder } from '../../seed';
 import { ensureProductionRoles, signTokenFor } from '../../helpers/user-factory';

--- a/test/unit/controller/banner-controller.ts
+++ b/test/unit/controller/banner-controller.ts
@@ -41,7 +41,7 @@ import Swagger from '../../../src/start/swagger';
 import BannerImage from '../../../src/entity/file/banner-image';
 import { DiskStorage } from '../../../src/files/storage';
 import { defaultPagination, PaginationResult } from '../../../src/helpers/pagination';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { ensureProductionRoles, signTokenFor } from '../../helpers/user-factory';
 import BannerSeeder from '../../seed/banner-seeder';

--- a/test/unit/controller/base-controller.ts
+++ b/test/unit/controller/base-controller.ts
@@ -33,7 +33,7 @@ import TokenHandler from '../../../src/authentication/token-handler';
 import { UserFactory } from '../../helpers/user-factory';
 import User, { TermsOfServiceStatus, UserType } from '../../../src/entity/user/user';
 import Database from '../../../src/database/database';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 
 const { expect, request } = chai;

--- a/test/unit/controller/borrelkaart-group-controller.ts
+++ b/test/unit/controller/borrelkaart-group-controller.ts
@@ -45,7 +45,7 @@ import {
 } from '../../../src/helpers/pagination';
 import Sinon from 'sinon';
 import { DineroObjectRequest } from '../../../src/controller/request/dinero-request';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { ensureProductionRoles, signTokenFor } from '../../helpers/user-factory';
 

--- a/test/unit/controller/container-controller.ts
+++ b/test/unit/controller/container-controller.ts
@@ -46,7 +46,7 @@ import { defaultPagination, PaginationResult } from '../../../src/helpers/pagina
 import { BaseContainerParams, CreateContainerRequest, UpdateContainerRequest } from '../../../src/controller/request/container-request';
 import { INVALID_ORGAN_ID, INVALID_PRODUCT_ID } from '../../../src/controller/request/validators/validation-errors';
 import ContainerRevision from '../../../src/entity/container/container-revision';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import Product from '../../../src/entity/product/product';
 import { ContainerSeeder, ProductSeeder } from '../../seed';

--- a/test/unit/controller/debtor-controller.ts
+++ b/test/unit/controller/debtor-controller.ts
@@ -46,7 +46,7 @@ import { defaultPagination, PaginationResult } from '../../../src/helpers/pagina
 import { calculateBalance, calculateFine } from '../../helpers/balance';
 import Mailer from '../../../src/mailer';
 import sinon, { SinonSandbox, SinonSpy } from 'sinon';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { Client } from 'pdf-generator-client';
 import { BasePdfService } from '../../../src/service/pdf/pdf-service';

--- a/test/unit/controller/event-controller.ts
+++ b/test/unit/controller/event-controller.ts
@@ -43,7 +43,7 @@ import {
 } from '../../../src/controller/response/event-response';
 import EventService from '../../../src/service/event-service';
 import { EventRequest } from '../../../src/controller/request/event-request';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { EventSeeder, UserSeeder } from '../../seed';
 import { ensureProductionRoles, signTokenFor } from '../../helpers/user-factory';

--- a/test/unit/controller/event-shift-controller.ts
+++ b/test/unit/controller/event-shift-controller.ts
@@ -42,7 +42,7 @@ import {
 import { EventShiftRequest } from '../../../src/controller/request/event-request';
 import EventShiftController from '../../../src/controller/event-shift-controller';
 import Event, { EventType } from '../../../src/entity/event/event';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import Role from '../../../src/entity/rbac/role';
 import { EventSeeder, UserSeeder } from '../../seed';

--- a/test/unit/controller/inactive-administrative-cost-controller.ts
+++ b/test/unit/controller/inactive-administrative-cost-controller.ts
@@ -28,7 +28,7 @@ import {
 } from '../../../src/controller/request/inactive-administrative-cost-request';
 import InactiveAdministrativeCost from '../../../src/entity/transactions/inactive-administrative-cost';
 import Database from '../../../src/database/database';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { TransferSeeder, UserSeeder } from '../../seed';
 import { ensureProductionRoles, signTokenFor } from '../../helpers/user-factory';
 import InactiveAdministrativeCostSeeder from '../../seed/ledger/inactive-administrative-cost-seeder';

--- a/test/unit/controller/invoice-controller.ts
+++ b/test/unit/controller/invoice-controller.ts
@@ -57,7 +57,7 @@ import InvoiceUser from '../../../src/entity/user/invoice-user';
 import { UpdateInvoiceUserRequest } from '../../../src/controller/request/user-request';
 import InvoicePdf from '../../../src/entity/file/invoice-pdf';
 import sinon from 'sinon';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { createTransactionRequest, requestToTransaction } from '../../helpers/transaction-factory';
 import { InvoiceSeeder, TransactionSeeder, UserSeeder } from '../../seed';

--- a/test/unit/controller/member-authentication-secure-controller.ts
+++ b/test/unit/controller/member-authentication-secure-controller.ts
@@ -37,7 +37,7 @@ import AuthenticationService from '../../../src/service/authentication-service';
 import MemberAuthenticationSecurePinRequest from '../../../src/controller/request/member-authentication-secure-pin-request';
 import PinAuthenticator from '../../../src/entity/authenticator/pin-authenticator';
 import PointOfSale from '../../../src/entity/point-of-sale/point-of-sale';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { PointOfSaleSeeder } from '../../seed';
 import TokenMiddleware from '../../../src/middleware/token-middleware';

--- a/test/unit/controller/payout-request-controller.ts
+++ b/test/unit/controller/payout-request-controller.ts
@@ -39,7 +39,7 @@ import {
 } from '../../../src/controller/response/payout-request-response';
 import { defaultPagination, PaginationResult } from '../../../src/helpers/pagination';
 import { PayoutRequestState } from '../../../src/entity/transactions/payout/payout-request-status';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import generateBalance, { finishTestDB } from '../../helpers/test-helpers';
 import BalanceService from '../../../src/service/balance-service';
 import { ensureProductionRoles, inUserContext, signTokenFor, UserFactory } from '../../helpers/user-factory';

--- a/test/unit/controller/product-category-controller.ts
+++ b/test/unit/controller/product-category-controller.ts
@@ -35,7 +35,7 @@ import RoleManager from '../../../src/rbac/role-manager';
 import TokenMiddleware from '../../../src/middleware/token-middleware';
 import ProductCategory from '../../../src/entity/product/product-category';
 import { defaultPagination, PaginationResult } from '../../../src/helpers/pagination';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { ProductCategorySeeder } from '../../seed';
 import { ensureProductionRoles, signTokenFor } from '../../helpers/user-factory';

--- a/test/unit/controller/product-controller.ts
+++ b/test/unit/controller/product-controller.ts
@@ -47,7 +47,7 @@ import ProductController from '../../../src/controller/product-controller';
 import { DineroObjectRequest } from '../../../src/controller/request/dinero-request';
 import { DiskStorage } from '../../../src/files/storage';
 import VatGroup from '../../../src/entity/vat-group';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import ProductRevision from '../../../src/entity/product/product-revision';
 import { ProductSeeder, VatGroupSeeder } from '../../seed';

--- a/test/unit/controller/stripe-controller.ts
+++ b/test/unit/controller/stripe-controller.ts
@@ -35,7 +35,7 @@ import TokenMiddleware from '../../../src/middleware/token-middleware';
 import { StripeRequest } from '../../../src/controller/request/stripe-request';
 import DineroTransformer from '../../../src/entity/transformer/dinero-transformer';
 import { StripePaymentIntentResponse } from '../../../src/controller/response/stripe-response';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import Stripe from 'stripe';
 import { STRIPE_API_VERSION } from '../../../src/service/stripe-service';

--- a/test/unit/controller/stripe-webhook-controller.ts
+++ b/test/unit/controller/stripe-webhook-controller.ts
@@ -32,7 +32,7 @@ import RoleManager from '../../../src/rbac/role-manager';
 import StripeWebhookController from '../../../src/controller/stripe-webhook-controller';
 import StripeService, { STRIPE_API_VERSION } from '../../../src/service/stripe-service';
 import { extractRawBody } from '../../../src/helpers/raw-body';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import StripeDeposit from '../../../src/entity/stripe/stripe-deposit';
 import { DepositSeeder, UserSeeder } from '../../seed';

--- a/test/unit/controller/sync-controller.ts
+++ b/test/unit/controller/sync-controller.ts
@@ -19,7 +19,7 @@
  */
 
 import { DefaultContext, defaultContext, finishTestDB } from '../../helpers/test-helpers';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { ADMIN_USER, UserFactory, ensureProductionRoles, signTokenFor } from '../../helpers/user-factory';
 import chai from 'chai';
 

--- a/test/unit/controller/terms-of-service-controller.ts
+++ b/test/unit/controller/terms-of-service-controller.ts
@@ -27,7 +27,7 @@ import TermsOfServiceController from '../../../src/controller/terms-of-service-c
 import TermsOfServiceService, { TermsOfService } from '../../../src/service/terms-of-service-service';
 import { TermsOfServiceResponse } from '../../../src/controller/response/terms-of-service-response';
 import { DefaultContext, defaultContext, finishTestDB } from '../../helpers/test-helpers';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { ADMIN_USER, ensureProductionRoles, signTokenFor, UserFactory } from '../../helpers/user-factory';
 
 const { expect, request } = chai;

--- a/test/unit/controller/transaction-controller.ts
+++ b/test/unit/controller/transaction-controller.ts
@@ -42,7 +42,7 @@ import { defaultPagination, maxPagination, PaginationResult } from '../../../src
 import { inUserContext, UserFactory } from '../../helpers/user-factory';
 import OrganMembership from '../../../src/entity/organ/organ-membership';
 import ServerSettingsStore from '../../../src/server-settings/server-settings-store';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import dinero from 'dinero.js';
 import { ensureProductionRoles, signTokenFor } from '../../helpers/user-factory';

--- a/test/unit/controller/user-controller.ts
+++ b/test/unit/controller/user-controller.ts
@@ -70,7 +70,7 @@ import { TransactionReportResponse } from '../../../src/controller/response/tran
 import { TransactionFilterParameters } from '../../../src/service/transaction-service';
 import UpdateNfcRequest from '../../../src/controller/request/update-nfc-request';
 import UserFineGroup from '../../../src/entity/fine/userFineGroup';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import Role from '../../../src/entity/rbac/role';
 import { createTransactions, createValidTransactionRequest } from '../../helpers/transaction-factory';

--- a/test/unit/controller/user-notification-preference-controller.ts
+++ b/test/unit/controller/user-notification-preference-controller.ts
@@ -26,7 +26,7 @@ import UserNotificationPreference, {
   NotificationChannels,
 } from '../../../src/entity/notifications/user-notification-preference';
 import Database from '../../../src/database/database';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { UserSeeder } from '../../seed';
 import { ensureProductionRoles, signTokenFor } from '../../helpers/user-factory';
 import UserNotificationSeeder from '../../seed/ledger/user-notification-seeder';

--- a/test/unit/controller/vat-group-controller.ts
+++ b/test/unit/controller/vat-group-controller.ts
@@ -36,7 +36,7 @@ import RoleManager from '../../../src/rbac/role-manager';
 import TokenMiddleware from '../../../src/middleware/token-middleware';
 import { defaultPagination, PaginationResult } from '../../../src/helpers/pagination';
 import { VatDeclarationResponse } from '../../../src/controller/response/vat-group-response';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import {
   ContainerSeeder,

--- a/test/unit/controller/write-off-controller.ts
+++ b/test/unit/controller/write-off-controller.ts
@@ -19,7 +19,7 @@
  */
 
 import { DefaultContext, defaultContext, finishTestDB } from '../../helpers/test-helpers';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import WriteOff from '../../../src/entity/transactions/write-off';
 import User from '../../../src/entity/user/user';
 import { ADMIN_USER, ensureProductionRoles, inUserContext, signTokenFor, UserFactory } from '../../helpers/user-factory';

--- a/test/unit/files/storage/disk-storage.ts
+++ b/test/unit/files/storage/disk-storage.ts
@@ -26,7 +26,7 @@ import { DiskStorage } from '../../../../src/files/storage';
 import BaseFile from '../../../../src/entity/file/base-file';
 import User from '../../../../src/entity/user/user';
 import Database from '../../../../src/database/database';
-import { truncateAllTables } from '../../../setup';
+import { truncateAllTables } from '../../../helpers/database-helpers';
 import { finishTestDB } from '../../../helpers/test-helpers';
 import { UserSeeder } from '../../../seed';
 

--- a/test/unit/gewis/controller/gewis-authentication-controller.ts
+++ b/test/unit/gewis/controller/gewis-authentication-controller.ts
@@ -41,7 +41,7 @@ import AuthenticationLDAPRequest from '../../../../src/controller/request/authen
 import userIsAsExpected from '../../../helpers/authentication-helpers';
 import AuthenticationService from '../../../../src/service/authentication-service';
 import PinAuthenticator from '../../../../src/entity/authenticator/pin-authenticator';
-import { truncateAllTables } from '../../../setup';
+import { truncateAllTables } from '../../../helpers/database-helpers';
 import { finishTestDB } from '../../../helpers/test-helpers';
 import { RbacSeeder } from '../../../seed';
 

--- a/test/unit/gewis/gewis.ts
+++ b/test/unit/gewis/gewis.ts
@@ -39,7 +39,7 @@ import TokenHandler from '../../../src/authentication/token-handler';
 import RoleManager from '../../../src/rbac/role-manager';
 import UserController from '../../../src/controller/user-controller';
 import TokenMiddleware from '../../../src/middleware/token-middleware';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { RbacSeeder } from '../../seed';
 import { LDAPUser } from '../../../src/helpers/ad';
 

--- a/test/unit/mailer/mailer.ts
+++ b/test/unit/mailer/mailer.ts
@@ -26,7 +26,7 @@ import User, { UserType } from '../../../src/entity/user/user';
 import Database from '../../../src/database/database';
 import HelloWorld from '../../../src/mailer/messages/hello-world';
 import { Language } from '../../../src/mailer/mail-message';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import fs from 'fs';
 import { rootStubs } from '../../root-hooks';

--- a/test/unit/middleware/restriction-middleware.ts
+++ b/test/unit/middleware/restriction-middleware.ts
@@ -28,7 +28,7 @@ import { UserFactory } from '../../helpers/user-factory';
 import User, { TermsOfServiceStatus, UserType } from '../../../src/entity/user/user';
 import TokenHandler from '../../../src/authentication/token-handler';
 import TokenMiddleware from '../../../src/middleware/token-middleware';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import ServerSettingsStore from '../../../src/server-settings/server-settings-store';
 import sinon from 'sinon';

--- a/test/unit/middleware/token-middleware.ts
+++ b/test/unit/middleware/token-middleware.ts
@@ -25,7 +25,7 @@ import chai from 'chai';
 
 import TokenHandler from '../../../src/authentication/token-handler';
 import User from '../../../src/entity/user/user';
-import { generateKeys } from '../../setup';
+import { generateKeys } from '../../helpers/crypto-helpers';
 import TokenMiddleware, { RequestWithToken } from '../../../src/middleware/token-middleware';
 import JsonWebToken from '../../../src/authentication/json-web-token';
 

--- a/test/unit/rbac/default-roles.ts
+++ b/test/unit/rbac/default-roles.ts
@@ -21,7 +21,7 @@
 import { DataSource } from 'typeorm';
 import database from '../../../src/database/database';
 import { finishTestDB } from '../../helpers/test-helpers';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import RBACService from '../../../src/service/rbac-service';
 import DefaultRoles from '../../../src/rbac/default-roles';
 import { expect } from 'chai';

--- a/test/unit/service/ad-service.ts
+++ b/test/unit/service/ad-service.ts
@@ -32,7 +32,7 @@ import LDAPAuthenticator from '../../../src/entity/authenticator/ldap-authentica
 import { LDAPGroup, LDAPUser } from '../../../src/helpers/ad';
 import userIsAsExpected from '../../helpers/authentication-helpers';
 import { finishTestDB, restoreLDAPEnv, setDefaultLDAPEnv, storeLDAPEnv } from '../../helpers/test-helpers';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { UserSeeder } from '../../seed';
 import { Client } from 'ldapts';
 import RoleManager from '../../../src/rbac/role-manager';

--- a/test/unit/service/authentication-service.ts
+++ b/test/unit/service/authentication-service.ts
@@ -36,7 +36,7 @@ import { finishTestDB, restoreLDAPEnv, storeLDAPEnv } from '../../helpers/test-h
 import HashBasedAuthenticationMethod from '../../../src/entity/authenticator/hash-based-authentication-method';
 import LocalAuthenticator from '../../../src/entity/authenticator/local-authenticator';
 import AuthenticationResetTokenRequest from '../../../src/controller/request/authentication-reset-token-request';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import OrganMembership from '../../../src/entity/organ/organ-membership';
 import RoleManager from '../../../src/rbac/role-manager';
 import TokenHandler from '../../../src/authentication/token-handler';

--- a/test/unit/service/balance-service.ts
+++ b/test/unit/service/balance-service.ts
@@ -39,7 +39,7 @@ import { addTransaction, addTransfer } from '../../helpers/transaction-helpers';
 import { calculateBalance } from '../../helpers/balance';
 import Fine from '../../../src/entity/fine/fine';
 import BalanceResponse, { UserTypeTotalBalanceResponse } from '../../../src/controller/response/balance-response';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { FineSeeder, PointOfSaleSeeder, TransactionSeeder, TransferSeeder, UserSeeder } from '../../seed';
 import MemberUser from '../../../src/entity/user/member-user';

--- a/test/unit/service/container-service.ts
+++ b/test/unit/service/container-service.ts
@@ -42,7 +42,7 @@ import PointOfSaleService from '../../../src/service/point-of-sale-service';
 import { CreatePointOfSaleParams } from '../../../src/controller/request/point-of-sale-request';
 import AuthenticationService from '../../../src/service/authentication-service';
 import OrganMembership from '../../../src/entity/organ/organ-membership';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import PointOfSale from '../../../src/entity/point-of-sale/point-of-sale';
 import sinon from 'sinon';

--- a/test/unit/service/debtor-service.ts
+++ b/test/unit/service/debtor-service.ts
@@ -34,7 +34,7 @@ import { calculateBalance, calculateFine } from '../../helpers/balance';
 import FineHandoutEvent from '../../../src/entity/fine/fineHandoutEvent';
 import sinon, { SinonSandbox, SinonSpy } from 'sinon';
 import Mailer from '../../../src/mailer';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import dinero from 'dinero.js';
 import TransferService from '../../../src/service/transfer-service';

--- a/test/unit/service/event-service.ts
+++ b/test/unit/service/event-service.ts
@@ -29,7 +29,7 @@ import { expect } from 'chai';
 import AssignedRole from '../../../src/entity/rbac/assigned-role';
 import sinon, { SinonSandbox, SinonSpy } from 'sinon';
 import Mailer from '../../../src/mailer';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import Role from '../../../src/entity/rbac/role';
 import { EventSeeder, UserSeeder } from '../../seed';

--- a/test/unit/service/file-service.ts
+++ b/test/unit/service/file-service.ts
@@ -35,7 +35,7 @@ import FileService, { StorageMethod } from '../../../src/service/file-service';
 import { DiskStorage } from '../../../src/files/storage';
 import Product from '../../../src/entity/product/product';
 import ProductImage from '../../../src/entity/file/product-image';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { ProductSeeder, UserSeeder } from '../../seed';
 

--- a/test/unit/service/inactive-administrative-cost-service.ts
+++ b/test/unit/service/inactive-administrative-cost-service.ts
@@ -25,7 +25,7 @@ import User, { UserType } from '../../../src/entity/user/user';
 import Transfer from '../../../src/entity/transactions/transfer';
 import Transaction from '../../../src/entity/transactions/transaction';
 import Database from '../../../src/database/database';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import {
   ContainerSeeder,
   PointOfSaleSeeder,

--- a/test/unit/service/invoice-pdf-service.ts
+++ b/test/unit/service/invoice-pdf-service.ts
@@ -33,7 +33,7 @@ import Swagger from '../../../src/start/swagger';
 import { json } from 'body-parser';
 import FileService from '../../../src/service/file-service';
 import deepEqualInAnyOrder from 'deep-equal-in-any-order';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { INVOICE_PDF_LOCATION } from '../../../src/files/storage';
 import { InvoiceSeeder, TransactionSeeder, UserSeeder } from '../../seed';

--- a/test/unit/service/invoice-service.ts
+++ b/test/unit/service/invoice-service.ts
@@ -43,7 +43,7 @@ import { TransactionRequest } from '../../../src/controller/request/transaction-
 import { InvoiceState } from '../../../src/entity/invoices/invoice-status';
 import Transaction from '../../../src/entity/transactions/transaction';
 import InvoiceUser from '../../../src/entity/user/invoice-user';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { createInvoiceWithTransfers } from '../../helpers/invoice-helpers';
 import { InvoiceSeeder, TransactionSeeder, UserSeeder } from '../../seed';

--- a/test/unit/service/payout-request-pdf-service.ts
+++ b/test/unit/service/payout-request-pdf-service.ts
@@ -30,7 +30,7 @@ import Swagger from '../../../src/start/swagger';
 import { json } from 'body-parser';
 import FileService from '../../../src/service/file-service';
 import deepEqualInAnyOrder from 'deep-equal-in-any-order';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import PayoutRequest from '../../../src/entity/transactions/payout/payout-request';
 import PayoutRequestPdfService from '../../../src/service/pdf/payout-request-pdf-service';

--- a/test/unit/service/payout-request-service.ts
+++ b/test/unit/service/payout-request-service.ts
@@ -27,7 +27,7 @@ import Database from '../../../src/database/database';
 import PayoutRequestService from '../../../src/service/payout-request-service';
 import { PayoutRequestState } from '../../../src/entity/transactions/payout/payout-request-status';
 import PayoutRequestRequest from '../../../src/controller/request/payout-request-request';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import BalanceService from '../../../src/service/balance-service';
 import { PayoutRequestSeeder, UserSeeder } from '../../seed';

--- a/test/unit/service/point-of-sale-service.ts
+++ b/test/unit/service/point-of-sale-service.ts
@@ -37,7 +37,7 @@ import { CreatePointOfSaleParams, UpdatePointOfSaleParams } from '../../../src/c
 import AuthenticationService from '../../../src/service/authentication-service';
 import OrganMembership from '../../../src/entity/organ/organ-membership';
 import PointOfSaleRevision from '../../../src/entity/point-of-sale/point-of-sale-revision';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import RbacSeeder, { SeededRole } from '../../seed/rbac-seeder';
 import { ContainerSeeder, PointOfSaleSeeder, ProductSeeder, UserSeeder } from '../../seed';

--- a/test/unit/service/product-category-service.ts
+++ b/test/unit/service/product-category-service.ts
@@ -27,7 +27,7 @@ import Swagger from '../../../src/start/swagger';
 import ProductCategory from '../../../src/entity/product/product-category';
 import ProductCategoryService from '../../../src/service/product-category-service';
 import ProductCategoryRequest from '../../../src/controller/request/product-category-request';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { ProductCategorySeeder } from '../../seed';
 

--- a/test/unit/service/product-service.ts
+++ b/test/unit/service/product-service.ts
@@ -45,7 +45,7 @@ import { CreatePointOfSaleParams } from '../../../src/controller/request/point-o
 import PointOfSaleService from '../../../src/service/point-of-sale-service';
 import OrganMembership from '../../../src/entity/organ/organ-membership';
 import AuthenticationService from '../../../src/service/authentication-service';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import sinon from 'sinon';
 import { ContainerSeeder, PointOfSaleSeeder, ProductSeeder, UserSeeder } from '../../seed';

--- a/test/unit/service/qr-service.ts
+++ b/test/unit/service/qr-service.ts
@@ -24,7 +24,7 @@ import QRService from '../../../src/service/qr-service';
 import QRAuthenticator, { QRAuthenticatorStatus } from '../../../src/entity/authenticator/qr-authenticator';
 import User from '../../../src/entity/user/user';
 import Database from '../../../src/database/database';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { QRAuthenticatorSeeder, UserSeeder } from '../../seed';
 

--- a/test/unit/service/stripe-service.ts
+++ b/test/unit/service/stripe-service.ts
@@ -29,7 +29,7 @@ import DineroTransformer from '../../../src/entity/transformer/dinero-transforme
 import { StripePaymentIntentState } from '../../../src/entity/stripe/stripe-payment-intent-status';
 import BalanceResponse from '../../../src/controller/response/balance-response';
 import { StripeRequest } from '../../../src/controller/request/stripe-request';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { DepositSeeder, UserSeeder } from '../../seed';
 

--- a/test/unit/service/transaction-pdf-service.ts
+++ b/test/unit/service/transaction-pdf-service.ts
@@ -26,7 +26,7 @@ import Database from '../../../src/database/database';
 import Transaction from '../../../src/entity/transactions/transaction';
 import TransactionPdfService from '../../../src/service/pdf/transaction-pdf-service';
 import { finishTestDB } from '../../helpers/test-helpers';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { ContainerSeeder, PointOfSaleSeeder, ProductSeeder, TransactionSeeder, UserSeeder } from '../../seed';
 import { PdfError } from '../../../src/errors';
 

--- a/test/unit/service/transaction-service.ts
+++ b/test/unit/service/transaction-service.ts
@@ -47,7 +47,7 @@ import ContainerRevision from '../../../src/entity/container/container-revision'
 import generateBalance, { finishTestDB } from '../../helpers/test-helpers';
 import { inUserContext, UserFactory } from '../../helpers/user-factory';
 import { createInvoiceWithTransfers } from '../../helpers/invoice-helpers';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import ProductRevision from '../../../src/entity/product/product-revision';
 import { calculateBalance } from '../../helpers/balance';
 import { ContainerSeeder, PointOfSaleSeeder, ProductSeeder, TransactionSeeder, UserSeeder } from '../../seed';

--- a/test/unit/service/transfer-pdf-service.ts
+++ b/test/unit/service/transfer-pdf-service.ts
@@ -28,7 +28,7 @@ import User from '../../../src/entity/user/user';
 import TransferPdfService from '../../../src/service/pdf/transfer-pdf-service';
 import DineroTransformer from '../../../src/entity/transformer/dinero-transformer';
 import { finishTestDB } from '../../helpers/test-helpers';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { UserSeeder } from '../../seed';
 import Invoice from '../../../src/entity/invoices/invoice';
 import WriteOff from '../../../src/entity/transactions/write-off';

--- a/test/unit/service/transfer-service.ts
+++ b/test/unit/service/transfer-service.ts
@@ -32,7 +32,7 @@ import TransferService, { TransferCategory } from '../../../src/service/transfer
 import Invoice from '../../../src/entity/invoices/invoice';
 import Swagger from '../../../src/start/swagger';
 import DineroTransformer from '../../../src/entity/transformer/dinero-transformer';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import VatGroup from '../../../src/entity/vat-group';
 import {

--- a/test/unit/service/user-notification-preference-service.ts
+++ b/test/unit/service/user-notification-preference-service.ts
@@ -26,7 +26,7 @@ import UserNotificationPreference, {
   NotificationChannels,
 } from '../../../src/entity/notifications/user-notification-preference';
 import Database from '../../../src/database/database';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { UserSeeder } from '../../seed';
 import UserNotificationSeeder from '../../seed/ledger/user-notification-seeder';
 import Swagger from '../../../src/start/swagger';

--- a/test/unit/service/user-service.ts
+++ b/test/unit/service/user-service.ts
@@ -27,7 +27,7 @@ import WelcomeToSudosos from '../../../src/mailer/messages/welcome-to-sudosos';
 import Mailer from '../../../src/mailer';
 import AuthenticationService from '../../../src/service/authentication-service';
 import Database from '../../../src/database/database';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import {
   UserSeeder, PointOfSaleSeeder, ContainerSeeder, ProductSeeder, VatGroupSeeder,

--- a/test/unit/service/vat-group-service.ts
+++ b/test/unit/service/vat-group-service.ts
@@ -27,7 +27,7 @@ import { VatGroupRequest } from '../../../src/controller/request/vat-group-reque
 import Database from '../../../src/database/database';
 import VatGroupService from '../../../src/service/vat-group-service';
 import { VatDeclarationResponse } from '../../../src/controller/response/vat-group-response';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import {
   ContainerSeeder,

--- a/test/unit/service/voucher-group-service.ts
+++ b/test/unit/service/voucher-group-service.ts
@@ -27,7 +27,7 @@ import Transfer from '../../../src/entity/transactions/transfer';
 import User, { TermsOfServiceStatus } from '../../../src/entity/user/user';
 import VoucherGroup from '../../../src/entity/user/voucher-group';
 import VoucherGroupService from '../../../src/service/voucher-group-service';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 
 export function bkgEq(req: VoucherGroupParams, voucherGroup: VoucherGroup, users: User[]): void {

--- a/test/unit/service/websocket/pos-relation-helper.ts
+++ b/test/unit/service/websocket/pos-relation-helper.ts
@@ -22,7 +22,7 @@ import { DataSource } from 'typeorm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import Database from '../../../../src/database/database';
-import { truncateAllTables } from '../../../setup';
+import { truncateAllTables } from '../../../helpers/database-helpers';
 import { finishTestDB } from '../../../helpers/test-helpers';
 import { UserSeeder, PointOfSaleSeeder } from '../../../seed';
 import User, { UserType } from '../../../../src/entity/user/user';

--- a/test/unit/service/wrapped-service.ts
+++ b/test/unit/service/wrapped-service.ts
@@ -34,7 +34,7 @@ import PointOfSaleRevision from '../../../src/entity/point-of-sale/point-of-sale
 import OrganMembership from '../../../src/entity/organ/organ-membership';
 import Swagger from '../../../src/start/swagger';
 import { finishTestDB } from '../../helpers/test-helpers';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { UserSeeder, ContainerSeeder, ProductSeeder, TransactionSeeder } from '../../seed';
 import ProductRevision from '../../../src/entity/product/product-revision';
 import ContainerRevision from '../../../src/entity/container/container-revision';

--- a/test/unit/service/write-off-service.ts
+++ b/test/unit/service/write-off-service.ts
@@ -19,7 +19,7 @@
  */
 
 import { defaultContext, finishTestDB } from '../../helpers/test-helpers';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { DataSource } from 'typeorm';
 import { Express } from 'express';
 import { SwaggerSpecification } from 'swagger-model-validator';

--- a/test/unit/subscribe/transaction-subscriber.ts
+++ b/test/unit/subscribe/transaction-subscriber.ts
@@ -38,7 +38,7 @@ import { expect } from 'chai';
 import TransactionService from '../../../src/service/transaction-service';
 import { SubTransactionRequest, TransactionRequest } from '../../../src/controller/request/transaction-request';
 import BalanceService from '../../../src/service/balance-service';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import {
   ContainerSeeder,

--- a/test/unit/subscribe/transfer-subscriber.ts
+++ b/test/unit/subscribe/transfer-subscriber.ts
@@ -31,7 +31,7 @@ import { addTransfer } from '../../helpers/transaction-helpers';
 import BalanceService from '../../../src/service/balance-service';
 import dinero from 'dinero.js';
 import Fine from '../../../src/entity/fine/fine';
-import { truncateAllTables } from '../../setup';
+import { truncateAllTables } from '../../helpers/database-helpers';
 import { finishTestDB } from '../../helpers/test-helpers';
 import { TransactionSeeder, TransferSeeder, UserSeeder } from '../../seed';
 


### PR DESCRIPTION
## Summary

Two fixes for the seed CLIs, in separate commits.

### 1. `fix: make pnpm run seed:dev runnable under Vitest`

`pnpm run seed:dev` has been broken since the Mocha -> Vitest migration in #884. Two bugs in the test infrastructure that combine:

- `test/root-hooks.ts` calls `beforeAll`/`beforeEach`/`afterEach`/`afterAll` at module top level. Mocha exposed those as ambient globals everywhere, so the file was safe to import outside the runner. Vitest only injects them while it's running, so importing root-hooks anywhere else throws `ReferenceError: beforeAll is not defined`. Both `cli/dev-seed.ts` and `cli/seed.ts` end up pulling it in transitively (through `test/setup.ts` for `truncateAllTables`, and through `test/helpers/test-helpers.ts` -> `test/setup.ts` for the helpers `WriteOffSeeder` uses), so both crash at module load.
- `test/setup.ts` mutates `process.env` unconditionally. It forces `NODE_ENV=test`, swaps `TYPEORM_DATABASE` to `:memory:`, and proxy-wraps the env. Anything that imports it transitively from outside the runner silently flips into test mode and would have seeded an in-memory DB that disappears at process exit.

The shared cause: `test/setup.ts` and `test/root-hooks.ts` mix Vitest setup-time side effects with plain utility exports (`truncateAllTables`, `generateKeys`) that callers want to use on their own. The seed CLIs wanted the utilities and got the side effects too.

So I pulled the utilities out:

- new file `test/helpers/database-helpers.ts` -- exports `truncateAllTables`
- new file `test/helpers/crypto-helpers.ts` -- exports `generateKeys`
- `test/setup.ts` is now a pure Vitest setupFile; no public exports, loaded only by `vitest.config.mts` setupFiles
- `test/root-hooks.ts` is loaded only by `test/setup.ts` and the handful of tests that need `rootStubs`, so the unguarded `beforeAll`/etc. calls are fine

65 test files updated to pull `truncateAllTables` from the new helper, plus 2 files for `generateKeys`. `cli/seed.ts` imports `truncateAllTables` from the new helper. `cli/dev-seed.ts` doesn't import from `test/setup` anymore -- the `truncateAllTables` call there was dropped, since it's a no-op on SQLite anyway.

### 2. `fix: resolve product/banner image asset paths in dev seeders`

Once the load-time crash is gone, `cli/seed.ts` finally reaches `BannerSeeder.defineBannerImage` and `ProductSeeder.defineProductImage` for the first time in months -- and immediately ENOENTs. Both seeders had off-by-one `path.join(__dirname, ...)` paths. The fix is the same in both files: one extra `../` on the source, one extra `../` on the destination.

| File | source (was) | source (now) | dest (was) | dest (now) |
|---|---|---|---|---|
| `test/seed/banner-seeder.ts` | `test/seed/static/banner.png` | `test/static/banner.png` | `test/data/banners/...` | `data/banners/...` |
| `test/seed/catalogue/product-seeder.ts` | `test/seed/catalogue/static/product.png` | `test/static/product.png` | `test/seed/data/products/...` | `data/products/...` |

The PNGs actually live at `test/static/{banner,product}.png`. The destination directories at repo root get created by `initializeDiskStorage()`. This branch only runs when `NODE_ENV !== 'test'`, so the test suite never hit it.

A `grep` over `test/seed/**` for `path.join(__dirname, ...)` shows these are the only two cases.

## Test plan

- [x] `pnpm exec eslint package.json src test --ext .js --ext .ts` -- clean
- [x] `pnpm exec tsc --noEmit` -- clean
- [x] `rm -f local.sqlite && pnpm run schema && pnpm exec ts-node --transpile-only cli/dev-seed.ts` -- seeds 8 users / 6 transactions / 1 invoice / 4 products
- [x] `rm -f local.sqlite && pnpm run schema && pnpm exec ts-node --transpile-only cli/seed.ts` -- runs the heavy dataset; writes 18 banner PNGs to `data/banners/` and 72 product PNGs to `data/products/`
- [x] `pnpm exec vitest run test/unit/service/invoice-pdf-service.ts` -- 12 pass, 0 fail
- [x] `pnpm exec vitest run test/unit/mailer/mailer.ts` -- 5 pass, 0 fail (exercises the `rootStubs` consumer)
- [x] CI: full vitest suite green

## Notes

- No production code touched. Just test infrastructure, the two dev seed CLIs, and the two seeder asset paths.
- "Add tests" on the PR template doesn't apply here -- this fixes dev-only tooling and a `NODE_ENV !== 'test'` code path. Neither has test coverage; the verification is that the seeds run.
- "DB migration" on the PR template doesn't apply.
- Supersedes #928 (closed). The asset-path fix was originally split out into its own PR; pulling it back here so the whole seed-CLI fix lands as one review.
