### PR TITLE
Upgrade to TypeORM 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Back-end API and database management for SudoSOS.",
   "main": "out/index.js",
   "packageManager": "pnpm@10.33.0",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "build": "tsc",
     "watch": "nodemon --watch \"src/**\" --ext \"ts,json\" --exec \"ts-node src/index.ts\"",
@@ -75,7 +78,7 @@
     "stripe": "16.12.0",
     "swagger-model-validator": "3.0.21",
     "swagger-ui-express": "5.0.1",
-    "typeorm": "0.3.29",
+    "typeorm": "1.0.0",
     "uuid": "10.0.0",
     "validator": "13.15.35",
     "vitepress-theme-openapi": "0.0.3-alpha.34"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: 5.0.1
         version: 5.0.1(express@4.22.2)
       typeorm:
-        specifier: 0.3.29
-        version: 0.3.29(better-sqlite3@12.10.0)(ioredis@5.10.1)(mysql2@3.22.4(@types/node@20.19.41))(sqlite3@5.1.7)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.41)(typescript@5.9.3))
+        specifier: 1.0.0
+        version: 1.0.0(better-sqlite3@12.10.0)(ioredis@5.10.1)(mysql2@3.22.4(@types/node@20.19.41))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.41)(typescript@5.9.3))
       uuid:
         specifier: 10.0.0
         version: 10.0.0
@@ -720,9 +720,6 @@ packages:
   '@floating-ui/vue@1.1.11':
     resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
 
-  '@gar/promisify@1.1.3':
-    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
-
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
@@ -851,17 +848,9 @@ packages:
     resolution: {integrity: sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  '@npmcli/fs@1.1.1':
-    resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
-
   '@npmcli/fs@3.1.1':
     resolution: {integrity: sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  '@npmcli/move-file@1.1.2':
-    resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
-    engines: {node: '>=10'}
-    deprecated: This functionality has been moved to @npmcli/fs
 
   '@opencensus/core@0.0.8':
     resolution: {integrity: sha512-yUFT59SFhGMYQgX0PhoTR0LBff2BEhPrD9io1jWfF/VDbakRfs6Pq60rjv0Z7iaTav5gQlttJCX2+VPxFWCuoQ==}
@@ -1232,10 +1221,6 @@ packages:
     resolution: {integrity: sha512-b5jPluAR6U3eOq6GWAYSpj3ugnAIZgGR0e6aGAgyRse0Yu6MVQQ0ZWm9SArSXWtageogn6bkVD8D//c4IjW3xQ==}
     peerDependencies:
       vue: ^2.7.0 || ^3.0.0
-
-  '@tootallnate/once@1.1.2':
-    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
-    engines: {node: '>= 6'}
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
@@ -1735,10 +1720,6 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
-
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
@@ -1802,10 +1783,6 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  app-root-path@3.1.0:
-    resolution: {integrity: sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==}
-    engines: {node: '>= 6.0.0'}
-
   aproba@1.2.0:
     resolution: {integrity: sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==}
 
@@ -1819,11 +1796,6 @@ packages:
   are-we-there-yet@2.0.0:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer supported.
-
-  are-we-there-yet@3.0.1:
-    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
   arg@4.1.3:
@@ -2003,9 +1975,6 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
-  buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
-
   bullmq@5.77.6:
     resolution: {integrity: sha512-WCpSoCD4vWyRD+btOsFrO7iBGInrTgG155gTZCV8qY0Yex2KtsbVtFERx6V1WZ2xWl/5ZxnLar8Z8ufnS4f5jg==}
     engines: {node: '>=12.22.0'}
@@ -2026,10 +1995,6 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
-
-  cacache@15.3.0:
-    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
-    engines: {node: '>= 10'}
 
   cacache@18.0.4:
     resolution: {integrity: sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==}
@@ -2147,6 +2112,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -2670,6 +2639,9 @@ packages:
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -2956,6 +2928,15 @@ packages:
   fclone@1.0.11:
     resolution: {integrity: sha512-GDqVQezKzRABdeqflsgMr7ktzgF9CyS+p2oe0jJqUY6izSSbhPIQJDpoU4PtGcD7VPM9xh/dVrTu6z1nwgmEGw==}
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -3066,11 +3047,6 @@ packages:
     engines: {node: '>=10'}
     deprecated: This package is no longer supported.
 
-  gauge@4.0.4:
-    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    deprecated: This package is no longer supported.
-
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
 
@@ -3081,6 +3057,10 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
 
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
@@ -3226,10 +3206,6 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
-  http-proxy-agent@4.0.1:
-    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
-    engines: {node: '>= 6'}
-
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -3241,9 +3217,6 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
-
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -3290,9 +3263,6 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
-  infer-owner@1.0.4:
-    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
-
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -3324,10 +3294,6 @@ packages:
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
-    engines: {node: '>= 12'}
-
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ip-regex@2.1.0:
@@ -3736,10 +3702,6 @@ packages:
     resolution: {integrity: sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  make-fetch-happen@9.1.0:
-    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
-    engines: {node: '>= 10'}
-
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
 
@@ -3845,17 +3807,9 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass-collect@1.0.2:
-    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
-    engines: {node: '>= 8'}
-
   minipass-collect@2.0.1:
     resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minipass-fetch@1.4.1:
-    resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
-    engines: {node: '>=8'}
 
   minipass-fetch@3.0.5:
     resolution: {integrity: sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==}
@@ -3997,9 +3951,6 @@ packages:
   node-addon-api@5.1.0:
     resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
 
-  node-addon-api@7.1.1:
-    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
-
   node-cron@3.0.3:
     resolution: {integrity: sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==}
     engines: {node: '>=6.0.0'}
@@ -4024,11 +3975,6 @@ packages:
   node-gyp@10.3.1:
     resolution: {integrity: sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
-    hasBin: true
-
-  node-gyp@8.4.1:
-    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
-    engines: {node: '>= 10.12.0'}
     hasBin: true
 
   node-pre-gyp@0.17.0:
@@ -4081,11 +4027,6 @@ packages:
 
   npmlog@5.0.1:
     resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
-    deprecated: This package is no longer supported.
-
-  npmlog@6.0.2:
-    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
   nssocket@0.6.0:
@@ -4342,14 +4283,6 @@ packages:
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-
-  promise-inflight@1.0.1:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
 
   promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
@@ -4626,11 +4559,6 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  sha.js@2.4.12:
-    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
-    engines: {node: '>= 0.10'}
-    hasBin: true
-
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -4716,20 +4644,12 @@ packages:
     resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
     engines: {node: '>=10.2.0'}
 
-  socks-proxy-agent@6.2.1:
-    resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
-    engines: {node: '>= 10'}
-
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
 
   socks@2.8.7:
     resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-
-  socks@2.8.9:
-    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sort-any@4.0.7:
@@ -4768,16 +4688,9 @@ packages:
     resolution: {integrity: sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA==}
     engines: {node: '>=14'}
 
-  sqlite3@5.1.7:
-    resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
-
   ssri@10.0.6:
     resolution: {integrity: sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  ssri@8.0.1:
-    resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
-    engines: {node: '>= 8'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -4818,6 +4731,10 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
 
   string.prototype.trim@1.2.10:
     resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
@@ -4971,6 +4888,10 @@ packages:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4982,10 +4903,6 @@ packages:
   tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
-
-  to-buffer@1.2.2:
-    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
-    engines: {node: '>= 0.4'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -5129,27 +5046,26 @@ packages:
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
 
-  typeorm@0.3.29:
-    resolution: {integrity: sha512-wwPEX/df4l72gCmOsrs0otJZYLGA9lLQkUZCkukbsymEycV4zXv2KM7wU7v2r8L01TaCgY9ApSSqHQWBOUhEoQ==}
-    engines: {node: '>=16.13.0'}
+  typeorm@1.0.0:
+    resolution: {integrity: sha512-2mSKNqucP8vo+xQLP59xlHUcqLvG6qajxA7q7tnhJgeZjTrA6lK/Ar7LRyiAxdXhyXmGbIPsArPmcUB9Xg+M7w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.11.0}
     hasBin: true
     peerDependencies:
-      '@google-cloud/spanner': ^5.18.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      '@google-cloud/spanner': ^8.0.0
       '@sap/hana-client': ^2.14.22
-      better-sqlite3: ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0
+      better-sqlite3: ^12.0.0
       ioredis: 5.10.1
-      mongodb: ^5.8.0 || ^6.0.0
-      mssql: ^9.1.1 || ^10.0.0 || ^11.0.0 || ^12.0.0
-      mysql2: ^2.2.5 || ^3.0.1
+      mongodb: ^7.0.0
+      mssql: ^12.0.0
+      mysql2: ^3.15.3
       oracledb: ^6.3.0
       pg: ^8.5.1
       pg-native: ^3.0.0
       pg-query-stream: ^4.0.0
-      redis: ^3.1.1 || ^4.0.0 || ^5.0.14
+      redis: ^5.0.0
       sql.js: ^1.4.0
-      sqlite3: ^5.0.3
-      ts-node: ^10.7.0
-      typeorm-aurora-data-api-driver: ^2.0.0 || ^3.0.0
+      ts-node: ^10.9.2
+      typeorm-aurora-data-api-driver: ^3.0.0
     peerDependenciesMeta:
       '@google-cloud/spanner':
         optional: true
@@ -5176,8 +5092,6 @@ packages:
       redis:
         optional: true
       sql.js:
-        optional: true
-      sqlite3:
         optional: true
       ts-node:
         optional: true
@@ -5207,15 +5121,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  unique-filename@1.1.1:
-    resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
-
   unique-filename@3.0.0:
     resolution: {integrity: sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  unique-slug@2.0.2:
-    resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
 
   unique-slug@4.0.0:
     resolution: {integrity: sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==}
@@ -5484,6 +5392,10 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -5549,6 +5461,10 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
@@ -5556,6 +5472,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
@@ -6008,9 +5928,6 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@gar/promisify@1.1.3':
-    optional: true
-
   '@gerrit0/mini-shiki@3.23.0':
     dependencies:
       '@shikijs/engine-oniguruma': 3.23.0
@@ -6164,21 +6081,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@npmcli/fs@1.1.1':
-    dependencies:
-      '@gar/promisify': 1.1.3
-      semver: 7.8.1
-    optional: true
-
   '@npmcli/fs@3.1.1':
     dependencies:
       semver: 7.8.1
-
-  '@npmcli/move-file@1.1.2':
-    dependencies:
-      mkdirp: 1.0.4
-      rimraf: 3.0.2
-    optional: true
 
   '@opencensus/core@0.0.8':
     dependencies:
@@ -6560,9 +6465,6 @@ snapshots:
     dependencies:
       '@tanstack/virtual-core': 3.13.23
       vue: 3.5.32(typescript@5.9.3)
-
-  '@tootallnate/once@1.1.2':
-    optional: true
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
@@ -7151,11 +7053,6 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
-    optional: true
-
   aggregate-error@3.1.0:
     dependencies:
       clean-stack: 2.2.0
@@ -7230,8 +7127,6 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
-  app-root-path@3.1.0: {}
-
   aproba@1.2.0: {}
 
   aproba@2.1.0: {}
@@ -7245,12 +7140,6 @@ snapshots:
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.2
-
-  are-we-there-yet@3.0.1:
-    dependencies:
-      delegates: 1.0.0
-      readable-stream: 3.6.2
-    optional: true
 
   arg@4.1.3: {}
 
@@ -7457,11 +7346,6 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  buffer@6.0.3:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
   bullmq@5.77.6:
     dependencies:
       cron-parser: 4.9.0
@@ -7480,30 +7364,6 @@ snapshots:
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
-
-  cacache@15.3.0:
-    dependencies:
-      '@npmcli/fs': 1.1.1
-      '@npmcli/move-file': 1.1.2
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      glob: 7.2.3
-      infer-owner: 1.0.4
-      lru-cache: 6.0.0
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-flush: 1.0.7
-      minipass-pipeline: 1.2.4
-      mkdirp: 1.0.4
-      p-map: 4.0.0
-      promise-inflight: 1.0.1
-      rimraf: 3.0.2
-      ssri: 8.0.1
-      tar: 6.2.1
-      unique-filename: 1.1.1
-    transitivePeerDependencies:
-      - bluebird
-    optional: true
 
   cacache@18.0.4:
     dependencies:
@@ -7654,6 +7514,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   clsx@2.1.1: {}
 
@@ -8136,6 +8002,8 @@ snapshots:
 
   emoji-regex-xs@1.0.0: {}
 
+  emoji-regex@10.6.0: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -8574,6 +8442,10 @@ snapshots:
 
   fclone@1.0.11: {}
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -8715,18 +8587,6 @@ snapshots:
       strip-ansi: 6.0.1
       wide-align: 1.1.5
 
-  gauge@4.0.4:
-    dependencies:
-      aproba: 2.1.0
-      color-support: 1.1.3
-      console-control-strings: 1.1.0
-      has-unicode: 2.0.1
-      signal-exit: 3.0.7
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wide-align: 1.1.5
-    optional: true
-
   generate-function@2.3.1:
     dependencies:
       is-property: 1.0.2
@@ -8734,6 +8594,8 @@ snapshots:
   generator-function@2.0.1: {}
 
   get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
 
   get-func-name@2.0.2: {}
 
@@ -8914,15 +8776,6 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@4.0.1:
-    dependencies:
-      '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2
-      debug: 4.4.3(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -8943,11 +8796,6 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
-
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
-    optional: true
 
   husky@9.1.7: {}
 
@@ -8983,9 +8831,6 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
-
-  infer-owner@1.0.4:
-    optional: true
 
   inflight@1.0.6:
     dependencies:
@@ -9023,9 +8868,6 @@ snapshots:
       - supports-color
 
   ip-address@10.1.0: {}
-
-  ip-address@10.2.0:
-    optional: true
 
   ip-regex@2.1.0: {}
 
@@ -9433,29 +9275,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  make-fetch-happen@9.1.0:
-    dependencies:
-      agentkeepalive: 4.6.0
-      cacache: 15.3.0
-      http-cache-semantics: 4.2.0
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.1
-      is-lambda: 1.0.1
-      lru-cache: 6.0.0
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-fetch: 1.4.1
-      minipass-flush: 1.0.7
-      minipass-pipeline: 1.2.4
-      negotiator: 0.6.4
-      promise-retry: 2.0.1
-      socks-proxy-agent: 6.2.1
-      ssri: 8.0.1
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-    optional: true
-
   mark.js@8.11.1: {}
 
   markdown-it@14.1.1:
@@ -9575,23 +9394,9 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass-collect@1.0.2:
-    dependencies:
-      minipass: 3.3.6
-    optional: true
-
   minipass-collect@2.0.1:
     dependencies:
       minipass: 7.1.3
-
-  minipass-fetch@1.4.1:
-    dependencies:
-      minipass: 3.3.6
-      minipass-sized: 1.0.3
-      minizlib: 2.1.2
-    optionalDependencies:
-      encoding: 0.1.13
-    optional: true
 
   minipass-fetch@3.0.5:
     dependencies:
@@ -9740,9 +9545,6 @@ snapshots:
 
   node-addon-api@5.1.0: {}
 
-  node-addon-api@7.1.1:
-    optional: true
-
   node-cron@3.0.3:
     dependencies:
       uuid: 8.3.2
@@ -9779,23 +9581,6 @@ snapshots:
       which: 4.0.0
     transitivePeerDependencies:
       - supports-color
-
-  node-gyp@8.4.1:
-    dependencies:
-      env-paths: 2.2.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      make-fetch-happen: 9.1.0
-      nopt: 5.0.0
-      npmlog: 6.0.2
-      rimraf: 3.0.2
-      semver: 7.8.1
-      tar: 6.2.1
-      which: 2.0.2
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-    optional: true
 
   node-pre-gyp@0.17.0:
     dependencies:
@@ -9870,14 +9655,6 @@ snapshots:
       console-control-strings: 1.1.0
       gauge: 3.0.2
       set-blocking: 2.0.0
-
-  npmlog@6.0.2:
-    dependencies:
-      are-we-there-yet: 3.0.1
-      console-control-strings: 1.1.0
-      gauge: 4.0.4
-      set-blocking: 2.0.0
-    optional: true
 
   nssocket@0.6.0:
     dependencies:
@@ -10149,9 +9926,6 @@ snapshots:
   proc-log@4.2.0: {}
 
   process-nextick-args@2.0.1: {}
-
-  promise-inflight@1.0.1:
-    optional: true
 
   promise-retry@2.0.1:
     dependencies:
@@ -10504,12 +10278,6 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  sha.js@2.4.12:
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-      to-buffer: 1.2.2
-
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -10636,15 +10404,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  socks-proxy-agent@6.2.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3(supports-color@5.5.0)
-      socks: 2.8.9
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
@@ -10657,12 +10416,6 @@ snapshots:
     dependencies:
       ip-address: 10.1.0
       smart-buffer: 4.2.0
-
-  socks@2.8.9:
-    dependencies:
-      ip-address: 10.2.0
-      smart-buffer: 4.2.0
-    optional: true
 
   sort-any@4.0.7: {}
 
@@ -10687,27 +10440,9 @@ snapshots:
 
   sql-highlight@6.1.0: {}
 
-  sqlite3@5.1.7:
-    dependencies:
-      bindings: 1.5.0
-      node-addon-api: 7.1.1
-      prebuild-install: 7.1.3
-      tar: 6.2.1
-    optionalDependencies:
-      node-gyp: 8.4.1
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-    optional: true
-
   ssri@10.0.6:
     dependencies:
       minipass: 7.1.3
-
-  ssri@8.0.1:
-    dependencies:
-      minipass: 3.3.6
-    optional: true
 
   stackback@0.0.2: {}
 
@@ -10750,6 +10485,12 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
   string.prototype.trim@1.2.10:
@@ -10932,17 +10673,16 @@ snapshots:
 
   tinyexec@1.2.4: {}
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@1.1.1: {}
 
   tinyrainbow@1.2.0: {}
 
   tinyspy@3.0.2: {}
-
-  to-buffer@1.2.2:
-    dependencies:
-      isarray: 2.0.5
-      safe-buffer: 5.2.1
-      typed-array-buffer: 1.0.3
 
   to-regex-range@5.0.1:
     dependencies:
@@ -11124,28 +10864,22 @@ snapshots:
       typescript: 5.9.3
       yaml: 2.8.3
 
-  typeorm@0.3.29(better-sqlite3@12.10.0)(ioredis@5.10.1)(mysql2@3.22.4(@types/node@20.19.41))(sqlite3@5.1.7)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.41)(typescript@5.9.3)):
+  typeorm@1.0.0(better-sqlite3@12.10.0)(ioredis@5.10.1)(mysql2@3.22.4(@types/node@20.19.41))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.41)(typescript@5.9.3)):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 4.2.0
-      app-root-path: 3.1.0
-      buffer: 6.0.3
       dayjs: 1.11.21
       debug: 4.4.3(supports-color@5.5.0)
       dedent: 1.7.2
-      dotenv: 16.6.1
-      glob: 10.5.0
       reflect-metadata: 0.2.2
-      sha.js: 2.4.12
       sql-highlight: 6.1.0
+      tinyglobby: 0.2.17
       tslib: 2.8.1
-      uuid: 11.1.1
-      yargs: 17.7.2
+      yargs: 18.0.0
     optionalDependencies:
       better-sqlite3: 12.10.0
       ioredis: 5.10.1
       mysql2: 3.22.4(@types/node@20.19.41)
-      sqlite3: 5.1.7
       ts-node: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.41)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -11168,19 +10902,9 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  unique-filename@1.1.1:
-    dependencies:
-      unique-slug: 2.0.2
-    optional: true
-
   unique-filename@3.0.0:
     dependencies:
       unique-slug: 4.0.0
-
-  unique-slug@2.0.2:
-    dependencies:
-      imurmurhash: 0.1.4
-    optional: true
 
   unique-slug@4.0.0:
     dependencies:
@@ -11517,6 +11241,12 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   ws@7.5.10: {}
@@ -11549,6 +11279,8 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
+  yargs-parser@22.0.0: {}
+
   yargs@15.4.1:
     dependencies:
       cliui: 6.0.0
@@ -11572,6 +11304,15 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yn@3.1.1: {}
 

--- a/src/controller/authentication-controller.ts
+++ b/src/controller/authentication-controller.ts
@@ -188,7 +188,9 @@ export default class AuthenticationController extends BaseController {
         return;
       }
 
-      const pinAuthenticator = await PinAuthenticator.findOne({ where: { user: { id: user.id } }, relations: ['user'] });
+      const pinAuthenticator = await PinAuthenticator.findOne({ where: { user: { id: user.id } }, relations: {
+        user: true,
+      } });
       if (!pinAuthenticator) {
         res.status(403).json({
           message: 'Invalid credentials.',
@@ -298,7 +300,9 @@ export default class AuthenticationController extends BaseController {
         return;
       }
 
-      const localAuthenticator = await LocalAuthenticator.findOne({ where: { user: { id: user.id } }, relations: ['user'] });
+      const localAuthenticator = await LocalAuthenticator.findOne({ where: { user: { id: user.id } }, relations: {
+        user: true,
+      } });
       if (!localAuthenticator) {
         res.status(403).json({
           message: 'Invalid credentials.',

--- a/src/controller/banner-controller.ts
+++ b/src/controller/banner-controller.ts
@@ -226,7 +226,9 @@ export default class BannerController extends BaseController {
     const bannerId = parseInt(id, 10);
 
     try {
-      const banner = await Banner.findOne({ where: { id: bannerId }, relations: ['image'] });
+      const banner = await Banner.findOne({ where: { id: bannerId }, relations: {
+        image: true,
+      } });
       if (banner) {
         await this.fileService.uploadEntityImage(
           banner, file, req.token.user,

--- a/src/controller/container-controller.ts
+++ b/src/controller/container-controller.ts
@@ -351,7 +351,9 @@ export default class ContainerController extends BaseController {
    */
   static async getRelation(req: RequestWithToken): Promise<string> {
     const containerId = asNumber(req.params.id);
-    const container: Container = await Container.findOne({ where: { id: containerId }, relations: ['owner'] });
+    const container: Container = await Container.findOne({ where: { id: containerId }, relations: {
+      owner: true,
+    } });
 
     if (!container) return 'all';
     if (userTokenInOrgan(req, container.owner.id)) return 'organ';

--- a/src/controller/debtor-controller.ts
+++ b/src/controller/debtor-controller.ts
@@ -305,7 +305,9 @@ export default class DebtorController extends BaseController {
 
     try {
       const parsedId = Number.parseInt(id, 10);
-      const event = await FineHandoutEvent.findOne({ where: { id: parsedId }, relations: ['fines'] });
+      const event = await FineHandoutEvent.findOne({ where: { id: parsedId }, relations: {
+        fines: true,
+      } });
       if (event == null) {
         res.status(404).send();
         return;

--- a/src/controller/event-controller.ts
+++ b/src/controller/event-controller.ts
@@ -335,7 +335,10 @@ export default class EventController extends BaseController {
 
     try {
       const parsedId = Number.parseInt(id, 10);
-      const event = await Event.findOne({ where: { id: parsedId }, relations: ['answers', 'shifts'] });
+      const event = await Event.findOne({ where: { id: parsedId }, relations: {
+        answers: true,
+        shifts: true,
+      } });
       if (event == null) {
         res.status(404).send();
         return;
@@ -374,7 +377,9 @@ export default class EventController extends BaseController {
     let shiftId = Number.parseInt(rawShiftId, 10);
     let userId = Number.parseInt(rawUserId, 10);
     try {
-      const answer = await EventShiftAnswer.findOne({ where: { eventId, shiftId, userId }, relations: ['event'] });
+      const answer = await EventShiftAnswer.findOne({ where: { eventId, shiftId, userId }, relations: {
+        event: true,
+      } });
       if (answer == null) {
         res.status(404).send();
         return;
@@ -427,7 +432,9 @@ export default class EventController extends BaseController {
     let shiftId = Number.parseInt(rawShiftId, 10);
     let eventId = Number.parseInt(rawEventId, 10);
     try {
-      const answer = await EventShiftAnswer.findOne({ where: { eventId, shiftId, userId }, relations: ['event'] });
+      const answer = await EventShiftAnswer.findOne({ where: { eventId, shiftId, userId }, relations: {
+        event: true,
+      } });
       if (answer == null) {
         res.status(404).send();
         return;

--- a/src/controller/invoice-controller.ts
+++ b/src/controller/invoice-controller.ts
@@ -441,7 +441,9 @@ export default class InvoiceController extends BaseController {
         return;
       }
 
-      const invoiceUser = await InvoiceUser.findOne({ where: { userId }, relations: ['user'] });
+      const invoiceUser = await InvoiceUser.findOne({ where: { userId }, relations: {
+        user: true,
+      } });
       if (!invoiceUser) {
         res.status(404).json('Invoice User not found.');
         return;
@@ -567,7 +569,9 @@ export default class InvoiceController extends BaseController {
    * @return whether invoice is connected to used token
    */
   static async getRelation(req: RequestWithToken): Promise<string> {
-    const invoice: Invoice = await Invoice.findOne({ where: { id: parseInt(req.params.id, 10) }, relations: ['to'] });
+    const invoice: Invoice = await Invoice.findOne({ where: { id: parseInt(req.params.id, 10) }, relations: {
+      to: true,
+    } });
     if (!invoice) return 'all';
     if (invoice.to.id === req.token.user.id) return 'own';
     return 'all';

--- a/src/controller/member-authentication-secure-controller.ts
+++ b/src/controller/member-authentication-secure-controller.ts
@@ -111,7 +111,9 @@ export default class MemberAuthenticationSecureController extends BaseController
       // Look up the member user by memberId
       const memberUser = await MemberUser.findOne({
         where: { memberId: body.memberId },
-        relations: ['user'],
+        relations: {
+          user: true,
+        },
       });
 
       if (!memberUser) {

--- a/src/controller/payout-request-controller.ts
+++ b/src/controller/payout-request-controller.ts
@@ -98,7 +98,9 @@ export default class PayoutRequestController extends BaseController {
     }
 
     const { id } = req.params;
-    const payoutRequest = await PayoutRequest.findOne({ where: { id: parseInt(id, 10) }, relations: ['requestedBy'] });
+    const payoutRequest = await PayoutRequest.findOne({ where: { id: parseInt(id, 10) }, relations: {
+      requestedBy: true,
+    } });
     return (payoutRequest != null && payoutRequest.requestedBy.id === req.token.user.id) ? 'own' : 'all';
   }
 
@@ -304,7 +306,11 @@ export default class PayoutRequestController extends BaseController {
 
     try {
       const force = !!asBoolean(req.query.force);
-      const payoutRequest = await PayoutRequest.findOne({ where: { id: payoutRequestId }, relations: ['requestedBy', 'approvedBy', 'payoutRequestStatus'] });
+      const payoutRequest = await PayoutRequest.findOne({ where: { id: payoutRequestId }, relations: {
+        requestedBy: true,
+        approvedBy: true,
+        payoutRequestStatus: true,
+      } });
       if (!payoutRequest) {
         res.status(404).json('Unknown payout request ID.');
         return;

--- a/src/controller/point-of-sale-controller.ts
+++ b/src/controller/point-of-sale-controller.ts
@@ -224,7 +224,7 @@ export default class PointOfSaleController extends BaseController {
     try {
       const pointOfSaleId = parseInt(id, 10);
       // Check if point of sale exists.
-      if (!await PointOfSale.findOne({ where: { id: pointOfSaleId } })) {
+      if (!(await PointOfSale.findOne({ where: { id: pointOfSaleId } }))) {
         res.status(404).json('Point of Sale not found.');
         return;
       }
@@ -261,7 +261,7 @@ export default class PointOfSaleController extends BaseController {
       const pointOfSaleRevision = parseInt(revision, 10);
 
       // Check if point of sale exists.
-      if (!await PointOfSale.findOne({ where: { id: pointOfSaleId } })) {
+      if (!(await PointOfSale.findOne({ where: { id: pointOfSaleId } }))) {
         res.status(404).json('Point of Sale not found.');
         return;
       }
@@ -418,7 +418,7 @@ export default class PointOfSaleController extends BaseController {
     // handle request
     try {
       // Point of sale does not exist.
-      if (!await PointOfSale.findOne({ where: { id: pointOfSaleId } })) {
+      if (!(await PointOfSale.findOne({ where: { id: pointOfSaleId } }))) {
         res.status(404).json('Point of Sale not found.');
         return;
       }
@@ -465,7 +465,9 @@ export default class PointOfSaleController extends BaseController {
       // Get organ memberships with indices
       const organMemberships = await OrganMembership.find({
         where: { organId: pos.owner.id },
-        relations: ['user'],
+        relations: {
+          user: true,
+        },
       });
 
       // Get cashiers (no indices needed)
@@ -559,7 +561,10 @@ export default class PointOfSaleController extends BaseController {
    */
   static async getRelation(req: RequestWithToken): Promise<string> {
     const pointOfSaleId = asNumber(req.params.id);
-    const pos: PointOfSale = await PointOfSale.findOne({ where: { id: pointOfSaleId }, relations: ['owner', 'user'] });
+    const pos: PointOfSale = await PointOfSale.findOne({ where: { id: pointOfSaleId }, relations: {
+      owner: true,
+      user: true,
+    } });
 
     if (!pos) return 'all';
     if (userTokenInOrgan(req, pos.owner.id)) return 'organ';

--- a/src/controller/product-controller.ts
+++ b/src/controller/product-controller.ts
@@ -305,7 +305,9 @@ export default class ProductController extends BaseController {
 
     // handle request
     try {
-      const product = await Product.findOne({ where: { id: productId }, relations: ['image'] });
+      const product = await Product.findOne({ where: { id: productId }, relations: {
+        image: true,
+      } });
       if (product) {
         await this.fileService.uploadEntityImage(
           product, file, req.token.user,
@@ -379,7 +381,9 @@ export default class ProductController extends BaseController {
    */
   static async getRelation(req: RequestWithToken): Promise<string> {
     const productId = asNumber(req.params.id);
-    const product = await Product.findOne({ where: { id: productId }, relations: ['owner'] });
+    const product = await Product.findOne({ where: { id: productId }, relations: {
+      owner: true,
+    } });
     if (product && product.owner.id === req.token.user.id) return 'own';
     if (product && userTokenInOrgan(req, product.owner.id)) return 'organ';
     return 'all';

--- a/src/controller/request/validators/invoice-request-spec.ts
+++ b/src/controller/request/validators/invoice-request-spec.ts
@@ -86,7 +86,9 @@ async function validTransactionIds<T extends BaseInvoice>(p: T) {
  * @param p
  */
 async function existsAndNotPaidOrDeleted<T extends UpdateInvoiceParams>(p: T) {
-  const base: Invoice = await Invoice.findOne({ where: { id: p.invoiceId }, relations: ['invoiceStatus'] });
+  const base: Invoice = await Invoice.findOne({ where: { id: p.invoiceId }, relations: {
+    invoiceStatus: true,
+  } });
 
   if (!base) return toFail(INVALID_INVOICE_ID());
   const current = base.invoiceStatus.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())[base.invoiceStatus.length - 1].state;
@@ -107,7 +109,9 @@ async function existsAndNotPaidOrDeleted<T extends UpdateInvoiceParams>(p: T) {
 async function differentState<T extends UpdateInvoiceParams>(p: T) {
   if (!p.state) return toPass(p);
 
-  const base: Invoice = await Invoice.findOne({ where: { id: p.invoiceId }, relations: ['invoiceStatus'] });
+  const base: Invoice = await Invoice.findOne({ where: { id: p.invoiceId }, relations: {
+    invoiceStatus: true,
+  } });
   if (base.invoiceStatus[base.invoiceStatus.length - 1].state === p.state) {
     return toFail(SAME_INVOICE_STATE());
   }

--- a/src/controller/transaction-controller.ts
+++ b/src/controller/transaction-controller.ts
@@ -182,7 +182,7 @@ export default class TransactionController extends BaseController {
     try {
       // Verify POS token for lesser tokens
       if (req.token.posId) {
-        if (!await POSTokenVerifier.verify(req, body.pointOfSale.id)) {
+        if (!(await POSTokenVerifier.verify(req, body.pointOfSale.id))) {
           res.status(403).end('Invalid POS token.');
           return;
         }
@@ -202,7 +202,7 @@ export default class TransactionController extends BaseController {
       const fromUser = context.users.get(body.from)!;
 
       // verify balance if user cannot have negative balance, using cached total cost
-      if (!fromUser.canGoIntoDebt && !await transactionService.verifyBalance(body, context.totalCost)) {
+      if (!fromUser.canGoIntoDebt && !(await transactionService.verifyBalance(body, context.totalCost))) {
         res.status(403).json('Insufficient balance.');
         return;
       }
@@ -375,7 +375,7 @@ export default class TransactionController extends BaseController {
     try {
       // Verify POS token for lesser tokens
       if (req.token.posId) {
-        if (!await POSTokenVerifier.verify(req, body.pointOfSale.id)) {
+        if (!(await POSTokenVerifier.verify(req, body.pointOfSale.id))) {
           res.status(403).end('Invalid POS token.');
           return;
         }
@@ -411,7 +411,10 @@ export default class TransactionController extends BaseController {
     this.logger.trace('Get transaction PDF', id, 'by user', req.token.user);
 
     try {
-      const transaction = await Transaction.findOne({ where: { id: transactionId }, relations: ['from', 'createdBy']  });
+      const transaction = await Transaction.findOne({ where: { id: transactionId }, relations: {
+        from: true,
+        createdBy: true,
+      }  });
       if (!transaction) {
         res.status(404).json('Transaction not found.');
         return;
@@ -455,9 +458,9 @@ export default class TransactionController extends BaseController {
 
       // Check organ relation
       if (
-        (fromId && await UserService.areInSameOrgan(userId, fromId)) ||
-          (toId && await UserService.areInSameOrgan(userId, toId)) ||
-          (createdById && await UserService.areInSameOrgan(userId, createdById))
+        (fromId && (await UserService.areInSameOrgan(userId, fromId))) ||
+          (toId && (await UserService.areInSameOrgan(userId, toId))) ||
+          (createdById && (await UserService.areInSameOrgan(userId, createdById)))
       ) {
         return 'organ';
       }
@@ -499,7 +502,16 @@ export default class TransactionController extends BaseController {
   static async getRelation(req: RequestWithToken): Promise<string> {
     const transaction = await Transaction.findOne({
       where: { id: asNumber(req.params.id) },
-      relations: ['from', 'createdBy', 'pointOfSale', 'pointOfSale.pointOfSale', 'pointOfSale.pointOfSale.owner'],
+      relations: {
+        from: true,
+        createdBy: true,
+
+        pointOfSale: {
+          pointOfSale: {
+            owner: true,
+          },
+        },
+      },
     });
     if (!transaction) return 'all';
     if (userTokenInOrgan(req, transaction.from.id)

--- a/src/controller/transfer-controller.ts
+++ b/src/controller/transfer-controller.ts
@@ -108,7 +108,10 @@ export default class TransferController extends BaseController {
    * @return whether transaction is connected to used token
    */
   static async getRelation(req: RequestWithToken): Promise<string> {
-    const transfer = await Transfer.findOne({ where: { id: parseInt(req.params.id, 10) }, relations: ['to', 'from'] });
+    const transfer = await Transfer.findOne({ where: { id: parseInt(req.params.id, 10) }, relations: {
+      to: true,
+      from: true,
+    } });
     if (!transfer) return 'all';
     const fromId = transfer.from != null ? transfer.from.id : undefined;
     const toId = transfer.to != null ? transfer.to.id : undefined;

--- a/src/controller/user-notification-preference-controller.ts
+++ b/src/controller/user-notification-preference-controller.ts
@@ -241,7 +241,9 @@ export default class UserNotificationController extends BaseController {
 
     const preference = await UserNotificationPreference.findOne({
       where: { id: asNumber(req.params.id) },
-      relations: ['user'],
+      relations: {
+        user: true,
+      },
     });
 
     if (!preference) return 'all';

--- a/src/controller/write-off-controller.ts
+++ b/src/controller/write-off-controller.ts
@@ -208,7 +208,9 @@ export default class WriteOffController extends BaseController {
 
     try {
       const force = !!asBoolean(req.query.force);
-      const writeOff = await WriteOff.findOne({ where: { id: writeOffId }, relations: ['transfer'] });
+      const writeOff = await WriteOff.findOne({ where: { id: writeOffId }, relations: {
+        transfer: true,
+      } });
       if (!writeOff) {
         res.status(404).json('Write Off not found.');
         return;

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -142,6 +142,17 @@ function getDataSourceOptions(): DataSourceOptions {
     } : {}),
     synchronize: config.database.synchronize,
     logging: config.database.logging,
+    // TypeORM 1.0 changed the default of `invalidWhereValuesBehavior` from
+    // "silently skip" to "throw". Two patterns in this codebase rely on the
+    // older behavior:
+    //  - `undefined`: services like QueryFilter.createFilterWhereDate return
+    //    undefined when a date param is absent, and the resulting key is
+    //    expected to be ignored.
+    //  - `null` (-> `sql-null`): TypeORM's own internal soft-delete handling
+    //    generates `deletedAt: null` predicates on relations to entities with
+    //    @DeleteDateColumn; under the new default these throw. Translating
+    //    null to SQL IS NULL preserves the original filtering semantics.
+    invalidWhereValuesBehavior: { undefined: 'ignore', null: 'sql-null' },
     migrations: [
       InitialSQLMigration1743601882766,
       QrAuthenticator1743601882766,

--- a/src/entity/invoices/invoice.ts
+++ b/src/entity/invoices/invoice.ts
@@ -23,8 +23,11 @@
  *
  * ```ts
  * const invoice = await this.manager.findOne(Invoice, {
- *    where: { id: invoiceId }, relations: ['transfer', 'transfer.from',
- *   'invoiceStatus', 'invoiceStatus.changedBy']
+ *   where: { id: invoiceId },
+ *   relations: {
+ *     transfer: { from: true },
+ *     invoiceStatus: { changedBy: true },
+ *   },
  * });
  * ```
  *

--- a/src/gewis/gewis.ts
+++ b/src/gewis/gewis.ts
@@ -49,7 +49,9 @@ export default class Gewis extends WithManager {
     try {
       const memberId = asNumber(ADUser.mNumber);
       // Check if Member User already exists.
-      memberUser = await MemberUser.findOne({ where: { memberId }, relations: ['user'] });
+      memberUser = await MemberUser.findOne({ where: { memberId }, relations: {
+        user: true,
+      } });
       if (memberUser) {
         // If user exists we only have to bind the AD user
         await bindUser(this.manager, ADUser, memberUser.user);

--- a/src/gewis/service/gewisdb-sync-service.ts
+++ b/src/gewis/service/gewisdb-sync-service.ts
@@ -61,9 +61,11 @@ export default class GewisDBSyncService extends UserSyncService {
   }
 
   async guard(entity: User): Promise<boolean> {
-    if (!await super.guard(entity)) return false;
+    if (!(await super.guard(entity))) return false;
     
-    const memberUser = await this.manager.findOne(MemberUser, { where: { user: { id: entity.id } }, relations: ['user'] });
+    const memberUser = await this.manager.findOne(MemberUser, { where: { user: { id: entity.id } }, relations: {
+      user: true,
+    } });
     return !!memberUser;
   }
 
@@ -76,7 +78,9 @@ export default class GewisDBSyncService extends UserSyncService {
   }
 
   async sync(entity: User, isDryRun: boolean = false): Promise<boolean> {
-    const memberUser = await this.manager.findOne(MemberUser, { where: { user: { id: entity.id } }, relations: ['user'] });
+    const memberUser = await this.manager.findOne(MemberUser, { where: { user: { id: entity.id } }, relations: {
+      user: true,
+    } });
     if (!memberUser) {
       throw new Error('Member User not found.');
     }
@@ -127,7 +131,7 @@ export default class GewisDBSyncService extends UserSyncService {
     // await this.manager.delete(MemberUser, memberUser);
 
     // Sync deleting a user is quite impactful, so we only do it if the setting is explicitly set.
-    if (!await GewisDBSyncService.getAllowDelete()) return;
+    if (!(await GewisDBSyncService.getAllowDelete())) return;
 
     const currentBalance = await new BalanceService().getBalance(entity.id);
     const shouldDelete = currentBalance.amount.amount === 0;

--- a/src/notifications/notifier.ts
+++ b/src/notifications/notifier.ts
@@ -109,7 +109,9 @@ export default class Notifier {
   private async getPreferences(user: User, notifyType: NotificationTypes): Promise<string[]> {
     const preferences = await UserNotificationPreference.find({
       where: { userId: user.id, type: notifyType, enabled: true },
-      select: ['channel'],
+      select: {
+        channel: true,
+      },
     });
 
     return preferences.map(p => p.channel);

--- a/src/rbac/role-manager.ts
+++ b/src/rbac/role-manager.ts
@@ -127,7 +127,9 @@ export default class RoleManager {
    * @param user
    */
   public async getUserOrgans(user: User) {
-    const organs = (await OrganMembership.find({ where: { user: { id: user.id } }, relations: ['organ'] })).map((organ) => organ.organ);
+    const organs = (await OrganMembership.find({ where: { user: { id: user.id } }, relations: {
+      organ: true,
+    } })).map((organ) => organ.organ);
     return organs.filter((organ) => organ.type === UserType.ORGAN);
   }
 

--- a/src/service/ad-service.ts
+++ b/src/service/ad-service.ts
@@ -112,7 +112,9 @@ export default class ADService extends WithManager {
     if (createIfNew) await this.createAccountIfNew(ldapUsers);
 
     const uuids = ldapUsers.map((u) => (u.objectGUID));
-    const authenticators = await this.manager.find(LDAPAuthenticator, { where: { UUID: In(uuids) }, relations: ['user'] });
+    const authenticators = await this.manager.find(LDAPAuthenticator, { where: { UUID: In(uuids) }, relations: {
+      user: true,
+    } });
 
     return authenticators.map((u) => u.user);
   }
@@ -123,7 +125,9 @@ export default class ADService extends WithManager {
    */
   async filterUnboundGUID(ldapResponses: LDAPResponse[]) {
     const ids = ldapResponses.map((s) => s.objectGUID);
-    const auths = await this.manager.find(LDAPAuthenticator, { where: { UUID: In(ids) }, relations: ['user'] });
+    const auths = await this.manager.find(LDAPAuthenticator, { where: { UUID: In(ids) }, relations: {
+      user: true,
+    } });
     const existing = auths.map((l: LDAPAuthenticator) => l.UUID);
 
     // Use Buffer.compare to filter out existing GUIDs
@@ -139,7 +143,9 @@ export default class ADService extends WithManager {
    * @param sharedAccount - Account to give access
    */
   async updateSharedAccountMembership(client: Client, sharedAccount: LDAPGroup): Promise<void> {
-    const auth = await LDAPAuthenticator.findOne({ where: { UUID: sharedAccount.objectGUID }, relations: ['user'] });
+    const auth = await LDAPAuthenticator.findOne({ where: { UUID: sharedAccount.objectGUID }, relations: {
+      user: true,
+    } });
     if (!auth) throw new Error('No authenticator found for shared account');
 
     // Get all the members of the shared account from AD

--- a/src/service/authentication-service.ts
+++ b/src/service/authentication-service.ts
@@ -26,7 +26,7 @@ import bcrypt from 'bcrypt';
 // @ts-ignore
 import { filter } from 'ldap-escape';
 import log4js, { Logger } from 'log4js';
-import { FindOptionsWhere, In } from 'typeorm';
+import { FindOptionsRelations, FindOptionsWhere, In } from 'typeorm';
 import { randomBytes } from 'crypto';
 import User, { LocalUserTypes, UserType } from '../entity/user/user';
 import JsonWebToken from '../authentication/json-web-token';
@@ -189,7 +189,9 @@ export default class AuthenticationService extends WithManager {
     });
     if (!user) return undefined;
 
-    const resetToken = await ResetToken.findOne({ where: { user: { id: user.id } }, relations: ['user'] });
+    const resetToken = await ResetToken.findOne({ where: { user: { id: user.id } }, relations: {
+      user: true,
+    } });
     if (!resetToken) return undefined;
 
     // Test if the hash matches the token
@@ -257,7 +259,10 @@ export default class AuthenticationService extends WithManager {
   public async setUserAuthenticationHash<T extends HashBasedAuthenticationMethod>(user: User,
     pass: string, Type: new () => T): Promise<T> {
     const repo = this.manager.getRepository(Type);
-    let authenticator = await repo.findOne({ where: { user: { id: user.id } } as FindOptionsWhere<T>, relations: ['user'] });
+    let authenticator = await repo.findOne({
+      where: { user: { id: user.id } } as FindOptionsWhere<T>,
+      relations: { user: true } as FindOptionsRelations<T>,
+    });
 
     // Use lower rounds for PIN authenticators
     const hash = (Type as any).IS_PIN_AUTHENTICATOR === true
@@ -283,7 +288,10 @@ export default class AuthenticationService extends WithManager {
   public async setUserAuthenticationNfc<T extends NfcAuthenticator>(user: User,
     nfcCode: string, Type: new () => T): Promise<T> {
     const repo = this.manager.getRepository(Type);
-    let authenticator = await repo.findOne({ where: { user: { id: user.id } } as FindOptionsWhere<T>, relations: ['user'] });
+    let authenticator = await repo.findOne({
+      where: { user: { id: user.id } } as FindOptionsWhere<T>,
+      relations: { user: true } as FindOptionsRelations<T>,
+    });
 
     if (authenticator) {
       // We only need to update the nfcCode
@@ -403,7 +411,9 @@ export default class AuthenticationService extends WithManager {
    * @param user
    */
   public async getMemberAuthenticators(user: User): Promise<User[]> {
-    const users = (await this.manager.find(OrganMembership, { where: { user: { id: user.id } }, relations: ['organ'] }))
+    const users = (await this.manager.find(OrganMembership, { where: { user: { id: user.id } }, relations: {
+      organ: true,
+    } }))
       .map((auth) => auth.organ);
 
     users.push(user);
@@ -553,7 +563,7 @@ export default class AuthenticationService extends WithManager {
     const roleNames = roles.map((r) => r.name);
     const overrideMaintenance = await context.roleManager.can(roleNames, 'override', 'all', 'Maintenance', ['*']);
     const contents = await this.makeJsonWebToken(user, roles, organs, overrideMaintenance, posId);
-    const finalSalt = salt || await bcrypt.genSalt(AuthenticationService.BCRYPT_ROUNDS);
+    const finalSalt = salt || (await bcrypt.genSalt(AuthenticationService.BCRYPT_ROUNDS));
     const token = await context.tokenHandler.signToken(contents, finalSalt, expiry);
 
     return { user: contents.user, roles, organs: contents.organs, token };

--- a/src/service/banner-service.ts
+++ b/src/service/banner-service.ts
@@ -138,7 +138,7 @@ export default class BannerService {
     const orderDirection = filters.order || 'DESC';
     const options: FindManyOptions = {
       where: whereClause,
-      relations: ['image'],
+      relations: { image: true },
       order: { startDate: orderDirection },
     };
 
@@ -182,7 +182,9 @@ export default class BannerService {
     // patch banner if found
     const banner = this.asBanner(bannerReq);
     await Banner.update(id, banner);
-    return Banner.findOne({ where: { id }, relations: ['image'] });
+    return Banner.findOne({ where: { id }, relations: {
+      image: true,
+    } });
   }
 
   /**
@@ -193,7 +195,9 @@ export default class BannerService {
    */
   public static async deleteBanner(id: number, fileService: FileService): Promise<Banner> {
     // check if banner in database
-    const banner = await Banner.findOne({ where: { id }, relations: ['image'] });
+    const banner = await Banner.findOne({ where: { id }, relations: {
+      image: true,
+    } });
 
     // return undefined if not found
     if (!banner) {

--- a/src/service/debtor-service.ts
+++ b/src/service/debtor-service.ts
@@ -244,7 +244,11 @@ export default class DebtorService extends WithManager {
   }: HandOutFinesParams, createdBy: User): Promise<FineHandoutEvent> {
     const previousFineGroup = (await this.manager.find(FineHandoutEvent, {
       order: { id: 'desc' },
-      relations: ['fines', 'fines.userFineGroup'],
+      relations: {
+        fines: {
+          userFineGroup: true,
+        },
+      },
       take: 1,
     }))[0];
 
@@ -267,7 +271,12 @@ export default class DebtorService extends WithManager {
       // Create and save the fine information
       let fines: Fine[] = await Promise.all(balanceRecords.map(async (b) => {
         const previousFine = previousFineGroup?.fines.find((fine) => fine.userFineGroup.userId === b.id);
-        const user = await manager.findOne(User, { where: { id: b.id }, relations: ['currentFines', 'currentFines.user', 'currentFines.fines'] });
+        const user = await manager.findOne(User, { where: { id: b.id }, relations: {
+          currentFines: {
+            user: true,
+            fines: true,
+          },
+        } });
         const amount = calculateFine(b.amount);
 
         let userFineGroup = user.currentFines;
@@ -343,7 +352,13 @@ export default class DebtorService extends WithManager {
    * @param id
    */
   public async deleteFine(id: number): Promise<void> {
-    const fine = await this.manager.findOne(Fine, { where: { id }, relations: ['transfer', 'userFineGroup', 'userFineGroup.fines'] });
+    const fine = await this.manager.findOne(Fine, { where: { id }, relations: {
+      transfer: true,
+
+      userFineGroup: {
+        fines: true,
+      },
+    } });
     if (fine == null) return;
 
     const { transfer, userFineGroup } = fine;

--- a/src/service/event-service.ts
+++ b/src/service/event-service.ts
@@ -133,7 +133,9 @@ export async function parseUpdateEventRequestParameters(
     // Check that every shift has at least 1 person to do the shift
     // First, get an array with tuples. The first item is the ID, the second whether the shift has any users.
     const shiftsWithUsers = await Promise.all(shifts.map(async (s) => {
-      const roles = await AssignedRole.find({ where: { role: { id: In(s.roles.map((r) => r.id)) } }, relations: ['user'] });
+      const roles = await AssignedRole.find({ where: { role: { id: In(s.roles.map((r) => r.id)) } }, relations: {
+        user: true,
+      } });
       return [s.id, roles.length > 0];
     }));
     // Then, apply a filter to only get the shifts without users
@@ -224,7 +226,7 @@ export default class EventService {
 
     const options: FindManyOptions<Event> = {
       where: QueryFilter.createFilterWhereClause(filterMapping, params),
-      relations: ['createdBy'],
+      relations: { createdBy: true },
       order: { startDate: 'desc' },
     };
 
@@ -300,7 +302,10 @@ export default class EventService {
         // Find the answer sheet in the database
         const dbAnswer = await EventShiftAnswer.findOne({
           where: { user: { id: user.id }, event: { id: event.id }, shift: { id: shift.id } },
-          relations: ['shift', 'user'],
+          relations: {
+            shift: true,
+            user: true,
+          },
         });
         // Return it if it exists. Otherwise create a new one
         if (dbAnswer != null) return dbAnswer;
@@ -470,7 +475,9 @@ export default class EventService {
     const [events] = await EventService.getEvents({ beforeDate: inThreeDays, afterDate: inTwoDays });
 
     await Promise.all(events.map(async (event) => {
-      const answers = await EventShiftAnswer.find({ where: { eventId: event.id, availability: IsNull() }, relations: ['user'] });
+      const answers = await EventShiftAnswer.find({ where: { eventId: event.id, availability: IsNull() }, relations: {
+        user: true,
+      } });
       // Get all users and remove duplicates
       const users = answers
         .map((a) => a.user)

--- a/src/service/invoice-service.ts
+++ b/src/service/invoice-service.ts
@@ -371,7 +371,9 @@ export default class InvoiceService extends WithManager {
     // Only load defaults for invoice users.
     if (!user || user.type !== UserType.INVOICE) return undefined;
 
-    const invoiceUser = await this.manager.findOne(InvoiceUser, { where: { userId }, relations: ['user'] });
+    const invoiceUser = await this.manager.findOne(InvoiceUser, { where: { userId }, relations: {
+      user: true,
+    } });
     if (!invoiceUser) return undefined;
 
     const addressee = `${user.firstName} ${user.lastName}`;

--- a/src/service/payout-request-service.ts
+++ b/src/service/payout-request-service.ts
@@ -235,7 +235,9 @@ export default class PayoutRequestService {
   ): Promise<PayoutRequest | undefined> {
     const payoutRequest = await PayoutRequest.findOne({
       where: { id },
-      relations: ['requestedBy'],
+      relations: {
+        requestedBy: true,
+      },
     });
 
     if (payoutRequest == null) throw Error(`PayoutRequest with ID ${id} does not exist`);

--- a/src/service/pdf/transaction-pdf-service.ts
+++ b/src/service/pdf/transaction-pdf-service.ts
@@ -38,14 +38,18 @@ export default class TransactionPdfService extends HtmlUnstoredPdfService<Transa
   async getParameters(entity: Transaction): Promise<ITransactionPdf> {
     const transaction = await this.manager.findOne(Transaction, {
       where: { id: entity.id },
-      relations: [
-        'from',
-        'createdBy',
-        'subTransactions',
-        'subTransactions.subTransactionRows',
-        'subTransactions.subTransactionRows.product',
-        'subTransactions.subTransactionRows.product.vat',
-      ],
+      relations: {
+        from: true,
+        createdBy: true,
+
+        subTransactions: {
+          subTransactionRows: {
+            product: {
+              vat: true,
+            },
+          },
+        },
+      },
     });
 
     if (!transaction) {

--- a/src/service/pdf/transfer-pdf-service.ts
+++ b/src/service/pdf/transfer-pdf-service.ts
@@ -45,7 +45,10 @@ export default class TransferPdfService extends HtmlUnstoredPdfService<Transfer,
   async getParameters(entity: Transfer): Promise<ITransferPdf> {
     const transfer = await this.manager.findOne(Transfer, {
       where: { id: entity.id },
-      relations: ['from', 'to'],
+      relations: {
+        from: true,
+        to: true,
+      },
     });
 
     if (!transfer) {

--- a/src/service/point-of-sale-service.ts
+++ b/src/service/point-of-sale-service.ts
@@ -159,12 +159,14 @@ export default class PointOfSaleService {
    */
   public static async updatePointOfSale(update: UpdatePointOfSaleParams): Promise<PointOfSaleRevision> {
     const base = await PointOfSale.findOne({ where: { id: update.id } });
-    const containers = await Container.findByIds(update.containers);
+    const containers = await Container.findBy({
+      id: In(update.containers),
+    });
 
     const containerIds: { revision: number, container: { id: number } }[] = (
       containers.map((container) => (
         ({ revision: container.currentRevision, container: { id: container.id } }))));
-    const containerRevisions: ContainerRevision[] = await ContainerRevision.findByIds(containerIds);
+    const containerRevisions: ContainerRevision[] = await ContainerRevision.find({ where: containerIds });
     const pointOfSaleRevision: PointOfSaleRevision = Object.assign(new PointOfSaleRevision(), {
       pointOfSale: base,
       containers: containerRevisions,

--- a/src/service/stripe-service.ts
+++ b/src/service/stripe-service.ts
@@ -36,7 +36,7 @@ import {
   StripePaymentIntentStatusResponse,
 } from '../controller/response/stripe-response';
 import TransferService from './transfer-service';
-import { EntityManager, IsNull } from 'typeorm';
+import { EntityManager, FindOptionsRelations, IsNull } from 'typeorm';
 import { parseUserToBaseResponse } from '../helpers/revision-to-response';
 import BalanceResponse from '../controller/response/balance-response';
 import { StripeRequest } from '../controller/request/stripe-request';
@@ -132,7 +132,9 @@ export default class StripeService extends WithManager {
           },
         },
       },
-      relations: ['to'],
+      relations: {
+        to: true,
+      },
     });
 
     return deposits.filter((d) => !d.stripePaymentIntent.paymentIntentStatuses.some(
@@ -140,10 +142,16 @@ export default class StripeService extends WithManager {
         || s.state === StripePaymentIntentState.FAILED));
   }
 
-  public static async getStripeDeposit(id: number, relations: string[] = []): Promise<StripeDeposit> {
+  public static async getStripeDeposit(
+    id: number,
+    relations: FindOptionsRelations<StripeDeposit> = {},
+  ): Promise<StripeDeposit> {
     return StripeDeposit.findOne({
       where: { id },
-      relations: ['stripePaymentIntent', 'stripePaymentIntent.paymentIntentStatuses'].concat(relations),
+      relations: {
+        stripePaymentIntent: { paymentIntentStatuses: true },
+        ...relations,
+      },
     });
   }
 

--- a/src/service/transaction-service.ts
+++ b/src/service/transaction-service.ts
@@ -438,7 +438,10 @@ export default class TransactionService extends WithManager {
         revision: req.pointOfSale.revision,
         pointOfSale: { id: req.pointOfSale.id, deletedAt: IsNull() },
       },
-      relations: ['pointOfSale', 'containers'],
+      relations: {
+        pointOfSale: true,
+        containers: true,
+      },
     });
 
     if (!pointOfSale) {
@@ -463,7 +466,10 @@ export default class TransactionService extends WithManager {
             revision,
             container: { id, deletedAt: IsNull() },
           },
-          relations: ['container', 'products'],
+          relations: {
+            container: true,
+            products: true,
+          },
         });
       }),
     );
@@ -952,14 +958,29 @@ export default class TransactionService extends WithManager {
   public async getSingleTransaction(id: number): Promise<Transaction | undefined> {
     const transaction = await this.manager.findOne(Transaction, {
       where: { id },
-      relations: [
-        'from', 'createdBy', 'subTransactions', 'subTransactions.to', 'subTransactions.subTransactionRows',
-        // We query a lot here, but we will parse this later to a very simple BaseResponse
-        'pointOfSale', 'pointOfSale.pointOfSale',
-        'subTransactions.container', 'subTransactions.container.container',
-        'subTransactions.subTransactionRows.product', 'subTransactions.subTransactionRows.product.product',
-        'subTransactions.subTransactionRows.product.vat',
-      ],
+      relations: {
+        from: true,
+        createdBy: true,
+
+        subTransactions: {
+          to: true,
+
+          subTransactionRows: {
+            product: {
+              product: true,
+              vat: true,
+            },
+          },
+
+          container: {
+            container: true,
+          },
+        },
+
+        pointOfSale: {
+          pointOfSale: true,
+        },
+      },
       withDeleted: true,
     });
 
@@ -1106,17 +1127,23 @@ export default class TransactionService extends WithManager {
       where: {
         id: In(ids),
       },
-      relations: [
-        'subTransactions',
-        'from',
-        'subTransactions.to',
-        'subTransactions.subTransactionRows',
-        'subTransactions.subTransactionRows.product',
-        'subTransactions.subTransactionRows.product.category',
-        'subTransactions.subTransactionRows.product.product',
-        'subTransactions.subTransactionRows.product.vat',
-        'subTransactions.subTransactionRows.invoice',
-      ],
+      relations: {
+        subTransactions: {
+          to: true,
+
+          subTransactionRows: {
+            product: {
+              category: true,
+              product: true,
+              vat: true,
+            },
+
+            invoice: true,
+          },
+        },
+
+        from: true,
+      },
     });
 
     // Don't consider transactions from invoice accounts

--- a/src/service/transfer-service.ts
+++ b/src/service/transfer-service.ts
@@ -324,8 +324,8 @@ export default class TransferService extends WithManager {
     // a transfer is always at least from a valid user OR to a valid user
     // a transfer may be from null to an user, or from an user to null
     return (request.fromId || request.toId)
-        && (await this.manager.findOne(User, { where: { id: request.fromId } })
-        || await this.manager.findOne(User, { where: { id: request.toId } }))
+        && ((await this.manager.findOne(User, { where: { id: request.fromId } }))
+        || (await this.manager.findOne(User, { where: { id: request.toId } })))
         && request.amount.precision === dinero.defaultPrecision
         && request.amount.currency === dinero.defaultCurrency;
   }
@@ -393,7 +393,19 @@ export default class TransferService extends WithManager {
   public async deleteTransfer(id: number): Promise<void> {
     const transfer = await this.manager.findOne(Transfer, {
       where: { id },
-      relations: ['from', 'to', 'payoutRequest', 'sellerPayout', 'deposit', 'invoice', 'creditInvoice', 'fine', 'writeOff', 'waivedFines', 'inactiveAdministrativeCost'],
+      relations: {
+        from: true,
+        to: true,
+        payoutRequest: true,
+        sellerPayout: true,
+        deposit: true,
+        invoice: true,
+        creditInvoice: true,
+        fine: true,
+        writeOff: true,
+        waivedFines: true,
+        inactiveAdministrativeCost: true,
+      },
     });
 
     if (!transfer) {

--- a/src/service/user-service.ts
+++ b/src/service/user-service.ts
@@ -242,7 +242,9 @@ export default class UserService {
     if (filters.organId) {
       // This allows us to search for organ members
       const userIds = await OrganMembership
-        .find({ where: { organ: { id: filters.organId } }, relations: ['user'] });
+        .find({ where: { organ: { id: filters.organId } }, relations: {
+          user: true,
+        } });
       processedFilters.id = userIds.map((auth) => auth.user.id);
     }
     if (filters.assignedRoleIds) {
@@ -517,8 +519,12 @@ export default class UserService {
    * @param right - User to check
    */
   public static async areInSameOrgan(left: number, right: number) {
-    const leftAuth = await OrganMembership.find({ where: { user: { id: left } }, relations: ['organ'] });
-    const rightAuth = await OrganMembership.find({ where: { user: { id: right } }, relations: ['organ'] });
+    const leftAuth = await OrganMembership.find({ where: { user: { id: left } }, relations: {
+      organ: true,
+    } });
+    const rightAuth = await OrganMembership.find({ where: { user: { id: right } }, relations: {
+      organ: true,
+    } });
 
     const rightIds = leftAuth.map((u) => u.organ.id);
     const overlap = rightAuth.map((u) => u.organ.id)
@@ -547,7 +553,9 @@ export default class UserService {
         return;
       case UserType.MEMBER:
         // When an account is converted to a member account, remove local authenticator if it exists
-        const localAuthenticator = await LocalAuthenticator.findOne({ where: { user: { id: user.id } }, relations: ['user'] });
+        const localAuthenticator = await LocalAuthenticator.findOne({ where: { user: { id: user.id } }, relations: {
+          user: true,
+        } });
         if (localAuthenticator) {
           await localAuthenticator.remove();
         }

--- a/src/service/voucher-group-service.ts
+++ b/src/service/voucher-group-service.ts
@@ -153,7 +153,7 @@ export default class VoucherGroupService {
 
     const options: FindManyOptions = {
       where: QueryFilter.createFilterWhereClause(mapping, filters),
-      relations: ['vouchers.user'],
+      relations: { vouchers: { user: true } },
     };
     const bkgs: VoucherGroup[] = await VoucherGroup.find({ ...options, take, skip });
     const count = await VoucherGroup.count({ where: options.where });
@@ -225,7 +225,9 @@ export default class VoucherGroupService {
 
     let usersCurrent = (
       await UserVoucherGroup.find({
-        relations: ['user'],
+        relations: {
+          user: true,
+        },
         where: { voucherGroup: { id } },
       })
     ).map((ubkg) => ubkg.user);

--- a/src/service/websocket/pos-relation-helper.ts
+++ b/src/service/websocket/pos-relation-helper.ts
@@ -37,7 +37,10 @@ export async function getPointOfSaleRelation(
 ): Promise<'all' | 'organ' | 'own'> {
   const pos = await PointOfSale.findOne({
     where: { id: pointOfSaleId },
-    relations: ['owner', 'user'],
+    relations: {
+      owner: true,
+      user: true,
+    },
   });
 
   if (!pos) return 'all';

--- a/src/service/wrapped-service.ts
+++ b/src/service/wrapped-service.ts
@@ -54,7 +54,9 @@ export default class WrappedService extends WithManager {
 
     return entityManager.findOne(Wrapped, {
       where: { userId },
-      relations: ['organs'],
+      relations: {
+        organs: true,
+      },
     });
   }
 
@@ -242,8 +244,13 @@ export default class WrappedService extends WithManager {
         from: { id: In(userIds) },
         createdAt: Between(start, end),
       },
-      select: ['id', 'createdAt'],
-      relations: ['from'],
+      select: {
+        id: true,
+        createdAt: true,
+      },
+      relations: {
+        from: true,
+      },
     });
 
     // Group transactions by user id

--- a/src/subscriber/transaction-subscriber.ts
+++ b/src/subscriber/transaction-subscriber.ts
@@ -51,7 +51,13 @@ export default class TransactionSubscriber implements EntitySubscriberInterface 
       || (entity.subTransactions.length > 0 && entity.subTransactions[0].subTransactionRows.length > 0 && entity.subTransactions[0].subTransactionRows[0].product == null)) {
       entity = await event.manager.findOne(Transaction, {
         where: { id: entity.id },
-        relations: ['subTransactions', 'subTransactions.subTransactionRows', 'subTransactions.subTransactionRows.product'],
+        relations: {
+          subTransactions: {
+            subTransactionRows: {
+              product: true,
+            },
+          },
+        },
       });
     }
 

--- a/src/subscriber/transfer-subscriber.ts
+++ b/src/subscriber/transfer-subscriber.ts
@@ -39,7 +39,9 @@ export default class TransferSubscriber implements EntitySubscriberInterface {
   async afterInsert(event: InsertEvent<Transfer>) {
     if (event.entity.toId == null) return;
 
-    const user = await event.manager.findOne(User, { where: { id: event.entity.toId }, relations: ['currentFines'] });
+    const user = await event.manager.findOne(User, { where: { id: event.entity.toId }, relations: {
+      currentFines: true,
+    } });
     if (user.currentFines == null) return;
 
     const balance = await new BalanceService().getBalance(user.id);

--- a/test/helpers/transaction-factory.ts
+++ b/test/helpers/transaction-factory.ts
@@ -86,7 +86,13 @@ function createValidSubTransactionRequest(
 
 export async function getAPOSWithProducts(index? : number):
 Promise<PointOfSaleWithContainersResponse> {
-  const posList = (await PointOfSaleRevision.find({ relations: ['pointOfSale', 'containers', 'containers.container'] })).filter((p) => p.containers.length > 0);
+  const posList = (await PointOfSaleRevision.find({ relations: {
+    pointOfSale: true,
+
+    containers: {
+      container: true,
+    },
+  } })).filter((p) => p.containers.length > 0);
   const pointOfSale = wrapGet(posList, index ?? 0);
   const [revisions] = await PointOfSaleService.getPointsOfSale(
     {
@@ -180,7 +186,11 @@ export async function createTransactions(debtorId: number, creditorId: number, t
   if (delta) {
     const promises: Promise<any>[] = [];
     const ids = transactions.transactions.map((t) => t.tId);
-    await Transaction.find({ where: { id: In(ids) }, relations: ['subTransactions', 'subTransactions.subTransactionRows'] }).then((tr) => {
+    await Transaction.find({ where: { id: In(ids) }, relations: {
+      subTransactions: {
+        subTransactionRows: true,
+      },
+    } }).then((tr) => {
       tr.forEach((t) => {
         let createdAt = new Date(t.createdAt.getTime() + delta);
         let query = `UPDATE \`transaction\` SET createdAt = '${toMySQLString(createdAt)}' WHERE id = ${t.id}`;

--- a/test/unit/controller/banner-controller.ts
+++ b/test/unit/controller/banner-controller.ts
@@ -616,7 +616,9 @@ describe('BannerController', async (): Promise<void> => {
       // invalid code
       expect(res.status).to.equal(400);
       // check if banner is unaltered
-      const databaseBanner = await Banner.findOne({ where: { id: 1 }, relations: ['image'] });
+      const databaseBanner = await Banner.findOne({ where: { id: 1 }, relations: {
+        image: true,
+      } });
       expect(bannerEq(databaseBanner, oldBanner)).to.be.true;
 
       // check response body has validation error shape
@@ -737,7 +739,9 @@ describe('BannerController', async (): Promise<void> => {
 
       expect(res.status).to.equal(204);
       expect(res.body).to.be.empty;
-      expect((await Banner.findOne({ where: { id }, relations: ['image'] })).image).to.be.not.undefined;
+      expect((await Banner.findOne({ where: { id }, relations: {
+        image: true,
+      } })).image).to.be.not.undefined;
     });
     it('should update the banner image if admin', async () => {
       const stub = sinon.stub(DiskStorage.prototype, 'validateFileLocation');
@@ -753,7 +757,9 @@ describe('BannerController', async (): Promise<void> => {
 
       expect(res.status).to.equal(204);
       expect(res.body).to.be.empty;
-      expect((await Banner.findOne({ where: { id }, relations: ['image'] })).image.id).to.not.equal(image);
+      expect((await Banner.findOne({ where: { id }, relations: {
+        image: true,
+      } })).image.id).to.not.equal(image);
     });
     it('should return 403 if not admin', async () => {
       const { id } = ctx.banners.filter((banner) => banner.image === undefined)[0];

--- a/test/unit/controller/container-controller.ts
+++ b/test/unit/controller/container-controller.ts
@@ -382,7 +382,9 @@ describe('ContainerController', async (): Promise<void> => {
       body.forEach((product) => expect(deletedProductIds).to.not.include(product.id));
     });
     it('should return an HTTP 403 if container not public or own and if not admin', async () => {
-      const { id } = await Container.findOne({ relations: ['owner'], where: { owner: { id: ctx.adminUser.id }, public: true } });
+      const { id } = await Container.findOne({ relations: {
+        owner: true,
+      }, where: { owner: { id: ctx.adminUser.id }, public: true } });
       const res = await request(ctx.app)
         .get(`/containers/${id}/products`)
         .set('Authorization', `Bearer ${ctx.localUser}`);
@@ -390,7 +392,9 @@ describe('ContainerController', async (): Promise<void> => {
       expect(res.status).to.equal(403);
     });
     it('should return an HTTP 200 and all the products in the container if public and if admin', async () => {
-      const { id } = await Container.findOne({ relations: ['owner'], where: { owner: { id: ctx.localUser.id }, public: true } });
+      const { id } = await Container.findOne({ relations: {
+        owner: true,
+      }, where: { owner: { id: ctx.localUser.id }, public: true } });
 
       const res = await request(ctx.app)
         .get(`/containers/${id}/products`)
@@ -529,7 +533,7 @@ describe('ContainerController', async (): Promise<void> => {
       expect(res.body.errors).to.be.an('array').with.length.greaterThan(0);
     });
     it('should return an HTTP 404 if the container with the given id does not exist', async () => {
-      const id = await Container.count({ withDeleted: true }) + 1;
+      const id = (await Container.count({ withDeleted: true })) + 1;
       const res = await request(ctx.app)
         .patch(`/containers/${id}`)
         .set('Authorization', `Bearer ${ctx.adminToken}`)
@@ -545,7 +549,9 @@ describe('ContainerController', async (): Promise<void> => {
       expect(res.status).to.equal(404);
     });
     it('should return an HTTP 403 if not admin nor owner and not public', async () => {
-      const { id } = await Container.findOne({ relations: ['owner'], where: { owner: { id: ctx.adminUser.id }, public: false } });
+      const { id } = await Container.findOne({ relations: {
+        owner: true,
+      }, where: { owner: { id: ctx.adminUser.id }, public: false } });
 
       const res = await request(ctx.app)
         .patch(`/containers/${id}`)

--- a/test/unit/controller/event-controller.ts
+++ b/test/unit/controller/event-controller.ts
@@ -725,7 +725,11 @@ describe('EventController', () => {
 
       originalEvent = await Event.findOne({
         where: { answers: { shift: { deletedAt: null } } },
-        relations: ['answers', 'answers.shift'],
+        relations: {
+          answers: {
+            shift: true,
+          },
+        },
       });
     });
 

--- a/test/unit/controller/invoice-controller.ts
+++ b/test/unit/controller/invoice-controller.ts
@@ -269,7 +269,9 @@ describe('InvoiceController', async () => {
     }
 
     it('should verify that all transactions are owned by the debtor', async () => {
-      const transactionIDs = (await Transaction.find({ relations: ['from'] })).filter((i) => i.from.id !== ctx.adminUser.id).map((t) => t.id);
+      const transactionIDs = (await Transaction.find({ relations: {
+        from: true,
+      } })).filter((i) => i.from.id !== ctx.adminUser.id).map((t) => t.id);
       const req: CreateInvoiceRequest = { ...ctx.validInvoiceRequest, transactionIDs };
       await expectError(req, INVALID_TRANSACTION_OWNER().value);
     });
@@ -282,7 +284,9 @@ describe('InvoiceController', async () => {
       await expectError(req, NO_TRANSACTION_IDS().value);
     });
     it('should verify that description is a valid string', async () => {
-      const transactionIDs = (await Transaction.find({ relations: ['from'] })).filter((i) => i.from.id === ctx.validInvoiceRequest.forId).map((t) => t.id);
+      const transactionIDs = (await Transaction.find({ relations: {
+        from: true,
+      } })).filter((i) => i.from.id === ctx.validInvoiceRequest.forId).map((t) => t.id);
       const req: CreateInvoiceRequest = { ...ctx.validInvoiceRequest, description: '', transactionIDs };
       await expectError(req, ZERO_LENGTH_STRING().value);
     });
@@ -314,7 +318,13 @@ describe('InvoiceController', async () => {
             },
           };
 
-          const invoiceTransactions = await Transaction.find({ where: { id: In(tIds) }, relations: ['subTransactions', 'subTransactions.subTransactionRows', 'subTransactions.subTransactionRows.invoice'] });
+          const invoiceTransactions = await Transaction.find({ where: { id: In(tIds) }, relations: {
+            subTransactions: {
+              subTransactionRows: {
+                invoice: true,
+              },
+            },
+          } });
           const subIDs: number[] = [];
           invoiceTransactions.forEach((t) => {
             t.subTransactions.forEach((tSub) => {
@@ -387,7 +397,9 @@ describe('InvoiceController', async () => {
         });
     });
     it('should filter on invoice status', async () => {
-      const sent = (await Invoice.find({ where: { invoiceStatus: true }, relations: ['invoiceStatus'] }))
+      const sent = (await Invoice.find({ where: { invoiceStatus: true }, relations: {
+        invoiceStatus: true,
+      } }))
         .filter((i) => i.invoiceStatus[i.invoiceStatus.length - 1].state === InvoiceState.SENT);
       expect(sent.length).to.be.at.least(1);
       expect(sent.length).to.not.equal(await Invoice.count());
@@ -514,7 +526,9 @@ describe('InvoiceController', async () => {
   });
   describe('PATCH /invoices/{id}', () => {
     it('should return an HTTP 200 and update an invoice if admin', async () => {
-      const invoice = (await Invoice.find({ relations: ['invoiceStatus'] }))
+      const invoice = (await Invoice.find({ relations: {
+        invoiceStatus: true,
+      } }))
         .filter((i) => i.invoiceStatus[i.invoiceStatus.length - 1].state === InvoiceState.SENT)[0];
       const updateRequest: UpdateInvoiceRequest = {
         addressee: 'Updated-addressee',
@@ -558,7 +572,9 @@ describe('InvoiceController', async () => {
       expect(res.status).to.equal(403);
     });
     it('should verify that new invoice state is not the same as current', async () => {
-      const invoice = (await Invoice.find({ relations: ['invoiceStatus'] }))[0];
+      const invoice = (await Invoice.find({ relations: {
+        invoiceStatus: true,
+      } }))[0];
       const currentState = invoice.invoiceStatus[invoice.invoiceStatus.length - 1].state;
       const req: UpdateInvoiceRequest = {
         addressee: 'Updated-addressee',
@@ -693,7 +709,9 @@ describe('InvoiceController', async () => {
   describe('/invoices/users/{id}', () => {
     describe('GET /invoices/users/{id}', () => {
       it('should return an HTTP 403 if not admin', async () => {
-        const invoiceUser = await InvoiceUser.findOne({ where: { user: { deleted: false, type: UserType.INVOICE } }, relations: ['user'] });
+        const invoiceUser = await InvoiceUser.findOne({ where: { user: { deleted: false, type: UserType.INVOICE } }, relations: {
+          user: true,
+        } });
         expect(invoiceUser).to.not.be.null;
 
         const res = await request(ctx.app)
@@ -704,7 +722,9 @@ describe('InvoiceController', async () => {
         expect(res.body).to.be.empty;
       });
       it('should return an HTTP 200 and the InvoiceUser if admin', async () => {
-        const invoiceUser = await InvoiceUser.findOne({ where: { user: { deleted: false, type: UserType.INVOICE } }, relations: ['user'] });
+        const invoiceUser = await InvoiceUser.findOne({ where: { user: { deleted: false, type: UserType.INVOICE } }, relations: {
+          user: true,
+        } });
         expect(invoiceUser).to.not.be.null;
 
         const res = await request(ctx.app)
@@ -757,7 +777,9 @@ describe('InvoiceController', async () => {
     });
     describe('DELETE /invoices/users/{id}', () => {
       it('should return an HTTP 403 if not admin', async () => {
-        const invoiceUser = await InvoiceUser.findOne({ where: { user: { deleted: false, type: UserType.INVOICE } }, relations: ['user'] });
+        const invoiceUser = await InvoiceUser.findOne({ where: { user: { deleted: false, type: UserType.INVOICE } }, relations: {
+          user: true,
+        } });
         expect(invoiceUser).to.not.be.null;
 
         const res = await request(ctx.app)
@@ -788,7 +810,9 @@ describe('InvoiceController', async () => {
             expect(res.status).to.equal(204);
             expect(res.body).to.be.empty;
 
-            const deleted = await InvoiceUser.findOne({ where: { userId: user.id }, relations: ['user'] });
+            const deleted = await InvoiceUser.findOne({ where: { userId: user.id }, relations: {
+              user: true,
+            } });
             expect(deleted).to.be.null;
           });
       });
@@ -807,7 +831,9 @@ describe('InvoiceController', async () => {
     });
     describe('PUT /invoices/users/{id}', () => {
       it('should return an HTTP 200 and the updated InvoiceUser if admin', async () => {
-        const invoiceUser = await InvoiceUser.findOne({ where: { user: { deleted: false, type: UserType.INVOICE } }, relations: ['user'] });
+        const invoiceUser = await InvoiceUser.findOne({ where: { user: { deleted: false, type: UserType.INVOICE } }, relations: {
+          user: true,
+        } });
         expect(invoiceUser).to.not.be.null;
 
         const update: UpdateInvoiceUserRequest = {
@@ -893,7 +919,9 @@ describe('InvoiceController', async () => {
           });
       });
       it('should return an HTTP 403 if not admin', async () => {
-        const invoiceUser = await InvoiceUser.findOne({ where: { user: { deleted: false, type: UserType.INVOICE } }, relations: ['user'] });
+        const invoiceUser = await InvoiceUser.findOne({ where: { user: { deleted: false, type: UserType.INVOICE } }, relations: {
+          user: true,
+        } });
         expect(invoiceUser).to.not.be.null;
 
         const update: UpdateInvoiceUserRequest = {

--- a/test/unit/controller/payout-request-controller.ts
+++ b/test/unit/controller/payout-request-controller.ts
@@ -490,7 +490,10 @@ describe('PayoutRequestController', () => {
         && req.payoutRequestStatus.length === 1)[1];
       const before = await PayoutRequest.findOne({
         where: { id },
-        relations: ['payoutRequestStatus', 'requestedBy'],
+        relations: {
+          payoutRequestStatus: true,
+          requestedBy: true,
+        },
       });
       await generateBalance(before.amount.getAmount() * 2, before.requestedBy.id);
       const res = await request(ctx.app)

--- a/test/unit/controller/point-of-sale-controller.ts
+++ b/test/unit/controller/point-of-sale-controller.ts
@@ -636,7 +636,9 @@ describe('PointOfSaleController', async () => {
   });
   describe('GET /pointsofsale/:id/products', async () => {
     it('should return correct model', async () => {
-      const pos = await PointOfSale.findOne({ relations: ['owner'], where: { owner: { id: ctx.adminUser.id } } });
+      const pos = await PointOfSale.findOne({ relations: {
+        owner: true,
+      }, where: { owner: { id: ctx.adminUser.id } } });
       expect(pos).to.not.be.null;
       const { id } = pos;
 

--- a/test/unit/controller/product-controller.ts
+++ b/test/unit/controller/product-controller.ts
@@ -441,7 +441,9 @@ describe('ProductController', async (): Promise<void> => {
       expect(res.status).to.equal(200);
     });
     it('should return an HTTP 200 and the product with the given id if connected via organ', async () => {
-      const product = await Product.findOne({ relations: ['owner'], where: { owner: { id: ctx.organ.id } } });
+      const product = await Product.findOne({ relations: {
+        owner: true,
+      }, where: { owner: { id: ctx.organ.id } } });
       const res = await request(ctx.app)
         .get(`/products/${product.id}`)
         .set('Authorization', `Bearer ${ctx.organMemberToken}`);
@@ -522,7 +524,7 @@ describe('ProductController', async (): Promise<void> => {
       expect(res.status).to.equal(404);
     });
     it('should return an HTTP 404 if the product with the given id does not exist', async () => {
-      const id = await Product.count({ withDeleted: true }) + 1;
+      const id = (await Product.count({ withDeleted: true })) + 1;
       const res = await request(ctx.app)
         .patch(`/products/${id}`)
         .set('Authorization', `Bearer ${ctx.adminToken}`)
@@ -582,7 +584,9 @@ describe('ProductController', async (): Promise<void> => {
 
       expect(res.status).to.equal(204);
       expect(res.body).to.be.empty;
-      expect((await Product.findOne({ where: { id }, relations: ['image'] })).image).to.be.not.undefined;
+      expect((await Product.findOne({ where: { id }, relations: {
+        image: true,
+      } })).image).to.be.not.undefined;
     });
     it('should update the product image if admin', async () => {
       const stub = sinon.stub(DiskStorage.prototype, 'validateFileLocation');
@@ -598,7 +602,9 @@ describe('ProductController', async (): Promise<void> => {
 
       expect(res.status).to.equal(204);
       expect(res.body).to.be.empty;
-      expect((await Product.findOne({ where: { id }, relations: ['image'] })).image.id).to.not.equal(image);
+      expect((await Product.findOne({ where: { id }, relations: {
+        image: true,
+      } })).image.id).to.not.equal(image);
     });
     it('should return 403 if not admin', async () => {
       const { id } = ctx.products.filter((product) => product.image === undefined)[1];

--- a/test/unit/controller/seller-payout-controller.ts
+++ b/test/unit/controller/seller-payout-controller.ts
@@ -67,7 +67,7 @@ describe('SellerPayoutController', () => {
   };
 
   beforeAll(async () => {
-    const c = { ...await defaultContext() };
+    const c = { ...(await defaultContext()) };
 
     const users = await new UserSeeder().seed();
 
@@ -322,7 +322,9 @@ describe('SellerPayoutController', () => {
     });
     it('should return HTTP 502 if pdf generation fails', async () => {
       clientStub.generateDisbursement.rejects(new Error('Failed to generate PDF'));
-      const sellerPayout = await SellerPayout.findOne({ where: { id: 1 }, relations: ['requestedBy'] });
+      const sellerPayout = await SellerPayout.findOne({ where: { id: 1 }, relations: {
+        requestedBy: true,
+      } });
       const res = await request(ctx.app)
         .get(`/seller-payouts/${sellerPayout.id}/report/pdf`)
         .set('Authorization', `Bearer ${ctx.adminToken}`)

--- a/test/unit/controller/stripe-controller.ts
+++ b/test/unit/controller/stripe-controller.ts
@@ -176,7 +176,9 @@ describe.skipIf(shouldSkipStripe)('StripeController', async (): Promise<void> =>
       expect(await StripeDeposit.count()).to.equal(stripeDepositCount + 1);
 
       ctx.specification.validateModel('StripePaymentIntentResponse', paymentIntent);
-      const stripeDeposit = await StripeDeposit.findOne({ where: { id: paymentIntent.id }, relations: ['to'] });
+      const stripeDeposit = await StripeDeposit.findOne({ where: { id: paymentIntent.id }, relations: {
+        to: true,
+      } });
       expect(ctx.localUser.id).to.equal(stripeDeposit.to.id);
 
       const stripePaymentIntent = await ctx.stripe.paymentIntents.retrieve(paymentIntent.stripeId);

--- a/test/unit/controller/transaction-controller.ts
+++ b/test/unit/controller/transaction-controller.ts
@@ -655,7 +655,9 @@ describe('TransactionController', (): void => {
 
   describe('GET /transactions/{id}', () => {
     it('should return HTTP 200 and transaction if connected via organ', async () => {
-      const trans = await Transaction.findOne({ relations: ['from'], where: { from: { id: ctx.users[0].id } } });
+      const trans = await Transaction.findOne({ relations: {
+        from: true,
+      }, where: { from: { id: ctx.users[0].id } } });
       expect(trans).to.not.be.undefined;
       const res = await request(ctx.app)
         .get(`/transactions/${trans.id}`)
@@ -670,7 +672,9 @@ describe('TransactionController', (): void => {
       expect(res.body.id).to.equal(trans.id);
     });
     it('should return HTTP 200 for own transaction', async () => {
-      const trans = await Transaction.findOne({ relations: ['from'], where: { from: { id: ctx.users[0].id } } });
+      const trans = await Transaction.findOne({ relations: {
+        from: true,
+      }, where: { from: { id: ctx.users[0].id } } });
       expect(trans).to.not.be.undefined;
       const res = await request(ctx.app)
         .get(`/transactions/${trans.id}`)
@@ -679,7 +683,9 @@ describe('TransactionController', (): void => {
       expect(res.body.id).to.equal(trans.id);
     });
     it('should return HTTP 403 if not admin and not connected via organ', async () => {
-      const trans = await Transaction.findOne({ relations: ['from'], where: { from: { id: ctx.users[3].id } } });
+      const trans = await Transaction.findOne({ relations: {
+        from: true,
+      }, where: { from: { id: ctx.users[3].id } } });
       expect(trans).to.not.be.undefined;
       const res = await request(ctx.app)
         .get(`/transactions/${trans.id}`)
@@ -1171,7 +1177,10 @@ describe('TransactionController', (): void => {
         .send(ctx.validTransReq);
       testTransaction = await Transaction.findOne({ 
         where: { id: createRes.body.id },
-        relations: ['from', 'createdBy'],
+        relations: {
+          from: true,
+          createdBy: true,
+        },
       });
     });
 

--- a/test/unit/controller/write-off-controller.ts
+++ b/test/unit/controller/write-off-controller.ts
@@ -56,7 +56,7 @@ describe('WriteOffController', () => {
   };
 
   beforeAll(async () => {
-    const c = { ...await defaultContext() };
+    const c = { ...(await defaultContext()) };
     await truncateAllTables(c.connection);
 
     const admin = await (await UserFactory(await ADMIN_USER())).get();
@@ -282,7 +282,9 @@ describe('WriteOffController', () => {
     it('should return HTTP 200 with the write off PDF belonging to the write off', async () => {
       fs.mkdirSync(WRITE_OFF_PDF_LOCATION, { recursive: true });
       resolveSuccessful();
-      const writeOff = await WriteOff.findOne({ where: { id: 1 }, relations: ['to'] });
+      const writeOff = await WriteOff.findOne({ where: { id: 1 }, relations: {
+        to: true,
+      } });
       const res = await request(ctx.app)
         .get(`/writeoffs/${writeOff.id}/pdf`)
         .set('Authorization', `Bearer ${ctx.adminToken}`);
@@ -305,7 +307,9 @@ describe('WriteOffController', () => {
     });
     it('should return HTTP 502 if pdf generation fails', async () => {
       clientStub.generateWriteOff.rejects(new Error('Failed to generate PDF'));
-      const writeOff = await WriteOff.findOne({ where: { id: 1 }, relations: ['to'] });
+      const writeOff = await WriteOff.findOne({ where: { id: 1 }, relations: {
+        to: true,
+      } });
       const res = await request(ctx.app)
         .get(`/writeoffs/${writeOff.id}/pdf`)
         .set('Authorization', `Bearer ${ctx.adminToken}`)

--- a/test/unit/gewis/gewisdb-sync-service.ts
+++ b/test/unit/gewis/gewisdb-sync-service.ts
@@ -62,7 +62,9 @@ function toWebResponse(memberUser: MemberUser): MemberAllAttributes {
 }
 
 async function checkUpdateAgainstDB(update: MemberAllAttributes, userId: number) {
-  const dbUser = await MemberUser.findOne({ where: { userId }, relations: ['user'] });
+  const dbUser = await MemberUser.findOne({ where: { userId }, relations: {
+    user: true,
+  } });
   expect(dbUser).to.not.be.undefined;
   expect(dbUser.user.deleted).to.eq(update.deleted);
   expect(dbUser.user.email).to.eq(update.email);
@@ -226,7 +228,9 @@ describe('GewisDBSyncService', () => {
           expect(result).to.be.true;
 
           // Check that the user was not actually updated in the database
-          const dbUser = await MemberUser.findOne({ where: { userId: memberUser.user.id }, relations: ['user'] });
+          const dbUser = await MemberUser.findOne({ where: { userId: memberUser.user.id }, relations: {
+            user: true,
+          } });
           expect(dbUser.user.firstName).to.eq(originalFirstName);
           expect(dbUser.user.lastName).to.eq(originalLastName);
           expect(dbUser.user.email).to.eq(originalEmail);

--- a/test/unit/service/ad-service.ts
+++ b/test/unit/service/ad-service.ts
@@ -127,7 +127,7 @@ describe('AD Service', (): void => {
 
   describe('createAccountIfNew function', () => {
     it('should create an account if GUID is unknown to DB', async () => {
-      const adUser = { ...(validADUser(await User.count() + 200)) };
+      const adUser = { ...(validADUser((await User.count()) + 200)) };
       // precondition.
       expect(await LDAPAuthenticator.findOne(
         { where: { UUID: adUser.objectGUID } },
@@ -138,14 +138,16 @@ describe('AD Service', (): void => {
 
       expect(await User.count()).to.be.equal(userCount + 1);
       const auth = (await LDAPAuthenticator.findOne(
-        { where: { UUID: adUser.objectGUID }, relations: ['user'] },
+        { where: { UUID: adUser.objectGUID }, relations: {
+          user: true,
+        } },
       ));
       expect(auth).to.exist;
       const { user } = auth;
       userIsAsExpected(user, adUser);
     });
     it('should not create an account if GUID is known to DB', async () => {
-      const adUser = { ...(validADUser(await User.count() + 200)) };
+      const adUser = { ...(validADUser((await User.count()) + 200)) };
       // precondition.
       await new ADService().createAccountIfNew([adUser]);
 
@@ -166,10 +168,12 @@ describe('AD Service', (): void => {
       expect(await LDAPAuthenticator.findOne(
         { where: { UUID: organUser.objectGUID } },
       )).to.be.null;
-      await new ADService().toSharedUser(validLDAPGroup(await User.count() + 200));
+      await new ADService().toSharedUser(validLDAPGroup((await User.count()) + 200));
       expect(await User.count()).to.be.equal(userCount + 1);
       const auth = (await LDAPAuthenticator.findOne(
-        { where: { UUID: organUser.objectGUID }, relations: ['user'] },
+        { where: { UUID: organUser.objectGUID }, relations: {
+          user: true,
+        } },
       ));
       expect(auth).to.exist;
       organIsAsExpected(auth.user, organUser);
@@ -179,7 +183,7 @@ describe('AD Service', (): void => {
   describe('toServiceAccount function', () => {
     it('should create an INTEGRATION user', async () => {
       const userCount = await User.count();
-      const adUser = validADUser(await User.count() + 200);
+      const adUser = validADUser((await User.count()) + 200);
       // precondition.
       expect(await LDAPAuthenticator.findOne(
         { where: { UUID: adUser.objectGUID } },
@@ -187,7 +191,9 @@ describe('AD Service', (): void => {
       await new ADService().toServiceAccount(adUser);
       expect(await User.count()).to.be.equal(userCount + 1);
       const auth = (await LDAPAuthenticator.findOne(
-        { where: { UUID: adUser.objectGUID }, relations: ['user'] },
+        { where: { UUID: adUser.objectGUID }, relations: {
+          user: true,
+        } },
       ));
       expect(auth).to.exist;
       serviceAccountIsAsExpected(auth.user, adUser);
@@ -196,14 +202,16 @@ describe('AD Service', (): void => {
 
   describe('getUsers function', () => {
     it('should return only bound users if createIfNew is false', async () => {
-      const rawLdapUsers = [validADUser(await User.count() + 200), validADUser(await User.count() + 201)];
+      const rawLdapUsers = [validADUser((await User.count()) + 200), validADUser((await User.count()) + 201)];
       await new ADService().createAccountIfNew(rawLdapUsers);
-      const newLdapUsers = [validADUser(await User.count() + 200), validADUser(await User.count() + 201)];
+      const newLdapUsers = [validADUser((await User.count()) + 200), validADUser((await User.count()) + 201)];
 
       const ldapUsers: User[] = [];
       for (const ldapUser of rawLdapUsers) {
         const auth = await LDAPAuthenticator.findOne(
-          { where: { UUID: ldapUser.objectGUID }, relations: ['user'] },
+          { where: { UUID: ldapUser.objectGUID }, relations: {
+            user: true,
+          } },
         );
         expect(auth).to.exist;
         ldapUsers.push(auth.user);
@@ -216,14 +224,16 @@ describe('AD Service', (): void => {
       expect(users).to.deep.equalInAnyOrder(ldapUsers);
     });
     it('should return return all and create new users if createIfNew is true', async () => {
-      const rawLdapUsers = [validADUser(await User.count() + 200), validADUser(await User.count() + 201)];
+      const rawLdapUsers = [validADUser((await User.count()) + 200), validADUser((await User.count()) + 201)];
       await new ADService().createAccountIfNew(rawLdapUsers);
-      const newLdapUsers = [validADUser(await User.count() + 200), validADUser(await User.count() + 201)];
+      const newLdapUsers = [validADUser((await User.count()) + 200), validADUser((await User.count()) + 201)];
 
       const ldapUsers: User[] = [];
       for (const ldapUser of rawLdapUsers) {
         const auth = await LDAPAuthenticator.findOne(
-          { where: { UUID: ldapUser.objectGUID }, relations: ['user'] },
+          { where: { UUID: ldapUser.objectGUID }, relations: {
+            user: true,
+          } },
         );
         expect(auth).to.exist;
         ldapUsers.push(auth.user);
@@ -231,7 +241,9 @@ describe('AD Service', (): void => {
 
       for (const ldapUser of newLdapUsers) {
         const auth = await LDAPAuthenticator.findOne(
-          { where: { UUID: ldapUser.objectGUID }, relations: ['user'] },
+          { where: { UUID: ldapUser.objectGUID }, relations: {
+            user: true,
+          } },
         );
         expect(auth).to.not.exist;
       }
@@ -380,7 +392,7 @@ describe('AD Service', (): void => {
         });
         sinon.stub(LDAPAuthenticator, 'findOne')
         // @ts-ignore
-          .withArgs({ where: { UUID: sharedAccountMock.objectGUID }, relations: ['user'] })
+          .withArgs({ where: { UUID: sharedAccountMock.objectGUID }, relations: { user: true } })
         // @ts-ignore
           .resolves({ user: { id: 1, displayName: sharedAccountMock.displayName } });
         // @ts-ignore
@@ -405,7 +417,7 @@ describe('AD Service', (): void => {
           });
           sinon.assert.calledOnceWithExactly(LDAPAuthenticator.findOne as sinon.SinonStub, {
             where: { UUID: ldapGroup.objectGUID },
-            relations: ['user'],
+            relations: { user: true },
           });
           sinon.assert.calledOnce(adService.getUsers as sinon.SinonStub);
           sinon.assert.calledOnce(AuthenticationService.prototype.setMemberAuthenticator as sinon.SinonStub);

--- a/test/unit/service/authentication-service.ts
+++ b/test/unit/service/authentication-service.ts
@@ -482,12 +482,16 @@ describe('AuthenticationService', (): void => {
   describe('resetLocalUsingToken function', () => {
     it('should reset password if resetToken is correct and user has no password', async () => {
       await inUserContext(await (await UserFactory()).clone(1), async (user: User) => {
-        let localAuthenticator = await LocalAuthenticator.findOne({ where: { user: { id: user.id } }, relations: ['user'] });
+        let localAuthenticator = await LocalAuthenticator.findOne({ where: { user: { id: user.id } }, relations: {
+          user: true,
+        } });
         expect(localAuthenticator).to.be.null;
 
         const tokenInfo = await new AuthenticationService().createResetToken(user);
         const auth = await new AuthenticationService().resetLocalUsingToken(tokenInfo.resetToken, tokenInfo.password, 'Password');
-        localAuthenticator = await LocalAuthenticator.findOne({ where: { user: { id: user.id } }, relations: ['user'] });
+        localAuthenticator = await LocalAuthenticator.findOne({ where: { user: { id: user.id } }, relations: {
+          user: true,
+        } });
         expect(localAuthenticator).to.not.be.null;
         expect(auth).to.not.be.undefined;
         await expect(new AuthenticationService().compareHash('Password', auth.hash)).to.eventually.be.true;

--- a/test/unit/service/balance-service.ts
+++ b/test/unit/service/balance-service.ts
@@ -454,7 +454,11 @@ describe('BalanceService', (): void => {
         const actualBalance = calculateBalance(user, ctx.transactions, ctx.subTransactions, ctx.transfers);
 
         // eslint-disable-next-line no-await-in-loop
-        const cachedBalance = await Balance.findOne({ where: { userId: user.id }, relations: ['user', 'lastTransaction', 'lastTransfer'] });
+        const cachedBalance = await Balance.findOne({ where: { userId: user.id }, relations: {
+          user: true,
+          lastTransaction: true,
+          lastTransfer: true,
+        } });
         expect(cachedBalance).to.not.be.undefined;
         // eslint-disable-next-line no-await-in-loop
         const balance = await new BalanceService().getBalance(user.id);
@@ -516,7 +520,11 @@ describe('BalanceService', (): void => {
       const oldBalance = await new BalanceService().getBalance(user.id);
       const oldBalanceCache = await Balance.findOne({
         where: { userId: user.id },
-        relations: ['user', 'lastTransaction', 'lastTransfer'],
+        relations: {
+          user: true,
+          lastTransaction: true,
+          lastTransfer: true,
+        },
       });
       // Sanity check
       expect(oldBalanceCache).to.not.be.undefined;
@@ -529,7 +537,11 @@ describe('BalanceService', (): void => {
       const newBalance = await new BalanceService().getBalance(user.id);
       let newBalanceCache = await Balance.findOne({
         where: { userId: user.id },
-        relations: ['user', 'lastTransaction', 'lastTransfer'],
+        relations: {
+          user: true,
+          lastTransaction: true,
+          lastTransfer: true,
+        },
       });
 
       expect(newBalance.id).to.equal(user.id);
@@ -542,7 +554,11 @@ describe('BalanceService', (): void => {
       await new BalanceService().updateBalances({});
       newBalanceCache = await Balance.findOne({
         where: { userId: user.id },
-        relations: ['user', 'lastTransaction', 'lastTransfer'],
+        relations: {
+          user: true,
+          lastTransaction: true,
+          lastTransfer: true,
+        },
       });
       expect(newBalanceCache.lastTransaction.id).to.equal(transaction.id);
       expect(newBalanceCache.amount.getAmount()).to.equal(newBalance.amount.amount);
@@ -719,7 +735,11 @@ describe('BalanceService', (): void => {
       } as any]);
       const oldBalanceCache = await Balance.findOne({
         where: { userId: newUser.id },
-        relations: ['user', 'lastTransaction', 'lastTransfer'],
+        relations: {
+          user: true,
+          lastTransaction: true,
+          lastTransfer: true,
+        },
       });
       expect(oldBalanceCache).to.not.be.undefined;
       expect(oldBalanceCache.lastTransaction).to.not.be.undefined;
@@ -735,7 +755,11 @@ describe('BalanceService', (): void => {
 
       const removedBalanceCache = await Balance.findOne({
         where: { userId: newUser.id },
-        relations: ['user', 'lastTransaction', 'lastTransfer'],
+        relations: {
+          user: true,
+          lastTransaction: true,
+          lastTransfer: true,
+        },
       });
       expect(removedBalanceCache).to.be.null;
       expect(await Transaction.findOne({ where: { id: transaction.transaction.id } }))

--- a/test/unit/service/container-service.ts
+++ b/test/unit/service/container-service.ts
@@ -70,7 +70,9 @@ function entityAsUpdate(update: UpdateContainerParams, container: ContainerRevis
 }
 
 async function entityAsCreation(creation: CreateContainerParams, entity: ContainerRevision) {
-  const container = await Container.findOne({ where: { id: entity.container.id }, relations: ['owner'] });
+  const container = await Container.findOne({ where: { id: entity.container.id }, relations: {
+    owner: true,
+  } });
   expect(creation.ownerId).to.be.eq(container.owner.id);
   expect(creation.name).to.be.eq(entity.name);
   expect(creation.public).to.be.eq(entity.container.public);
@@ -263,13 +265,17 @@ describe('ContainerService', async (): Promise<void> => {
         .public).to.be.true;
     });
     it('should return true if the user is the owner of private container', async () => {
-      const container = await Container.findOne({ where: { public: false }, relations: ['owner'] });
+      const container = await Container.findOne({ where: { public: false }, relations: {
+        owner: true,
+      } });
       expect((await ContainerService.canViewContainer(
         container.owner.id, container,
       )).own).to.be.true;
     });
     it('should return false if the user is not the owner and container is private', async () => {
-      const container = await Container.findOne({ where: { public: false }, relations: ['owner'] });
+      const container = await Container.findOne({ where: { public: false }, relations: {
+        owner: true,
+      } });
       expect(container.public).to.be.false;
       const visibility = await ContainerService.canViewContainer(
         container.owner.id + 1, container,
@@ -348,7 +354,11 @@ describe('ContainerService', async (): Promise<void> => {
       await ContainerService.updateContainer(update);
 
       const updatedPos = await PointOfSaleRevision
-        .findOne({ where: { revision: 2, pointOfSale: { id: pos.pointOfSaleId } }, relations: ['containers', 'containers.products'] });
+        .findOne({ where: { revision: 2, pointOfSale: { id: pos.pointOfSaleId } }, relations: {
+          containers: {
+            products: true,
+          },
+        } });
       expect(updatedPos).to.not.be.null;
       expect(updatedPos.containers).length(2);
 

--- a/test/unit/service/debtor-service.ts
+++ b/test/unit/service/debtor-service.ts
@@ -237,7 +237,11 @@ describe('DebtorService', (): void => {
     it('should correctly delete a single fine', async () => {
       const userFineGroupIndex = ctx.userFineGroups.findIndex((g) => g.fines.length === 1);
       const userFineGroup = ctx.userFineGroups[userFineGroupIndex];
-      let dbUserFineGroup = await UserFineGroup.findOne({ where: { id: userFineGroup.id }, relations: ['fines', 'fines.transfer'] });
+      let dbUserFineGroup = await UserFineGroup.findOne({ where: { id: userFineGroup.id }, relations: {
+        fines: {
+          transfer: true,
+        },
+      } });
       expect(dbUserFineGroup).to.not.be.null;
       expect(dbUserFineGroup.fines.length).to.equal(1);
 
@@ -259,7 +263,11 @@ describe('DebtorService', (): void => {
     it('should correctly delete a single fine in a larger fineUserGroup', async () => {
       const userFineGroupIndex = ctx.userFineGroups.findIndex((g) => g.fines.length > 1);
       const userFineGroup = ctx.userFineGroups[userFineGroupIndex];
-      let dbUserFineGroup = await UserFineGroup.findOne({ where: { id: userFineGroup.id }, relations: ['fines', 'fines.transfer'] });
+      let dbUserFineGroup = await UserFineGroup.findOne({ where: { id: userFineGroup.id }, relations: {
+        fines: {
+          transfer: true,
+        },
+      } });
       expect(dbUserFineGroup).to.not.be.null;
       expect(dbUserFineGroup.fines.length).to.be.greaterThan(1);
 
@@ -285,7 +293,11 @@ describe('DebtorService', (): void => {
     it('should correctly delete currentFines reference when user tops up after being fined the second time', async () => {
       const userFineGroupIndex = ctx.userFineGroups.findIndex((g) => g.fines.length > 1 && calculateBalance(g.user, ctx.transactions, ctx.subTransactions, ctx.transfersInclFines).amount.getAmount() < 0);
       const userFineGroup = ctx.userFineGroups[userFineGroupIndex];
-      let dbUserFineGroup = await UserFineGroup.findOne({ where: { id: userFineGroup.id }, relations: ['fines', 'fines.transfer'] });
+      let dbUserFineGroup = await UserFineGroup.findOne({ where: { id: userFineGroup.id }, relations: {
+        fines: {
+          transfer: true,
+        },
+      } });
       expect(dbUserFineGroup).to.not.be.null;
       expect(dbUserFineGroup.fines.length).to.be.greaterThan(1);
       const fine = dbUserFineGroup.fines[0];
@@ -356,7 +368,11 @@ describe('DebtorService', (): void => {
       }, actor);
 
       const eventId = handoutEvent.id;
-      const dbEvent = await FineHandoutEvent.findOne({ where: { id: eventId }, relations: ['fines', 'fines.transfer'] });
+      const dbEvent = await FineHandoutEvent.findOne({ where: { id: eventId }, relations: {
+        fines: {
+          transfer: true,
+        },
+      } });
       expect(dbEvent).to.not.be.undefined;
       expect(dbEvent!.fines.length).to.equal(handoutEvent.fines.length);
 
@@ -655,7 +671,9 @@ describe('DebtorService', (): void => {
   });
 
   async function clearFines() {
-    const fines = await Fine.find({ relations: ['transfer'] });
+    const fines = await Fine.find({ relations: {
+      transfer: true,
+    } });
     const fineTransfers = fines.map((f) => f.transfer);
 
     await Fine.clear();
@@ -685,7 +703,9 @@ describe('DebtorService', (): void => {
   describe('handOutFines', async () => {
     beforeAll(async () => {
       await clearFines();
-      const fineTransfers = (await Transfer.find({ relations: ['fine'] })).filter((t) => t.fine != null);
+      const fineTransfers = (await Transfer.find({ relations: {
+        fine: true,
+      } })).filter((t) => t.fine != null);
       expect(fineTransfers.length).to.equal(0);
     });
 
@@ -731,7 +751,9 @@ describe('DebtorService', (): void => {
       if (f.amount.getAmount() > 0) {
         expect((await User.findOne({
           where: { id: f.userFineGroup.userId },
-          relations: ['currentFines'],
+          relations: {
+            currentFines: true,
+          },
         })).currentFines.id).to.equal(f.userFineGroup.id);
       }
       expect(f.fineHandoutEvent.id).to.equal(fineGroup.id);
@@ -759,7 +781,17 @@ describe('DebtorService', (): void => {
       expect(fineHandoutEvent.createdBy.id).to.equal(ctx.actor.id);
 
       const fines = await Promise.all(fineHandoutEvent.fines.map((f) => Fine
-        .findOne({ where: { id: f.id }, relations: ['transfer', 'transfer.from', 'fineHandoutEvent', 'userFineGroup', 'userFineGroup.user'] })));
+        .findOne({ where: { id: f.id }, relations: {
+          transfer: {
+            from: true,
+          },
+
+          fineHandoutEvent: true,
+
+          userFineGroup: {
+            user: true,
+          },
+        } })));
 
       await Promise.all(fines.map(async (f) => {
         const preCalcedFine = usersToFine.find((u) => u.id === f.userFineGroup.userId);
@@ -786,7 +818,9 @@ describe('DebtorService', (): void => {
       expect(user).to.not.be.undefined;
       let userFineGroups = await UserFineGroup.find({
         where: { userId: user.id },
-        relations: ['fines'],
+        relations: {
+          fines: true,
+        },
       });
       expect(userFineGroups).to.be.length(0);
 
@@ -806,7 +840,9 @@ describe('DebtorService', (): void => {
       expect(fineHandoutEvent1.fines[0].userFineGroup.userId).to.equal(fineHandoutEvent2.fines[0].userFineGroup.userId);
       userFineGroups = await UserFineGroup.find({
         where: { userId: user.id },
-        relations: ['fines'],
+        relations: {
+          fines: true,
+        },
       });
       expect(userFineGroups.length).to.equal(1);
       const collection = userFineGroups[0];
@@ -830,7 +866,9 @@ describe('DebtorService', (): void => {
     });
     it('should not set User.currentFines attribute when user gets 0.00 fine', async () => {
       const user = ctx.users.find((u) => calculateBalance(u, ctx.transactions, ctx.subTransactions, ctx.transfersInclFines).amount.getAmount() > 0);
-      let dbUser = await User.findOne({ where: { id: user.id }, relations: ['currentFines'] });
+      let dbUser = await User.findOne({ where: { id: user.id }, relations: {
+        currentFines: true,
+      } });
       expect(dbUser.currentFines).to.be.null;
 
       const fineHandoutEvent = await new DebtorService().handOutFines({ userIds: [user.id], referenceDate: new Date() }, ctx.actor);
@@ -839,7 +877,9 @@ describe('DebtorService', (): void => {
       expect(fine.userFineGroup.userId).to.equal(user.id);
       expect(fine.amount.getAmount()).to.equal(0);
 
-      dbUser = await User.findOne({ where: { id: user.id }, relations: ['currentFines'] });
+      dbUser = await User.findOne({ where: { id: user.id }, relations: {
+        currentFines: true,
+      } });
       expect(calculateBalance(user, ctx.transactions, ctx.subTransactions, ctx.transfersInclFines).amount.getAmount())
         .to.be.greaterThanOrEqual(0);
       expect(dbUser.currentFines).to.be.null;
@@ -935,7 +975,10 @@ describe('DebtorService', (): void => {
       const debtorService = new DebtorService();
       await debtorService.waiveFines(fineHandoutEvent.fines[0].userFineGroup.userId, ctx.waiveFinesParams);
 
-      const transfer = await Transfer.findOne({ where: { waivedFines: { userId: fineHandoutEvent.fines[0].userFineGroup.userId } }, relations: ['fine', 'waivedFines'] });
+      const transfer = await Transfer.findOne({ where: { waivedFines: { userId: fineHandoutEvent.fines[0].userFineGroup.userId } }, relations: {
+        fine: true,
+        waivedFines: true,
+      } });
       transfer.fine = await Fine.create({
         userFineGroup: await UserFineGroup.findOne({ where: { userId: fineHandoutEvent.fines[0].userFineGroup.userId } }),
         fineHandoutEvent: await FineHandoutEvent.findOne({ where: { id: fineHandoutEvent.id } }),

--- a/test/unit/service/event-service.ts
+++ b/test/unit/service/event-service.ts
@@ -477,7 +477,11 @@ describe('eventService', () => {
     beforeAll(async () => {
       originalEvent = await Event.findOne({
         where: { answers: { shift: { deletedAt: null } } },
-        relations: ['answers', 'answers.shift'],
+        relations: {
+          answers: {
+            shift: true,
+          },
+        },
       });
     });
 

--- a/test/unit/service/invoice-service.ts
+++ b/test/unit/service/invoice-service.ts
@@ -355,11 +355,13 @@ describe('InvoiceService', () => {
             where: {
               id: In(transactions.map((transaction) => transaction.tId)),
             },
-            relations: [
-              'subTransactions',
-              'subTransactions.subTransactionRows',
-              'subTransactions.subTransactionRows.invoice',
-            ],
+            relations: {
+              subTransactions: {
+                subTransactionRows: {
+                  invoice: true,
+                },
+              },
+            },
           });
           linkedTransactions.forEach((t) => {
             t.subTransactions.forEach((tSub) => {
@@ -528,7 +530,9 @@ describe('InvoiceService', () => {
           expect(updatedInvoice.transfer.amountInclVat.getCurrency()).is.equal(validUpdateInvoiceParams.amount.currency);
           expect(updatedInvoice.transfer.amountInclVat.getPrecision()).is.equal(validUpdateInvoiceParams.amount.precision);
 
-          const fromDB = await Invoice.findOne({ where: { id: invoice.id }, relations: ['transfer'] });
+          const fromDB = await Invoice.findOne({ where: { id: invoice.id }, relations: {
+            transfer: true,
+          } });
           expect(fromDB.transfer.amountInclVat.getAmount()).is.equal(validUpdateInvoiceParams.amount.amount);
           expect(fromDB.transfer.amountInclVat.getCurrency()).is.equal(validUpdateInvoiceParams.amount.currency);
           expect(fromDB.transfer.amountInclVat.getPrecision()).is.equal(validUpdateInvoiceParams.amount.precision);
@@ -682,11 +686,13 @@ describe('InvoiceService', () => {
             where: {
               id: In(transactions.map((transaction) => transaction.tId)),
             },
-            relations: [
-              'subTransactions',
-              'subTransactions.subTransactionRows',
-              'subTransactions.subTransactionRows.invoice',
-            ],
+            relations: {
+              subTransactions: {
+                subTransactionRows: {
+                  invoice: true,
+                },
+              },
+            },
           });
           invoiceTransactions.forEach((t) => {
             t.subTransactions.forEach((tSub) => {
@@ -709,11 +715,13 @@ describe('InvoiceService', () => {
             where: {
               id: In(transactions.map((transaction) => transaction.tId)),
             },
-            relations: [
-              'subTransactions',
-              'subTransactions.subTransactionRows',
-              'subTransactions.subTransactionRows.invoice',
-            ],
+            relations: {
+              subTransactions: {
+                subTransactionRows: {
+                  invoice: true,
+                },
+              },
+            },
           });
           invoiceTransactions.forEach((t) => {
             t.subTransactions.forEach((tSub) => {
@@ -801,7 +809,11 @@ describe('InvoiceService', () => {
         // Get the transaction from the invoice's subtransaction rows
         const subTransactionRow = await SubTransactionRow.findOne({
           where: { id: invoice.subTransactionRows[0].id },
-          relations: ['subTransaction', 'subTransaction.transaction'],
+          relations: {
+            subTransaction: {
+              transaction: true,
+            },
+          },
         });
         const transaction = subTransactionRow.subTransaction.transaction;
 
@@ -838,14 +850,22 @@ describe('InvoiceService', () => {
         // Get one of the transactions
         const subTransactionRow = await SubTransactionRow.findOne({
           where: { id: invoice.subTransactionRows[0].id },
-          relations: ['subTransaction', 'subTransaction.transaction'],
+          relations: {
+            subTransaction: {
+              transaction: true,
+            },
+          },
         });
         const transaction = subTransactionRow.subTransaction.transaction;
 
         // Verify this transaction has multiple subtransaction rows
         const transactionWithRows = await Transaction.findOne({
           where: { id: transaction.id },
-          relations: ['subTransactions', 'subTransactions.subTransactionRows'],
+          relations: {
+            subTransactions: {
+              subTransactionRows: true,
+            },
+          },
         });
         const totalRows = transactionWithRows.subTransactions
           .map((s) => s.subTransactionRows.length)
@@ -876,7 +896,11 @@ describe('InvoiceService', () => {
 
         const subTransactionRow = await SubTransactionRow.findOne({
           where: { id: invoice.subTransactionRows[0].id },
-          relations: ['subTransaction', 'subTransaction.transaction'],
+          relations: {
+            subTransaction: {
+              transaction: true,
+            },
+          },
         });
         const transaction = subTransactionRow.subTransaction.transaction;
 

--- a/test/unit/service/payout-request-pdf-service.ts
+++ b/test/unit/service/payout-request-pdf-service.ts
@@ -220,7 +220,9 @@ describe('PayoutRequestPdfService', async () => {
         status: 200,
       });
 
-      const payoutRequest = await PayoutRequest.findOne({ where: { id: 1 }, relations: ['requestedBy'] });
+      const payoutRequest = await PayoutRequest.findOne({ where: { id: 1 }, relations: {
+        requestedBy: true,
+      } });
       const newPdf = Object.assign(new PayoutRequestPdf(), {
         hash: await payoutRequest.getPdfParamHash(),
         downloadName: 'test',
@@ -244,7 +246,17 @@ describe('PayoutRequestPdfService', async () => {
     it('should throw an error if PDF generation fails', async () => {
       generatePayoutRequestStub.rejects(new Error('Failed to generate PDF'));
 
-      const payoutRequest = await PayoutRequest.findOne({ where: { id: 1 }, relations: ['requestedBy', 'payoutRequestStatus', 'transfer', 'transfer.to', 'transfer.from', 'pdf'] });
+      const payoutRequest = await PayoutRequest.findOne({ where: { id: 1 }, relations: {
+        requestedBy: true,
+        payoutRequestStatus: true,
+
+        transfer: {
+          to: true,
+          from: true,
+        },
+
+        pdf: true,
+      } });
       payoutRequest.pdfService = pdfService;
       await expect(payoutRequest.createPdf()).to.eventually.be.rejectedWith();
     });

--- a/test/unit/service/payout-request-service.ts
+++ b/test/unit/service/payout-request-service.ts
@@ -343,7 +343,9 @@ describe('PayoutRequestService', () => {
 
       const payoutRequestRaw = await PayoutRequest.findOne({
         where: { id: payoutRequest.id },
-        relations: ['transfer'],
+        relations: {
+          transfer: true,
+        },
       });
       expect(payoutRequestRaw.transfer).to.not.be.undefined;
     });

--- a/test/unit/service/point-of-sale-service.ts
+++ b/test/unit/service/point-of-sale-service.ts
@@ -247,7 +247,9 @@ describe('PointOfSaleService', async (): Promise<void> => {
 
       expect(await PointOfSale.count()).to.equal(count + 1);
 
-      const updatedPointOfSale = await PointOfSaleRevision.findOne({ where: { pointOfSale: { id: res.id }, revision: res.revision }, relations: ['containers'] });
+      const updatedPointOfSale = await PointOfSaleRevision.findOne({ where: { pointOfSale: { id: res.id }, revision: res.revision }, relations: {
+        containers: true,
+      } });
       const containers = updatedPointOfSale.containers.map((container) => container.container.id);
       expect(ctx.validPOSParams.containers).to.deep.equalInAnyOrder(containers);
 

--- a/test/unit/service/product-service.ts
+++ b/test/unit/service/product-service.ts
@@ -205,7 +205,9 @@ describe('ProductService', async (): Promise<void> => {
           // eslint-disable-next-line no-await-in-loop
           const productRevision = await ProductRevision.findOne({
             where: { product: { id: p.id }, revision: p.revision },
-            relations: ['vat'],
+            relations: {
+              vat: true,
+            },
           });
           const vatGroup = productRevision!.vat;
           expect(vatGroup.hidden).to.be.true;
@@ -482,7 +484,13 @@ describe('ProductService', async (): Promise<void> => {
       const containerEntity = await Container.findOne({ where: { id: containerRev.containerId } });
       expect(containerEntity.currentRevision).to.be.eq(2);
 
-      const productInContainer = (await ContainerRevision.findOne({ where: { revision: 2, container: { id: containerRev.containerId } }, relations: ['container', 'products', 'products.category'] })).products[0];
+      const productInContainer = (await ContainerRevision.findOne({ where: { revision: 2, container: { id: containerRev.containerId } }, relations: {
+        container: true,
+
+        products: {
+          category: true,
+        },
+      } })).products[0];
       expect(productInContainer.name).to.eq(update.name);
       expect(typeof productInContainer.alcoholPercentage === 'string'
         ? parseInt(productInContainer.alcoholPercentage, 10)
@@ -552,7 +560,15 @@ describe('ProductService', async (): Promise<void> => {
       };
 
       await ProductService.updateProduct(productUpdate);
-      const productFromPos = (await PointOfSaleRevision.findOne({ where: { revision: 2, pointOfSale: { id: pos.pointOfSaleId } }, relations: ['pointOfSale', 'containers', 'containers.products', 'containers.products.category'] })).containers[0].products[0];
+      const productFromPos = (await PointOfSaleRevision.findOne({ where: { revision: 2, pointOfSale: { id: pos.pointOfSaleId } }, relations: {
+        pointOfSale: true,
+
+        containers: {
+          products: {
+            category: true,
+          },
+        },
+      } })).containers[0].products[0];
 
       expect(productFromPos.name).to.eq(productUpdate.name);
       expect(productFromPos.category.id).to.eq(productUpdate.category);

--- a/test/unit/service/qr-service.ts
+++ b/test/unit/service/qr-service.ts
@@ -199,7 +199,9 @@ describe('QRService', (): void => {
       // Verify the confirmation was saved
       const updatedQr = await QRAuthenticator.findOne({ 
         where: { sessionId: pendingQr.sessionId },
-        relations: ['user'],
+        relations: {
+          user: true,
+        },
       });
       expect(updatedQr.status).to.equal(QRAuthenticatorStatus.CONFIRMED);
       expect(updatedQr.user.id).to.equal(user.id);

--- a/test/unit/service/stripe-service.ts
+++ b/test/unit/service/stripe-service.ts
@@ -145,12 +145,12 @@ describe.skipIf(shouldSkipStripe)('StripeService', async (): Promise<void> => {
     });
     it('should correctly create only one success status', async () => {
       const { id } = (ctx.stripeDeposits.filter((d) => d.stripePaymentIntent.paymentIntentStatuses.length === 2 && !d.transfer))[0];
-      let deposit = await StripeService.getStripeDeposit(id, ['transfer', 'transfer.to', 'to']);
+      let deposit = await StripeService.getStripeDeposit(id, { transfer: { to: true }, to: true });
       expect(deposit.transfer).to.be.null;
 
       await testStatusCreation(id, StripePaymentIntentState.SUCCEEDED);
 
-      deposit = await StripeService.getStripeDeposit(id, ['transfer', 'transfer.to', 'to']);
+      deposit = await StripeService.getStripeDeposit(id, { transfer: { to: true }, to: true });
       // Correct transfer should have been created
       expect(deposit.transfer).to.not.be.null;
       expect(ctx.dineroTransformer.to(deposit.transfer.amountInclVat))

--- a/test/unit/service/transaction-service.ts
+++ b/test/unit/service/transaction-service.ts
@@ -1029,7 +1029,11 @@ describe('TransactionService', (): void => {
 
         const authPos = await PointOfSaleRevision.findOne({
           where: { useAuthentication: true },
-          relations: ['containers', 'containers.products'],
+          relations: {
+            containers: {
+              products: true,
+            },
+          },
         });
         expect(authPos).to.not.be.null;
         const posResponse = await getPOSResponse(authPos);
@@ -1052,7 +1056,11 @@ describe('TransactionService', (): void => {
 
         const nonAuthPos = await PointOfSaleRevision.findOne({
           where: { useAuthentication: false },
-          relations: ['containers', 'containers.products'],
+          relations: {
+            containers: {
+              products: true,
+            },
+          },
         });
         expect(nonAuthPos).to.not.be.null;
         const posResponse = await getPOSResponse(nonAuthPos);
@@ -1074,7 +1082,11 @@ describe('TransactionService', (): void => {
 
         const authPos = await PointOfSaleRevision.findOne({
           where: { useAuthentication: true },
-          relations: ['containers', 'containers.products'],
+          relations: {
+            containers: {
+              products: true,
+            },
+          },
         });
         const posResponse = await getPOSResponse(authPos);
 
@@ -1104,7 +1116,11 @@ describe('TransactionService', (): void => {
 
         const authPos = await PointOfSaleRevision.findOne({
           where: { useAuthentication: true },
-          relations: ['containers', 'containers.products'],
+          relations: {
+            containers: {
+              products: true,
+            },
+          },
         });
         const posResponse = await getPOSResponse(authPos);
 

--- a/test/unit/service/user-service.ts
+++ b/test/unit/service/user-service.ts
@@ -960,12 +960,16 @@ describe('UserService', async (): Promise<void> => {
         const user = ctx.users.find((u) => u.type === UserType.LOCAL_USER);
         const newType = UserType.MEMBER;
 
-        let localAuth = await LocalAuthenticator.findOne({ where: { user: { id: user.id } }, relations: ['user'] });
+        let localAuth = await LocalAuthenticator.findOne({ where: { user: { id: user.id } }, relations: {
+          user: true,
+        } });
         expect(localAuth).to.not.be.null;
 
         await UserService.updateUserType(user, newType);
 
-        localAuth = await LocalAuthenticator.findOne({ where: { user: { id: user.id } }, relations: ['user'] });
+        localAuth = await LocalAuthenticator.findOne({ where: { user: { id: user.id } }, relations: {
+          user: true,
+        } });
         expect(localAuth).to.be.null;
       });
     });

--- a/test/unit/service/websocket/pos-relation-helper.ts
+++ b/test/unit/service/websocket/pos-relation-helper.ts
@@ -55,7 +55,10 @@ describe('POS Relation Helper', () => {
     for (let i = 0; i < pointsOfSale.length; i++) {
       const loaded = await PointOfSale.findOne({
         where: { id: pointsOfSale[i].id },
-        relations: ['owner', 'user'],
+        relations: {
+          owner: true,
+          user: true,
+        },
       });
       expect(loaded).to.not.be.null;
       if (loaded) {

--- a/test/unit/service/write-off-pdf-service.ts
+++ b/test/unit/service/write-off-pdf-service.ts
@@ -204,7 +204,9 @@ describe('WriteOffPdfService', () => {
         status: 200,
       });
 
-      const writeOff = await WriteOff.findOne({ where: { id: 1 }, relations: ['to'] });
+      const writeOff = await WriteOff.findOne({ where: { id: 1 }, relations: {
+        to: true,
+      } });
       const newPdf = Object.assign(new WriteOffPdf(), {
         hash: await writeOff.getPdfParamHash(),
         downloadName: 'test',
@@ -228,7 +230,10 @@ describe('WriteOffPdfService', () => {
     it('should throw an error if PDF generation fails', async () => {
       generateWriteOffStub.rejects(new Error('Failed to generate PDF'));
 
-      const writeOff = await WriteOff.findOne({ where: { id: 1 }, relations: ['to', 'transfer'] });
+      const writeOff = await WriteOff.findOne({ where: { id: 1 }, relations: {
+        to: true,
+        transfer: true,
+      } });
       writeOff.pdfService = pdfService;
       await expect(writeOff.createPdf()).to.eventually.be.rejectedWith();
     });

--- a/test/unit/subscribe/transfer-subscriber.ts
+++ b/test/unit/subscribe/transfer-subscriber.ts
@@ -81,12 +81,16 @@ describe('TransferSubscriber', (): void => {
       const { fines } = await new DebtorService().handOutFines({ userIds: [user.id], referenceDate: new Date() }, ctx.users[0]);
       const fine = await Fine.findOne({
         where: { id: fines[0].id },
-        relations: ['userFineGroup'],
+        relations: {
+          userFineGroup: true,
+        },
       });
       expect(fine.userFineGroup.userId).to.equal(user.id);
       // Sanity check
 
-      let dbUser = await User.findOne({ where: { id: user.id }, relations: ['currentFines'] });
+      let dbUser = await User.findOne({ where: { id: user.id }, relations: {
+        currentFines: true,
+      } });
       expect(dbUser.currentFines).to.not.be.null;
       expect(dbUser.currentFines).to.not.be.undefined;
       // Positive number to be added
@@ -98,7 +102,9 @@ describe('TransferSubscriber', (): void => {
 
       const newBalance = await new BalanceService().getBalance(user.id);
       expect(newBalance.amount.amount).to.equal(0);
-      dbUser = await User.findOne({ where: { id: user.id }, relations: ['currentFines'] });
+      dbUser = await User.findOne({ where: { id: user.id }, relations: {
+        currentFines: true,
+      } });
       expect(dbUser.currentFines).to.be.null;
     });
     it('should not set currentFines to null when debt is not fully paid', async () => {
@@ -111,12 +117,16 @@ describe('TransferSubscriber', (): void => {
       const { fines } = await new DebtorService().handOutFines({ userIds: [user.id], referenceDate: new Date() }, ctx.users[0]);
       const fine = await Fine.findOne({
         where: { id: fines[0].id },
-        relations: ['userFineGroup'],
+        relations: {
+          userFineGroup: true,
+        },
       });
       expect(fine.userFineGroup.userId).to.equal(user.id);
       // Sanity check
 
-      let dbUser = await User.findOne({ where: { id: user.id }, relations: ['currentFines'] });
+      let dbUser = await User.findOne({ where: { id: user.id }, relations: {
+        currentFines: true,
+      } });
       expect(dbUser.currentFines).to.not.be.null;
       expect(dbUser.currentFines).to.not.be.undefined;
       // Positive number to be added, but not enough to pay the full debt
@@ -130,7 +140,9 @@ describe('TransferSubscriber', (): void => {
 
       const newBalance = await new BalanceService().getBalance(user.id);
       expect(newBalance.amount.amount).to.be.lessThan(0);
-      dbUser = await User.findOne({ where: { id: user.id }, relations: ['currentFines'] });
+      dbUser = await User.findOne({ where: { id: user.id }, relations: {
+        currentFines: true,
+      } });
       expect(dbUser.currentFines).to.not.be.null;
     });
     it('should not set currentFines to null for negative transfers', async () => {
@@ -143,12 +155,16 @@ describe('TransferSubscriber', (): void => {
       const { fines } = await new DebtorService().handOutFines({ userIds: [user.id], referenceDate: new Date() }, ctx.users[0]);
       const fine = await Fine.findOne({
         where: { id: fines[0].id },
-        relations: ['userFineGroup'],
+        relations: {
+          userFineGroup: true,
+        },
       });
       expect(fine.userFineGroup.userId).to.equal(user.id);
       // Sanity check
 
-      let dbUser = await User.findOne({ where: { id: user.id }, relations: ['currentFines'] });
+      let dbUser = await User.findOne({ where: { id: user.id }, relations: {
+        currentFines: true,
+      } });
       expect(dbUser.currentFines).to.not.be.null;
       expect(dbUser.currentFines).to.not.be.undefined;
       // Positive number to be added, but not enough to pay the full debt
@@ -160,7 +176,9 @@ describe('TransferSubscriber', (): void => {
 
       const newBalance = await new BalanceService().getBalance(user.id);
       expect(newBalance.amount.amount).to.be.greaterThanOrEqual(0);
-      dbUser = await User.findOne({ where: { id: user.id }, relations: ['currentFines'] });
+      dbUser = await User.findOne({ where: { id: user.id }, relations: {
+        currentFines: true,
+      } });
       expect(dbUser.currentFines).to.not.be.null;
     });
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
-        "target": "ES2021",
+        "target": "ES2023",
         "module": "commonjs",
+        "useDefineForClassFields": false,
         "noImplicitAny": true,
         "removeComments": true,
         "preserveConstEnums": true,

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -10,7 +10,7 @@ export default defineConfig({
           decorators: true,
           dynamicImport: true,
         },
-        target: 'es2021',
+        target: 'es2023',
         transform: {
           legacyDecorator: true,
           decoratorMetadata: true,


### PR DESCRIPTION
## Summary

- Bump `typeorm` from 0.3.29 to 1.0.0. Raise the TS and vitest swc target from ES2021 to ES2023, which is the new minimum.
- Pin `useDefineForClassFields: false` in tsconfig.json. ES2023 flips its default to `true`, so tsc starts emitting `this.relation = undefined` for declared-but-uninitialized relation fields. That breaks TypeORM entity hydration: `Permission.role` becomes a literal `undefined` property and shows up in property iteration. CI's JS-compiled test path caught it via `default-roles`. The TS-source vitest pass didn't, because swc already had this option set.
- Apply `@typeorm/codemod v1` across `src/`, `test/`, `cli/` to convert string-array `relations`/`select` find options to object syntax and rename `findByIds`/`findOneById`/`exist`.
- Add `invalidWhereValuesBehavior` settings in the DataSource so existing filter helpers keep working under the new defaults.

Closes #929.

## Behavioral changes I had to handle

Two 1.0 default changes broke things in `src/database/database.ts`. I pinned both back to 0.3 behavior instead of rewriting hundreds of call sites.

`undefined` in `where` used to be silently skipped. In 1.0 it throws. Plenty of services do `createdAt: createFilterWhereDate(from, till)` directly inside `where` and rely on the key dropping out when both dates are missing. Without the setting that's 175 test failures. With `invalidWhereValuesBehavior.undefined = 'ignore'` it's back to working.

`null` is similar, except some of the offenders are TypeORM itself. The internal soft-delete handling emits `deletedAt: null` when joining to entities with `@DeleteDateColumn` (e.g. `EventShift`), so the new default throws on queries that worked fine in 0.3. Setting `null = 'sql-null'` translates it to SQL `IS NULL`, which is what it's supposed to mean in that context anyway.

The other documented behavioral change, non-nullable relations now using INNER JOIN, I left alone. FK constraints rule out orphans on these relations and nothing in the test suite tripped.

## What I audited and didn't adopt

`await using` on QueryRunner. The 1.0 release notes claim support, but `QueryRunner.d.ts` doesn't actually declare `[Symbol.asyncDispose]`. tsc rejects `await using queryRunner = ds.createQueryRunner()` with TS2851. Worth revisiting once the types catch up; for now `try { ... } finally { release() }` stays.

`returning` on `update()`/`upsert()` needs a `RETURNING` clause. Prod is MySQL, no dice.

`ifExists` on the various drop methods only matters for new migrations. Editing already-applied ones is pointless churn.

The PostgreSQL / SAP HANA / MongoDB / Spanner / Aurora improvements are for engines we don't run.

The remaining bits (SQLite `jsonb`, `@Exclusion deferrable`, `increment`/`decrement` typing, DataSource-level `isolationLevel`, `valuesFromSelect()`) don't have a call site that would benefit.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` -- 2368 pass, 27 skipped on the rebased branch. (175 failed before the compat setting; the `default-roles` JS-compiled regression was fixed by the `useDefineForClassFields` pin.)
- [x] `pnpm run schema` -- in-memory SQLite bootstrap works
- [x] `pnpm run migrate` against MySQL -- ran via CI's `coverage-mariadb` job (passed, 5m9s)

Upgrade guide: https://typeorm.io/docs/releases/1.0/upgrading-from-0.3