### PR TITLE
fix: escape <name> placeholder in IInvoicePdf JSDoc

### DIFF
--- a/src/html/invoice.html.ts
+++ b/src/html/invoice.html.ts
@@ -96,7 +96,7 @@ export interface IInvoicePdf {
    *  Total headline. May be empty. */
   subject: string;
   addressee: string;
-  /** "For the attention of" recipient line. Rendered as "Attn. <name>" between
+  /** "For the attention of" recipient line. Rendered as `Attn. <name>` between
    *  the addressee and the street, omitted entirely when empty. */
   attention: string;
   address: IInvoiceAddress;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
The literal `<name>` in the `attention` field comment was rendered into the typedoc markdown table and parsed by vitepress as an unclosed HTML tag, breaking the docs Docker build on develop.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_