### PR TITLE
Route stray console.* calls through log4js

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@
  */
 
 import dotenv from 'dotenv';
+import log4js from 'log4js';
 
 dotenv.config();
 
@@ -215,9 +216,10 @@ export default class Config {
         .filter(([, value]) => value == null)
         .map(([key]) => key);
       if (missingKeys.length > 0) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `[Config] ENABLE_LDAP is true but the following LDAP_* environment variables are missing: ${missingKeys.join(', ')}. LDAP sync will fail at runtime.`,
+        const logger = log4js.getLogger('Config');
+        logger.level = getOptionalString('LOG_LEVEL') ?? 'info';
+        logger.warn(
+          `ENABLE_LDAP is true but the following LDAP_* environment variables are missing: ${missingKeys.join(', ')}. LDAP sync will fail at runtime.`,
         );
       }
     }

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -187,9 +187,8 @@ async function createCronTasks(): Promise<void> {
 if (require.main === module) {
   // Only execute the application directly if this is the main execution file.
   createCronTasks().catch((e) => {
-    console.error(e);
-    const logger = log4js.getLogger('index');
-    applyConfiguredLogLevel(logger);
+    const logger = log4js.getLogger('cron');
+    logger.level = process.env.LOG_LEVEL ?? 'info';
     logger.fatal(e);
   });
 }

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -116,12 +116,16 @@ import {
 } from '../migrations/1777010230751-stripe-payment-intent-payment-request';
 import Config from '../config';
 import { AddExpiryToUser1778681972323 } from '../migrations/1778681972323-add-expiry-to-user';
+import log4js, { Logger } from 'log4js';
+import { applyConfiguredLogLevel } from '../helpers/logging';
 
 function getDataSourceOptions(): DataSourceOptions {
   const config = Config.get();
 
   if (config.app.isTest) {
-    console.log('TYPEORM_CONNECTION:', config.database.connection);
+    const logger: Logger = log4js.getLogger('Database');
+    applyConfiguredLogLevel(logger);
+    logger.info(`TYPEORM_CONNECTION: ${config.database.connection}`);
   }
 
   const options = {

--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -56,7 +56,11 @@ export default async function migrate() {
 
 if (require.main === module) {
   // Only execute the application directly if this is the main execution file.
-  if (Config.get().database.isSqlite) console.warn('Migrations in sqlite most likely have no effect.');
+  if (Config.get().database.isSqlite) {
+    const logger = log4js.getLogger('Migration');
+    applyConfiguredLogLevel(logger);
+    logger.warn('Migrations in sqlite most likely have no effect.');
+  }
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   migrate();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -338,9 +338,8 @@ export default async function createApp(): Promise<Application> {
 if (require.main === module) {
   // Only execute the application directly if this is the main execution file.
   createApp().catch((e) => {
-    console.error(e);
     const logger = log4js.getLogger('index');
-    applyConfiguredLogLevel(logger);
+    logger.level = process.env.LOG_LEVEL ?? 'info';
     logger.fatal(e);
   });
 }

--- a/src/maintenance.ts
+++ b/src/maintenance.ts
@@ -175,9 +175,8 @@ async function runMaintenance(): Promise<void> {
     await application.stop();
     
   } catch (error) {
-    console.error('❌ Maintenance failed:', error);
-    const logger = log4js.getLogger('maintenance');
-    applyConfiguredLogLevel(logger);
+    const logger = log4js.getLogger('Maintenance');
+    logger.level = process.env.LOG_LEVEL ?? 'info';
     logger.fatal('Maintenance failed:', error);
     process.exit(1);
   }

--- a/src/middleware/policy-middleware.ts
+++ b/src/middleware/policy-middleware.ts
@@ -25,8 +25,10 @@
  */
 
 import { RequestHandler, Response } from 'express';
+import log4js, { Logger } from 'log4js';
 import { PolicyImplementation } from '../controller/policy';
 import { RequestWithToken } from './token-middleware';
+import { applyConfiguredLogLevel } from '../helpers/logging';
 
 /**
  * This class is responsible for:
@@ -38,12 +40,16 @@ export default class PolicyMiddleware {
    */
   private readonly policy: PolicyImplementation;
 
+  private readonly logger: Logger;
+
   /**
    * Creates a new policy middleware instance.
    * @param policy - the policy to be used by this middleware.
    */
   public constructor(policy: PolicyImplementation) {
     this.policy = policy;
+    this.logger = log4js.getLogger('PolicyMiddleware');
+    applyConfiguredLogLevel(this.logger);
   }
 
   /**
@@ -61,7 +67,7 @@ export default class PolicyMiddleware {
       res.status(403).end('You have insufficient permissions for the requested action.');
       return;
     } catch (e) {
-      console.error(e);
+      this.logger.error(e);
       res.status(500).json('Internal server error.');
     }
   }

--- a/src/service/ad-service.ts
+++ b/src/service/ad-service.ts
@@ -26,6 +26,7 @@
 
 import { Client, EqualityFilter, SearchResult } from 'ldapts';
 import { In } from 'typeorm';
+import log4js, { Logger } from 'log4js';
 import LDAPAuthenticator from '../entity/authenticator/ldap-authenticator';
 import User, { TermsOfServiceStatus, UserType } from '../entity/user/user';
 import { bindUser, LDAPGroup, LDAPResponse, LDAPResult, LDAPUser, userFromLDAP } from '../helpers/ad';
@@ -34,8 +35,18 @@ import RoleManager from '../rbac/role-manager';
 import WithManager from '../database/with-manager';
 import Gewis from '../gewis/gewis';
 import Config from '../config';
+import { applyConfiguredLogLevel } from '../helpers/logging';
 
 export default class ADService extends WithManager {
+  private static loggerInstance: Logger | undefined;
+
+  private static getLogger(): Logger {
+    if (!ADService.loggerInstance) {
+      ADService.loggerInstance = log4js.getLogger('ADService');
+      applyConfiguredLogLevel(ADService.loggerInstance);
+    }
+    return ADService.loggerInstance;
+  }
 
   /**
    * Creates and binds a Shared (Organ) group to an actual User
@@ -207,7 +218,7 @@ export default class ADService extends WithManager {
       });
       return searchEntries.map((e) => (e as any) as T);
     } catch (error) {
-      console.error(error);
+      ADService.getLogger().error(error);
       return undefined;
     }
   }

--- a/src/start/swagger.ts
+++ b/src/start/swagger.ts
@@ -100,7 +100,7 @@ export default class Swagger {
           JSON.stringify(swaggerObject),
           { encoding: 'utf-8' },
         ).catch((e) => {
-          console.error(e);
+          Swagger.logger.error('Failed to write Swagger specification:', e);
         });
         instance.removeAllListeners();
         resolve(swaggerObject); // Resolve the promise with the swaggerObject


### PR DESCRIPTION
# Description

Routes nine stray `console.warn`/`console.error`/`console.log` calls in `src/` through log4js so backend output is consistent.

Three of them (`cron.ts:190`, `index.ts:341`, `maintenance.ts:178`) sat right next to a `logger.fatal` of the same value, so I dropped the console call instead of rerouting.

`config.ts` reads `LOG_LEVEL` from `process.env` directly because `helpers/logging` imports `Config` -- using the helper would create a circular dep.

The `console.log = (...) => logger.debug(...)` redirects are left alone -- those intentionally pipe library output into log4js.

## Types of changes

- Style _(Change that do not affect the functionality of the code)_

---

## PR Checklist

- [x] **Test Coverage**: No behavior change. `tsc --noEmit` and `eslint` on the nine touched files both pass.
- [x] **Documentation**: No API or JSDoc changes.
- [x] **Database Changes**: None.