### PR TITLE
feat: Include date for ToS versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "express-fileupload": "1.5.2",
     "express-jsdoc-swagger": "1.8.0",
     "gewisdb-ts-client": "github:GEWIS/gewisdb-ts-client#6190730be45646d58ff5968689ec22b88d2c918c",
+    "gray-matter": "^4.0.3",
     "ioredis": "5.10.1",
     "jsonwebtoken": "9.0.3",
     "ldap-escape": "2.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       gewisdb-ts-client:
         specifier: github:GEWIS/gewisdb-ts-client#6190730be45646d58ff5968689ec22b88d2c918c
         version: https://codeload.github.com/GEWIS/gewisdb-ts-client/tar.gz/6190730be45646d58ff5968689ec22b88d2c918c(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.41)(debug@4.4.3)
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       ioredis:
         specifier: 5.10.1
         version: 5.10.1
@@ -2897,6 +2900,10 @@ packages:
     resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
 
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3147,6 +3154,10 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
@@ -3345,6 +3356,10 @@ packages:
   is-date-object@1.1.0:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -3556,6 +3571,10 @@ packages:
 
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   layout-base@1.0.2:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
@@ -4505,6 +4524,10 @@ packages:
   search-insights@2.17.3:
     resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
@@ -4768,6 +4791,10 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -8414,6 +8441,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -8714,6 +8745,13 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
   hachure-fill@0.5.2: {}
 
   has-bigints@1.1.0: {}
@@ -8920,6 +8958,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -9133,6 +9173,8 @@ snapshots:
       json-buffer: 3.0.1
 
   khroma@2.1.0: {}
+
+  kind-of@6.0.3: {}
 
   layout-base@1.0.2: {}
 
@@ -10211,6 +10253,11 @@ snapshots:
 
   search-insights@2.17.3: {}
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   semver@5.7.2: {}
 
   semver@6.3.1: {}
@@ -10540,6 +10587,8 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 

--- a/src/controller/response/terms-of-service-response.ts
+++ b/src/controller/response/terms-of-service-response.ts
@@ -27,9 +27,11 @@
 /**
  * @typedef {object} TermsOfServiceResponse
  * @property {string} versionNumber.required - The terms of service version number.
+ * @property {string} date.required - The date this version took effect.
  * @property {string} content.required - The terms of service content.
  */
 export interface TermsOfServiceResponse {
   versionNumber: string;
+  date: string;
   content: string;
 }

--- a/src/service/terms-of-service-service.ts
+++ b/src/service/terms-of-service-service.ts
@@ -20,6 +20,7 @@
 
 import path from 'path';
 import { promises as fs } from 'fs';
+import matter from 'gray-matter';
 import { TermsOfServiceResponse } from '../controller/response/terms-of-service-response';
 
 /**
@@ -32,6 +33,7 @@ const TOS_DIR = path.join(__dirname, '../../static/terms-of-service');
 
 export interface TermsOfService {
   versionNumber: string;
+  date: Date;
   content: string;
 }
 
@@ -43,8 +45,25 @@ export default class TermsOfServiceService {
   public static asTermsOfServiceResponse(tos: TermsOfService): TermsOfServiceResponse {
     return {
       versionNumber: tos.versionNumber,
+      date: tos.date.toISOString(),
       content: tos.content,
     };
+  }
+
+  /**
+   * Parse the required leading YAML frontmatter block holding the effective date.
+   * Throws if the frontmatter or its date is missing or invalid.
+   */
+  private static parseFrontmatter(raw: string, version: string): { date: Date; content: string } {
+    const { data, content } = matter(raw);
+    if (!(data.date instanceof Date) && typeof data.date !== 'string') {
+      throw new Error(`Terms of service version v${version} has a missing or invalid frontmatter date`);
+    }
+    const date = data.date instanceof Date ? data.date : new Date(data.date);
+    if (Number.isNaN(date.getTime())) {
+      throw new Error(`Terms of service version v${version} has a missing or invalid frontmatter date`);
+    }
+    return { date, content };
   }
 
   /**
@@ -77,16 +96,17 @@ export default class TermsOfServiceService {
   public static async getTermsOfService(version: string): Promise<TermsOfService> {
     // Check whether the version string is safe (no path traversal)
     if (/[/\\]|\.\./.test(version)) {
-      throw new Error(`Terms of service version v'${version}' not found`);
+      throw new Error(`Terms of service version v${version} not found`);
     }
     const filePath = path.join(TOS_DIR, `${version}.md`);
-    let content: string;
+    let raw: string;
     try {
-      content = await fs.readFile(filePath, 'utf-8');
+      raw = await fs.readFile(filePath, 'utf-8');
     } catch {
-      throw new Error(`Terms of service version v'${version}' not found`);
+      throw new Error(`Terms of service version v${version} not found`);
     }
-    return { versionNumber: version, content };
+    const { date, content } = TermsOfServiceService.parseFrontmatter(raw, version);
+    return { versionNumber: version, date, content };
   }
 
   /**

--- a/static/terms-of-service/1.0.md
+++ b/static/terms-of-service/1.0.md
@@ -1,3 +1,6 @@
+---
+date: 2022-08-14
+---
 ### 1 Definitions
 
 **SudoSOS** : SudoSOS is the bar system of Study Association GEWIS that handles financial transactions regarding the bar. It consists, but is not limited to, the touchscreens behind the bar with their barcode scanners, the mobile tablet, the website, the database and the paper list. The system acts as a mediator between buyer and seller.

--- a/test/unit/controller/root-controller.ts
+++ b/test/unit/controller/root-controller.ts
@@ -32,7 +32,7 @@ import { ADMIN_USER, UserFactory } from '../../helpers/user-factory';
 import sinon from 'sinon';
 import ServerSettingsStore from '../../../src/server-settings/server-settings-store';
 import BannerSeeder from '../../seed/banner-seeder';
-import TermsOfServiceService from '../../../src/service/terms-of-service-service';
+import TermsOfServiceService, { TermsOfService } from '../../../src/service/terms-of-service-service';
 import { TermsOfServiceResponse } from '../../../src/controller/response/terms-of-service-response';
 
 const { expect, request } = chai;
@@ -183,7 +183,7 @@ describe('RootController', async (): Promise<void> => {
     });
 
     it('should return correct model', async () => {
-      const tosResponse: TermsOfServiceResponse = { versionNumber: '1.0', content: '# TOS v1.0' };
+      const tosResponse: TermsOfService = { versionNumber: '1.0', date: new Date('2026-06-06'), content: '# TOS v1.0' };
       tosStub = sinon.stub(TermsOfServiceService, 'getLatestTermsOfService').resolves(tosResponse);
 
       const res = await request(ctx.app)
@@ -199,7 +199,7 @@ describe('RootController', async (): Promise<void> => {
     });
 
     it('should return 200 with the latest TOS content', async () => {
-      const tosResponse: TermsOfServiceResponse = { versionNumber: '2.0', content: '# Terms of Service v2.0' };
+      const tosResponse: TermsOfService = { versionNumber: '2.0', date: new Date('2026-06-06'), content: '# Terms of Service v2.0' };
       tosStub = sinon.stub(TermsOfServiceService, 'getLatestTermsOfService').resolves(tosResponse);
 
       const res = await request(ctx.app)
@@ -212,7 +212,7 @@ describe('RootController', async (): Promise<void> => {
     });
 
     it('should be publicly accessible without authentication', async () => {
-      const tosResponse: TermsOfServiceResponse = { versionNumber: '1.0', content: '# TOS' };
+      const tosResponse: TermsOfService = { versionNumber: '1.0', date: new Date('2026-06-06'), content: '# TOS' };
       tosStub = sinon.stub(TermsOfServiceService, 'getLatestTermsOfService').resolves(tosResponse);
 
       const res = await request(ctx.app)

--- a/test/unit/controller/terms-of-service-controller.ts
+++ b/test/unit/controller/terms-of-service-controller.ts
@@ -73,7 +73,7 @@ describe('TermsOfServiceController', () => {
 
   describe('GET /terms-of-service', () => {
     it('should return correct model', async () => {
-      const tosResponse: TermsOfService = { versionNumber: '1.0', content: '# TOS v1.0' };
+      const tosResponse: TermsOfService = { versionNumber: '1.0', date: new Date('2026-06-06'), content: '# TOS v1.0' };
       const stub = sinon.stub(TermsOfServiceService, 'getTermsOfService').resolves(tosResponse);
       stubs.push(stub);
 
@@ -92,7 +92,7 @@ describe('TermsOfServiceController', () => {
     });
 
     it('should return 200 with the correct TOS content when a valid version is requested', async () => {
-      const tosResponse: TermsOfService = { versionNumber: '1.0', content: '# Terms of Service v1.0' };
+      const tosResponse: TermsOfService = { versionNumber: '1.0', date: new Date('2026-06-06'), content: '# Terms of Service v1.0' };
       const stub = sinon.stub(TermsOfServiceService, 'getTermsOfService').resolves(tosResponse);
       stubs.push(stub);
 
@@ -169,7 +169,7 @@ describe('TermsOfServiceController', () => {
     });
 
     it('should return 200 for a regular user with own TOS permissions', async () => {
-      const tosResponse: TermsOfService = { versionNumber: '1.0', content: '# TOS v1.0' };
+      const tosResponse: TermsOfService = { versionNumber: '1.0', date: new Date('2026-06-06'), content: '# TOS v1.0' };
       const stub = sinon.stub(TermsOfServiceService, 'getTermsOfService').resolves(tosResponse);
       stubs.push(stub);
 

--- a/test/unit/service/terms-of-service-service.ts
+++ b/test/unit/service/terms-of-service-service.ts
@@ -72,15 +72,18 @@ describe('TermsOfServiceService', () => {
   });
 
   describe('getTermsOfService', () => {
-    it('should return the correct version and content for a valid version', async () => {
-      const content = '# Terms of Service v1.0\nContent here.';
-      const readFileStub = sinon.stub(fs, 'readFile').resolves(content as any);
+    it('should return the version, date and content for a valid version', async () => {
+      const body = '# Terms of Service v1.0\nContent here.';
+      const raw = `---\ndate: 2024-01-15\n---\n${body}`;
+      const readFileStub = sinon.stub(fs, 'readFile').resolves(raw as any);
       stubs.push(readFileStub);
 
       const result = await TermsOfServiceService.getTermsOfService('1.0');
 
       expect(result.versionNumber).to.equal('1.0');
-      expect(result.content).to.equal(content);
+      expect(result.content).to.equal(body);
+      expect(result.date).to.be.instanceOf(Date);
+      expect(result.date.toISOString()).to.equal(new Date('2024-01-15').toISOString());
     });
 
     it('should throw an error when the version file does not exist', async () => {
@@ -88,10 +91,47 @@ describe('TermsOfServiceService', () => {
       stubs.push(readFileStub);
 
       await expect(TermsOfServiceService.getTermsOfService('99.9'))
-        .to.eventually.be.rejectedWith("Terms of service version v'99.9' not found");
+        .to.eventually.be.rejectedWith('Terms of service version v99.9 not found');
     });
 
-    it('should return the actual content of the existing TOS version from disk', async () => {
+    it('should throw an error when the frontmatter is missing entirely', async () => {
+      const readFileStub = sinon.stub(fs, 'readFile').resolves('# No frontmatter here\nJust content.' as any);
+      stubs.push(readFileStub);
+
+      await expect(TermsOfServiceService.getTermsOfService('1.0'))
+        .to.eventually.be.rejectedWith('Terms of service version v1.0 has a missing or invalid frontmatter date');
+    });
+
+    it('should throw an error when the frontmatter has no date field', async () => {
+      const raw = '---\ntitle: Some title\n---\n# Body\nContent.';
+      const readFileStub = sinon.stub(fs, 'readFile').resolves(raw as any);
+      stubs.push(readFileStub);
+
+      await expect(TermsOfServiceService.getTermsOfService('1.0'))
+        .to.eventually.be.rejectedWith('Terms of service version v1.0 has a missing or invalid frontmatter date');
+    });
+
+    it('should throw an error when the frontmatter date is invalid', async () => {
+      const raw = '---\ndate: not-a-real-date\n---\n# Body\nContent.';
+      const readFileStub = sinon.stub(fs, 'readFile').resolves(raw as any);
+      stubs.push(readFileStub);
+
+      await expect(TermsOfServiceService.getTermsOfService('1.0'))
+        .to.eventually.be.rejectedWith('Terms of service version v1.0 has a missing or invalid frontmatter date');
+    });
+
+    it('should parse a date provided as a quoted string', async () => {
+      const raw = '---\ndate: "2023-06-30"\n---\n# Body\nContent.';
+      const readFileStub = sinon.stub(fs, 'readFile').resolves(raw as any);
+      stubs.push(readFileStub);
+
+      const result = await TermsOfServiceService.getTermsOfService('1.0');
+
+      expect(result.date).to.be.instanceOf(Date);
+      expect(result.date.toISOString()).to.equal(new Date('2023-06-30').toISOString());
+    });
+
+    it('should return the actual content and a valid date from disk', async () => {
       const versions = await TermsOfServiceService.listVersions();
       expect(versions.length).to.be.greaterThan(0);
 
@@ -101,6 +141,8 @@ describe('TermsOfServiceService', () => {
       expect(result.versionNumber).to.equal(version);
       expect(result.content).to.be.a('string');
       expect(result.content.length).to.be.greaterThan(0);
+      expect(result.date).to.be.instanceOf(Date);
+      expect(Number.isNaN(result.date.getTime())).to.be.false;
     });
   });
 
@@ -108,14 +150,26 @@ describe('TermsOfServiceService', () => {
     it('should return the TOS with the highest version (last in sorted order)', async () => {
       const readdirStub = sinon.stub(fs, 'readdir').resolves(['1.0.md', '2.0.md', '1.5.md'] as any);
       stubs.push(readdirStub);
-      const content = '# Latest TOS';
-      const readFileStub = sinon.stub(fs, 'readFile').resolves(content as any);
+      const body = '# Latest TOS';
+      const raw = `---\ndate: 2025-02-20\n---\n${body}`;
+      const readFileStub = sinon.stub(fs, 'readFile').resolves(raw as any);
       stubs.push(readFileStub);
 
       const result = await TermsOfServiceService.getLatestTermsOfService();
 
       expect(result.versionNumber).to.equal('2.0');
-      expect(result.content).to.equal(content);
+      expect(result.content).to.equal(body);
+      expect(result.date.toISOString()).to.equal(new Date('2025-02-20').toISOString());
+    });
+
+    it('should propagate a missing or invalid date error from the latest version', async () => {
+      const readdirStub = sinon.stub(fs, 'readdir').resolves(['1.0.md', '2.0.md'] as any);
+      stubs.push(readdirStub);
+      const readFileStub = sinon.stub(fs, 'readFile').resolves('# No frontmatter' as any);
+      stubs.push(readFileStub);
+
+      await expect(TermsOfServiceService.getLatestTermsOfService())
+        .to.eventually.be.rejectedWith('Terms of service version v2.0 has a missing or invalid frontmatter date');
     });
 
     it('should throw an error when no TOS files exist', async () => {
@@ -135,6 +189,21 @@ describe('TermsOfServiceService', () => {
       expect(result.versionNumber).to.equal(expectedLatest);
       expect(result.content).to.be.a('string');
       expect(result.content.length).to.be.greaterThan(0);
+    });
+  });
+
+  describe('asTermsOfServiceResponse', () => {
+    it('should serialize the date to an ISO string', () => {
+      const date = new Date('2024-01-15');
+      const response = TermsOfServiceService.asTermsOfServiceResponse({
+        versionNumber: '1.0',
+        date,
+        content: '# Body',
+      });
+
+      expect(response.versionNumber).to.equal('1.0');
+      expect(response.content).to.equal('# Body');
+      expect(response.date).to.equal(date.toISOString());
     });
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds the date in frontmatter to the .md ToS version files.

ToS versions are considered invalid if there is no date.

This can be used to show the effective date of a certain ToS version in the FE.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
- New feature _(non-breaking change which adds functionality)_

---

## ✅ PR Checklist

- [x] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [x] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated

## 🔗 Additional Notes
<!-- Any additional information that reviewers should know -->