### PR TITLE
Fix product/banner image path in dev seeders

### DIFF
--- a/test/seed/banner-seeder.ts
+++ b/test/seed/banner-seeder.ts
@@ -39,8 +39,8 @@ export default class BannerSeeder extends WithManager {
 
     let location;
     if (process.env.NODE_ENV !== 'test') {
-      const source = path.join(__dirname, './static/banner.png');
-      location = path.join(__dirname, '../', BANNER_IMAGE_LOCATION, downloadName);
+      const source = path.join(__dirname, '../static/banner.png');
+      location = path.join(__dirname, '../../', BANNER_IMAGE_LOCATION, downloadName);
       fs.copyFileSync(source, location);
     } else {
       location = `fake/storage/${downloadName}`;

--- a/test/seed/catalogue/product-seeder.ts
+++ b/test/seed/catalogue/product-seeder.ts
@@ -56,8 +56,8 @@ export default class ProductSeeder extends WithManager {
 
     let location;
     if (process.env.NODE_ENV !== 'test') {
-      const source = path.join(__dirname, './static/product.png');
-      location = path.join(__dirname, '../', PRODUCT_IMAGE_LOCATION, downloadName);
+      const source = path.join(__dirname, '../../static/product.png');
+      location = path.join(__dirname, '../../../', PRODUCT_IMAGE_LOCATION, downloadName);
       fs.copyFileSync(source, location);
     } else {
       location = `fake/storage/${downloadName}`;


### PR DESCRIPTION
## Summary

`BannerSeeder.defineBannerImage` and `ProductSeeder.defineProductImage` resolve their source PNGs and destination paths via `path.join(__dirname, ...)`. Both paths were off by one directory level, so when `NODE_ENV !== 'test'` the seed crashed with `ENOENT` on `copyFileSync`. The same fix applies to both files: one extra `../` on the source path and one extra `../` on the destination path.

| File | What it computed | What it should compute |
|---|---|---|
| `test/seed/banner-seeder.ts` source | `test/seed/static/banner.png` | `test/static/banner.png` |
| `test/seed/banner-seeder.ts` dest | `test/data/banners/...` | `data/banners/...` |
| `test/seed/catalogue/product-seeder.ts` source | `test/seed/catalogue/static/product.png` | `test/static/product.png` |
| `test/seed/catalogue/product-seeder.ts` dest | `test/seed/data/products/...` | `data/products/...` |

The source PNGs live at `test/static/{banner,product}.png`. The destination directories are created at repo root by `initializeDiskStorage()` (which uses `path.join(__dirname, '/../..', LOCATION)` from `src/files/initialize.ts`).

## Why now

The bug was masked. The image-copy branch only runs when `NODE_ENV !== 'test'`, and prior to #927 both seed CLIs (`cli/seed.ts` and `cli/dev-seed.ts`) crashed at module load with `ReferenceError: beforeAll is not defined` before getting this far. Once that load-time crash is fixed, the next thing `cli/seed.ts` hits is this `ENOENT`. Filed separately so the two PRs stay scoped to one bug each.

Grep confirms no other `path.join(__dirname, ...)` references in `test/seed/**` -- only these two seeders.

## Test plan

- [x] `pnpm exec eslint package.json src test --ext .js --ext .ts` -- clean
- [x] `pnpm exec tsc --noEmit` -- clean
- [x] End-to-end (with #927 stacked in locally for verification): `rm -f local.sqlite && pnpm run schema && pnpm exec ts-node --transpile-only cli/seed.ts` -- completes, writes banner PNGs (~666 KB each) to `data/banners/` and product PNGs (~549 KB each) to `data/products/`
- [ ] CI: full vitest suite green (this code path is `NODE_ENV !== 'test'` so tests don't exercise it, but the modified files are imported by the suite)

## Notes

- Two-line change per file. No production code touched.
- The PR template's "add tests" item does not apply -- this code path is only reachable from seed CLIs in dev/prod, not from the test suite.
- The PR template's "DB migration" item does not apply.
- End-to-end verification requires #927 to land first (so `cli/seed.ts` can reach the relevant code); the fix itself stands on its own and the path resolution can be verified mechanically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)