### PR TITLE
feat(UX): add SudoSOS link to debt notification messages

### DIFF
--- a/src/mailer/messages/user-debt-notification.ts
+++ b/src/mailer/messages/user-debt-notification.ts
@@ -34,7 +34,7 @@ const userDebtNotificationDutch = new MailContentBuilder<UserDebtNotificationOpt
 Het gaat hierbij om een bedrag van:<br>
 <span style="color: red; font-weight: bold; font-size: 20px">${context.balance.toFormat()}</span>.</p>
 
-<p>Ga snel naar de SudoSOS website om je saldo op te hogen! Zo voorkom je dat je een boete krijgt.</p>`,
+<p>Ga snel naar de <a href="https://sudosos.gewis.nl/" target="_blank" rel="noopener noreferrer">SudoSOS website</a> om je saldo op te hogen! Zo voorkom je dat je een boete krijgt.</p>`,
   getSubject: 'Je hebt een SudoSOS schuld!',
   getTitle: 'Schuldnotificatie',
   getText: (context) => `
@@ -51,7 +51,7 @@ const userDebtNotificationEnglish = new MailContentBuilder<UserDebtNotificationO
   getHTML: (context) => `
 <p>According to our administration, you currently have a balance of <span style="color: red; font-weight: bold">${context.balance.toFormat()}</span>.</p>
 
-<p>Go to the SudoSOS website to deposit money into your account. With this you prevent getting fined in the future.</p>`,
+<p>Go to the <a href="https://sudosos.gewis.nl/" target="_blank" rel="noopener noreferrer">SudoSOS website</a> to deposit money into your account. With this you prevent getting fined in the future.</p>`,
   getSubject: 'You have a SudoSOS debt',
   getTitle: 'Debt notification',
   getText: (context) => `


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

This PR adds the a direct link to the SudoSOS website in the debt notification message. This way, users can quickly top-up.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
None

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Documentation improvement

---

## ✅ PR Checklist

- [ ] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [ ] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [ ] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB

## 🔗 Additional Notes
<!-- Any additional information that reviewers should know -->