### PR TITLE
Documentation improvements: fines, write-offs, payouts, debtors

### DIFF
--- a/src/controller/debtor-controller.ts
+++ b/src/controller/debtor-controller.ts
@@ -19,8 +19,6 @@
  */
 
 /**
- * This is the module page of debtor-controller.
- *
  * @module debtors
  */
 
@@ -40,6 +38,12 @@ import { ReturnFileType } from 'pdf-generator-client';
 import { PdfError } from '../errors';
 import FineHandoutEvent from '../entity/fine/fineHandoutEvent';
 
+/**
+ * Controller for the `/fines` endpoints in the {@link debtors | debtors} module. Covers
+ * the full handout pipeline (eligibility, warning, batch creation, undo) and the
+ * treasurer-facing fine reports. Waiving lives on the user controller; see
+ * {@link users!UserController.waiveUserFines | waiveUserFines} (`POST /users/<id>/fines/waive`).
+ */
 export default class DebtorController extends BaseController {
   private logger: Logger = log4js.getLogger(' DebtorController');
 

--- a/src/controller/payout-request-controller.ts
+++ b/src/controller/payout-request-controller.ts
@@ -19,8 +19,6 @@
  */
 
 /**
- * This is the module page of payout-request-controller.
- *
  * @module payout-requests
  */
 
@@ -41,6 +39,14 @@ import { PdfUrlResponse } from './response/simple-file-response';
 import { PdfError } from '../errors';
 import { asBoolean } from '../helpers/validators';
 
+/**
+ * Controller for the `/payoutrequests` endpoints in the
+ * {@link payout-requests | payout-requests} module. Creation is open to members for their
+ * own balance; status transitions go through
+ * {@link PayoutRequestService.canUpdateStatus | canUpdateStatus} so that only the
+ * treasurer can move a request to a terminal state and the
+ * {@link transfers!Transfer | Transfer} is created on `APPROVED`.
+ */
 export default class PayoutRequestController extends BaseController {
   private logger: Logger = log4js.getLogger('PayoutRequestController');
 

--- a/src/controller/seller-payout-controller.ts
+++ b/src/controller/seller-payout-controller.ts
@@ -19,8 +19,6 @@
  */
 
 /**
- * This is the module page of the seller-payout-controller.
- *
  * @module seller-payouts
  */
 
@@ -37,6 +35,13 @@ import ReportService, { SalesReportService } from '../service/report-service';
 import { PdfError } from '../errors';
 import { PdfUrlResponse } from './response/simple-file-response';
 
+/**
+ * Controller for the `/seller-payouts` endpoints in the
+ * {@link seller-payouts | seller-payouts} module. The amount is snapshotted from
+ * {@link internal/reports!SalesReportService | SalesReportService} at creation time, so
+ * `GET /seller-payouts/<id>/report` re-runs the report live for drift detection and
+ * `PATCH /seller-payouts/<id>` is the lever for reconciling once drift is found.
+ */
 export default class SellerPayoutController extends BaseController {
   private logger: Logger = log4js.getLogger(' SellerPayoutController');
 

--- a/src/controller/write-off-controller.ts
+++ b/src/controller/write-off-controller.ts
@@ -19,8 +19,6 @@
  */
 
 /**
- * This is the module page of the write-off-controller.
- *
  * @module write-offs
  */
 
@@ -39,6 +37,12 @@ import { PdfError } from '../errors';
 import { PdfUrlResponse } from './response/simple-file-response';
 import { asBoolean } from '../helpers/validators';
 
+/**
+ * Controller for the `/writeoffs` endpoints in the {@link write-offs | write-offs}
+ * module. `POST /writeoffs` is the only mutating endpoint and is irreversible: it zeroes
+ * the user's negative balance and closes the account in one go. The rest are reads and
+ * the PDF receipt.
+ */
 export default class WriteOffController extends BaseController {
   private logger: Logger = log4js.getLogger(' WriteOffController');
 

--- a/src/entity/fine/userFineGroup.ts
+++ b/src/entity/fine/userFineGroup.ts
@@ -19,7 +19,65 @@
  */
 
 /**
- * This is the module page of the user-fine-group.
+ * A `fine` is a small penalty (capped at 5 EUR per round) applied to a user with a
+ * persistently negative {@link balance!Balance | Balance}. Fines are handed out in batches
+ * as a debtor-recovery step, not as a per-transaction fee. The amount is
+ * `min(5 EUR, floor(-balance / 5 EUR) * 1 EUR)`, never negative, so a user at -3.40 EUR
+ * gets nothing and a user at -42 EUR still gets only 5 EUR.
+ *
+ * ### Three entities, one story
+ * - {@link FineHandoutEvent} is one batch. A single `POST /fines/handout` creates one event
+ *   that groups every fine handed out in that round, records the `referenceDate` the fines
+ *   were calculated against, and the admin who triggered the run.
+ * - {@link Fine} is one user's slice of a batch. Each fine owns a debit
+ *   {@link transfers!Transfer | Transfer} that moves the penalty off the user's balance.
+ * - {@link UserFineGroup} is the per-user wrapper that ties every fine a user has ever
+ *   received together and (optionally) holds the `waivedTransfer` that cancels them.
+ *   {@link users!User | User.currentFines} points to it while the user still owes; a user
+ *   has at most one open group at a time.
+ *
+ * ### Lifecycle
+ * An admin (typically the financial responsible) hands out fines manually. There is no
+ * cron. The typical sequence is:
+ *
+ * 1. `GET /fines/eligible` returns users who are below -5 EUR both now and on the reference
+ *    date ({@link debtors!DebtorService.calculateFinesOnDate | calculateFinesOnDate}). The
+ *    double check exists so a user who just topped up does not get fined for a historical
+ *    low.
+ * 2. `POST /fines/notify` sends a warning email
+ *    ({@link debtors!DebtorService.sendFineWarnings | sendFineWarnings}) so users have a
+ *    grace period to top up.
+ * 3. `POST /fines/handout` runs the actual handout in one database transaction
+ *    ({@link debtors!DebtorService.handOutFines | handOutFines}): one
+ *    {@link FineHandoutEvent}, one {@link Fine} per eligible user, one debit
+ *    {@link transfers!Transfer | Transfer} per fine, and one notification per fined user.
+ *
+ * ### Waiving
+ * `POST /users/{id}/fines/waive` creates a credit
+ * {@link transfers!Transfer | Transfer} on the user's {@link UserFineGroup} as
+ * `waivedTransfer`. Waiving is replace-not-append: if the group already has a waived
+ * transfer it is removed and a fresh one is created with the new total. Waiving the full
+ * outstanding amount nulls {@link users!User | User.currentFines}, even if the user's
+ * balance is still negative.
+ *
+ * ### Undoing
+ * `DELETE /fines/single/{id}` removes one fine and its debit transfer; if that was the
+ * only fine in the group, the {@link UserFineGroup} goes too.
+ * `DELETE /fines/handout/{id}` rolls back a whole batch the same way. Both delete instead
+ * of writing a compensating row; fines are the rare exception to the rule that nothing on
+ * the ledger disappears.
+ *
+ * ### Reflection on the balance
+ * {@link balance!Balance | Balance} treats fine and waiver transfers like any other
+ * transfer. On top of that, {@link balance!BalanceResponse | BalanceResponse} surfaces
+ * the fine state as four "now" fields: `fine` (outstanding), `fineSince` (timestamp of
+ * the first fine), `nrFines` (count), and `fineWaived` (amount already waived). Those
+ * fields are not historical, so ignore them when `date` is in the past.
+ *
+ * ### Reporting
+ * `GET /fines/report?fromDate=...&tillDate=...` returns aggregate handed-out and waived
+ * totals for treasurer reconciliation; `GET /fines/report/pdf` produces the printable
+ * version. The service orchestrating everything above lives in {@link debtors | debtors}.
  *
  * @module fines
  * @mergeTarget

--- a/src/entity/transactions/payout/payout-request.ts
+++ b/src/entity/transactions/payout/payout-request.ts
@@ -19,7 +19,57 @@
  */
 
 /**
- * This is the module page of the payout-request.
+ * A `payout-request` is a user-initiated withdrawal: a member with a positive
+ * {@link balance!Balance | Balance} asks for the money to be sent to a real bank account.
+ * In practice this is mostly the exit hatch for members leaving the association who want
+ * their leftover credit back; active members tend to just keep spending it.
+ *
+ * ### Two-phase commit
+ * Creating a payout request does not move money. `POST /payoutrequests` saves a
+ * {@link PayoutRequest} with status {@link PayoutRequestState.CREATED | CREATED}; the
+ * member is on the hook for nothing yet.
+ *
+ * Money moves only when a treasurer approves it. `POST /payoutrequests/{id}/status` with
+ * `state = APPROVED` runs
+ * {@link PayoutRequestService.updateStatus | updateStatus}, which creates a debit
+ * {@link transfers!Transfer | Transfer} (`from = requestedBy`, `to = null` because the
+ * money leaves SudoSOS) and stamps `approvedBy`.
+ *
+ * ### State machine
+ * Statuses live on the related {@link PayoutRequestStatus} table as an append-only history,
+ * not as a single column. {@link PayoutRequestState} has four values and one start state:
+ *
+ * - {@link PayoutRequestState.CREATED | CREATED} is set on creation.
+ * - {@link PayoutRequestState.APPROVED | APPROVED} is terminal and creates the transfer.
+ *   Mutually exclusive with `DENIED` and `CANCELLED`.
+ * - {@link PayoutRequestState.DENIED | DENIED} is terminal. The treasurer rejected the
+ *   request, so no transfer is written.
+ * - {@link PayoutRequestState.CANCELLED | CANCELLED} is terminal. The requester pulled it
+ *   back, so no transfer is written.
+ *
+ * {@link PayoutRequestService.canUpdateStatus | canUpdateStatus} guards the transitions:
+ * any of the three terminal states locks out the other two, and a state cannot be applied
+ * twice.
+ *
+ * ### Bank details on the entity
+ * Unlike most money movement in SudoSOS, the destination here is outside the system, so
+ * `bankAccountNumber` and `bankAccountName` are columns on `PayoutRequest` itself. They
+ * are captured at request time and frozen, since editing them after approval would
+ * desync the printed PDF.
+ *
+ * ### Listing and PDFs
+ * `GET /payoutrequests` paginates with filters (status, requestedBy, date range);
+ * `GET /payoutrequests/{id}` returns the full status history. `PayoutRequest` extends
+ * `PdfAble`, so `GET /payoutrequests/{id}/pdf` produces the treasurer's printable receipt
+ * with the bank details on it.
+ *
+ * ### Versus seller-payouts
+ * Both modules share `BasePayout` (`requestedBy`, `amount`, `transfer`) and both debit a
+ * single user, but they answer different questions. A payout-request is one member
+ * asking for their own credit back, gated on treasurer approval. A
+ * {@link seller-payouts!SellerPayout | SellerPayout} is the treasurer settling sales
+ * credit to an organ for a closed time window, with no approval step and an amount
+ * derived from a sales report rather than declared by the user.
  *
  * @module payout-requests
  * @mergeTarget

--- a/src/entity/transactions/payout/seller-payout.ts
+++ b/src/entity/transactions/payout/seller-payout.ts
@@ -19,7 +19,54 @@
  */
 
 /**
- * This is the module page of the seller-payout.
+ * A `seller-payout` settles sales credit from SudoSOS to an organ. Every
+ * {@link transactions/sub-transactions!SubTransactionRow | SubTransactionRow} that crosses
+ * the till credits the container-owner's user account
+ * ({@link users!UserType.ORGAN | ORGAN} users hold this credit). Once a quarter, or
+ * whenever the organ asks for a settlement, a treasurer creates a seller-payout that
+ * sweeps the accumulated credit back out to the real-world bank account.
+ *
+ * ### Snapshot at creation, not a live link
+ * Each {@link SellerPayout} covers a `[startDate, endDate]` window of revenue. At creation
+ * time {@link SellerPayoutService.createSellerPayout | createSellerPayout} asks
+ * {@link internal/reports!SalesReportService | SalesReportService} for a report over that
+ * window and copies `report.totalInclVat` onto the entity. From then on the amount is
+ * frozen on both the payout and its linked {@link transfers!Transfer | Transfer}; the
+ * payout does not re-query the report.
+ *
+ * That snapshot can drift from reality. If a sub-transaction inside the window is changed
+ * or deleted after the payout exists (a refund, an admin correction), the snapshot and a
+ * fresh report for the same window no longer agree. Detecting this is what
+ * `GET /seller-payouts/{id}/report` is for: it re-runs the sales report with the payout's
+ * stored window and `requestedBy`, so the treasurer can compare the live total against
+ * `payout.amount`. `PATCH /seller-payouts/{id}` is the lever for reconciling once drift
+ * is found.
+ *
+ * Overlapping windows for the same seller are still refused, so the same revenue cannot
+ * be paid out twice. The refusal only checks date ranges though, not whether the prior
+ * payout still matches its window.
+ *
+ * ### One transfer, no approval step
+ * Unlike a {@link payout-requests!PayoutRequest | PayoutRequest}, a seller-payout has no
+ * status state machine. It is treasurer-initiated and lands already-final. `POST
+ * /seller-payouts` creates the {@link SellerPayout} and a single debit
+ * {@link transfers!Transfer | Transfer} (`from = requestedBy`, the seller user;
+ * `to = null`, since the money leaves SudoSOS) in one go. `requestedBy` on `BasePayout`
+ * is the seller being paid out, despite the name carried over from payout-requests.
+ *
+ * ### Editing and deleting
+ * `PATCH /seller-payouts/{id}` lets the treasurer adjust `amount` and `reference` after
+ * creation, typically used to reconcile drift surfaced by the `/report` endpoint. The
+ * linked transfer's `amountInclVat` is updated in lockstep.
+ * `DELETE /seller-payouts/{id}` removes both the payout row and its transfer; this is an
+ * admin escape hatch, not a regular user action.
+ *
+ * ### Inspecting the window
+ * `GET /seller-payouts/{id}/report` returns the live sales report for the stored window
+ * (see the drift note above). `GET /seller-payouts/{id}/report/pdf` is the printable
+ * version. {@link SellerPayout} itself is `PdfAble` too:
+ * `GET /seller-payouts/{id}/pdf` produces the payout receipt using the snapshotted
+ * amount, with the period and the `reference` printed on it.
  *
  * @module seller-payouts
  * @mergeTarget

--- a/src/entity/transactions/write-off.ts
+++ b/src/entity/transactions/write-off.ts
@@ -19,7 +19,37 @@
  */
 
 /**
- * This is the module page of the write-off.
+ * A `write-off` zeroes an unrecoverable negative {@link balance!Balance | Balance} and
+ * closes the account it belongs to. Treasurers use it for users who have left the
+ * association without settling up: rather than letting a stale debt sit on the books, the
+ * write-off cancels it out in one credit transfer and the account is retired.
+ *
+ * ### Lifecycle
+ * `POST /writeoffs` is the only way to create one. The handler refuses if the user has a
+ * non-negative balance, then
+ * {@link WriteOffService.createWriteOffAndCloseUser | createWriteOffAndCloseUser} runs:
+ *
+ * - A {@link WriteOff} is saved with `amount = -balance` (always positive) and `to`
+ *   pointing at the doomed account.
+ * - A credit {@link transfers!Transfer | Transfer} is created with `from = null` and
+ *   `to = user`, tagged with the server's high {@link catalogue/vat!VatGroup | VatGroup} so
+ *   the consumed goods stay accounted for at the higher rate.
+ * - {@link users!User | UserService.closeUser} marks the account closed and deleted.
+ *
+ * There is no `DELETE /writeoffs/{id}`. A write-off is final; reversing one requires a
+ * manual transfer.
+ *
+ * ### VAT on the credit transfer
+ * The write-off's credit transfer is tagged with the server's high
+ * {@link catalogue/vat!VatGroup | VatGroup}. The products the user consumed had VAT
+ * charged at sale time, and the write-off cancels payment for those products, so the
+ * VAT side of the books has to be accounted for too.
+ *
+ * ### Listing and PDFs
+ * `GET /writeoffs` and `GET /writeoffs/{id}` page through past write-offs for treasurer
+ * reconciliation. `GET /writeoffs/{id}/pdf` renders the receipt; `WriteOff` extends
+ * `PdfAble` and the PDF is regenerated on demand and cached as a {@link WriteOffPdf}
+ * relation.
  *
  * @module write-offs
  * @mergeTarget

--- a/src/service/debtor-service.ts
+++ b/src/service/debtor-service.ts
@@ -19,9 +19,67 @@
  */
 
 /**
- * This is the module page of the debtor-service.
+ * The `debtors` module is the orchestrator over the {@link fines | fines} entities. A
+ * "debtor" in SudoSOS is any user with a negative {@link balance!Balance | Balance},
+ * just below zero, not specifically below the -5 EUR fine threshold. Whether a user can
+ * become one in the first place is gated by
+ * {@link users!User.canGoIntoDebt | User.canGoIntoDebt}, off by default, so most accounts
+ * cannot purchase past zero. This module is the place where an admin or financial
+ * responsible decides what to do about the ones that can and have.
+ *
+ * Fines are the main lever and they use a stricter cutoff than "debtor": only users below
+ * -5 EUR persistently are eligible. See the lifecycle below.
+ *
+ * The merge target is {@link DebtorService}, which owns the full debtor-recovery
+ * pipeline: identify candidates, warn them, hand out fines, waive them, undo them, and
+ * report on the whole thing. Each method maps to one or more endpoints on
+ * {@link DebtorController}, with
+ * {@link users!UserController.waiveUserFines | waiveUserFines} as the one outlier living
+ * on the user controller.
+ *
+ * ### Identify
+ * {@link DebtorService.calculateFinesOnDate | calculateFinesOnDate} takes a list of
+ * reference dates and returns only the users who were below -5 EUR on every single one of
+ * them (including "now" if today is in the list). The double-check exists so a user who
+ * just topped up does not get fined for a historical dip. The endpoint is
+ * `GET /fines/eligible`.
+ *
+ * ### Warn
+ * {@link DebtorService.sendFineWarnings | sendFineWarnings} reuses the same eligibility
+ * filter and notifies each candidate that a fine is incoming. Users keep their grace
+ * period; if they top up before the handout they drop off the list. The endpoint is
+ * `POST /fines/notify`.
+ *
+ * ### Hand out
+ * {@link DebtorService.handOutFines | handOutFines} runs the whole batch in a single
+ * database transaction: one {@link fines!FineHandoutEvent | FineHandoutEvent}, one
+ * {@link fines!Fine | Fine} per eligible user, one debit
+ * {@link transfers!Transfer | Transfer} per fine, and one `UserGotFined` notification per
+ * fined user. The amount per fine caps at 5 EUR via the local `calculateFine` helper. The
+ * endpoint is `POST /fines/handout`.
+ *
+ * ### Waive
+ * {@link DebtorService.waiveFines | waiveFines} creates a credit transfer on the user's
+ * {@link fines!UserFineGroup | UserFineGroup} as `waivedTransfer`. Waiving is
+ * replace-not-append: an existing waiver is removed and a fresh one written with the new
+ * total. Waiving the full outstanding amount nulls
+ * {@link users!User | User.currentFines}. The endpoint is
+ * `POST /users/{id}/fines/waive`.
+ *
+ * ### Undo
+ * {@link DebtorService.deleteFine | deleteFine} and
+ * {@link DebtorService.deleteFineHandout | deleteFineHandout} remove a fine (or a whole
+ * batch) and its debit transfer outright. Fines are the rare exception to the rule that
+ * nothing on the ledger gets deleted; everywhere else, a compensating row is preferred.
+ * Endpoints: `DELETE /fines/single/{id}`, `DELETE /fines/handout/{id}`.
+ *
+ * ### Report
+ * {@link DebtorService.getFineReport | getFineReport} aggregates handed-out and waived
+ * totals over a date range for treasurer reconciliation. Endpoints: `GET /fines/report`,
+ * `GET /fines/report/pdf` (the PDF flavour goes through {@link reports | reports}).
  *
  * @module debtors
+ * @mergeTarget
  */
 
 import User, { UserType } from '../entity/user/user';


### PR DESCRIPTION
Part of #285. Continues from #913. That PR covered the core money-movement entities (balance, transactions, sub-transactions, transfers); this one covers the settlement-side modules that hang off them -- everything you reach for to actually get money out of (or off) a user's balance. One doc commit per module so it can be split later if review prefers smaller PRs.

## Scope
- `fines` -- prose on `UserFineGroup` (the `@mergeTarget`). Covers the three entities (`FineHandoutEvent`, `Fine`, `UserFineGroup`), the manual identify-warn-handout lifecycle, replace-not-append waiving, and the carve-out where fines are deleted outright instead of compensated.
- `write-offs` -- prose on `WriteOff`. It zeroes an unrecoverable negative balance and closes the account in one go, refuses positive balances, and runs the credit through the high VAT group. There is no `DELETE` on purpose.
- `payout-requests` -- prose on `PayoutRequest`. Two-phase: created on submission with no transfer; four-state machine; transfer written only when the treasurer approves. Bank details are frozen on the entity.
- `seller-payouts` -- prose on `SellerPayout`. Treasurer-initiated, windowed settlement; the amount comes from `SalesReportService` and overlapping windows are refused. One transfer per payout, no approval step.
- `debtors` -- prose on `DebtorService` with `@mergeTarget` promotion. It is the orchestrator over the `fines` entities -- one section per public method (identify, warn, hand out, waive, undo, report) tied to the endpoint it serves.

Each controller picks up a short class-level docstring linking back to its module page, same pattern as #913.

## Test plan
- [x] `pnpm exec tsc --noEmit` passes.
- [x] `pnpm lint` passes on the touched files.
- [x] `pnpm typedoc` runs clean -- no unresolved `@link` warnings.
- [x] No new tests needed (docs-only).
- [x] No DB migration (docs-only).