### PR TITLE
fix: Dockerfile docs not having right deps

### DIFF
--- a/Dockerfile-docs
+++ b/Dockerfile-docs
@@ -1,5 +1,6 @@
 FROM node:20-alpine AS typedoc-builder
 
+RUN apk add --no-cache python3 make g++
 RUN npm install -g pnpm@10.33.0
 
 WORKDIR /app
@@ -13,6 +14,7 @@ RUN pnpm typedoc
 
 FROM node:20-alpine AS vitepress-builder
 
+RUN apk add --no-cache python3 make g++
 RUN npm install -g pnpm@10.33.0
 
 WORKDIR /app


### PR DESCRIPTION
Adds python as dependency in the Dockerfile for docks

## Types of changes
- CI/CD _(Changes to the CI/CD configuration)_

---

## ✅ PR Checklist

- [X] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [X] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [X] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB