### PR TITLE
Migrate seller payout report PDF to pdf-compiler

### DIFF
--- a/src/files/templates/bac-letterhead.ts
+++ b/src/files/templates/bac-letterhead.ts
@@ -30,7 +30,7 @@ export const BAC = {
   postbus: 'Postbus 513, 5600MB Eindhoven',
   /** Visiting address, split to mirror a "Bill to" recipient block. */
   street: 'De Groene Loper 5',
-  postalCity: '5612AZ Eindhoven',
+  postalCity: '5612AE Eindhoven',
   country: 'The Netherlands',
   phone: '+31 40 247 2815',
   email: 'bacpm@gewis.nl',

--- a/src/html/document.html.ts
+++ b/src/html/document.html.ts
@@ -1,0 +1,376 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * Shared HTML skeleton for the BAC "F6c" two-section financial document: an
+ * AH-style cover page (band header, recipient block, meta-list, total
+ * headline + note, VAT specification, footer) followed by one or more
+ * line-items pages. The Invoice and the Seller Payout PDFs are both this
+ * document with a different band label, meta rows and note text.
+ *
+ * Compiled to a PDF by `pdf-compiler` via `BaseHtmlPdfService`.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { BAC } from '../files/templates/bac-letterhead';
+
+const PRIMARY = '#004b31';
+const PRIMARY_DARK = '#074a33';
+const MUTED = '#6B6B6B';
+
+// BAC logo, inlined as SVG so the rendered HTML doesn't need to fetch the
+// asset at compile time. The SVG fills its parent container, so sizing is
+// controlled by the wrapping `.logo` div.
+const BAC_LOGO = fs.readFileSync(
+  path.resolve(__dirname, '../../static/pdf/bac_logo.svg'),
+  'utf-8',
+)
+  .replace(/<\?xml[^>]*\?>/g, '')
+  .replace('<svg ', '<svg style="width:100%;height:100%;display:block" ');
+
+/** One row in the cover-page VAT specification matrix (per-VAT-band totals). */
+export interface IDocumentVatBand {
+  /** VAT percentage; 0 renders as "None" on the cover. */
+  rate: number;
+  /** Sum of the excl-VAT amount across rows in this band, in euros. */
+  excl: number;
+  /** Sum of the VAT amount across rows in this band, in euros. */
+  vat: number;
+  /** Sum of the incl-VAT amount across rows in this band, in euros. */
+  incl: number;
+}
+
+/** One row in the line-items page. */
+export interface IDocumentLineItem {
+  description: string;
+  qty: number;
+  /** VAT percentage; 0 renders as "None". */
+  rate: number;
+  /** Per-row excl-VAT amount in euros. */
+  excl: number;
+  /** Per-row VAT amount in euros. */
+  vat: number;
+  /** Per-row incl-VAT amount in euros. */
+  incl: number;
+}
+
+/** A label/value pair in one of the right-aligned meta-lists. */
+export interface IDocumentMetaRow {
+  lbl: string;
+  /** Pre-escaped value; rendered raw. */
+  v: string;
+}
+
+export interface IDocumentPdf {
+  /** Small uppercase lockup label in the header band (e.g. "Invoice"). */
+  bandLabel: string;
+  /** Large reference shown under the band label and on the line-items page. */
+  reference: string;
+  /** Pre-rendered recipient/account block (already escaped). */
+  recipientHtml: string;
+  /** Cover-page meta-list rows (values already escaped). */
+  metaRows: IDocumentMetaRow[];
+  /** Optional pre-rendered section between the meta block and the headline. */
+  subjectSection?: string;
+  totalIncl: number;
+  /** Headline label shown before the total amount (e.g. "Total including VAT"). */
+  totalLabel: string;
+  /** Pre-rendered paragraph under the total headline (already escaped). */
+  noteHtml: string;
+  /** Description shown in every VAT-spec row (e.g. "Orders" / "Sales"). */
+  specDescription: string;
+  vatBreakdown: IDocumentVatBand[];
+  subtotalExcl: number;
+  totalVat: number;
+  /** Pre-rendered line under the VAT spec (already escaped). */
+  questionsLine: string;
+  /** Lockup label on the line-items page band. */
+  lineItemsLabel: string;
+  /** Line-items page meta-list rows (values already escaped). */
+  lineItemsMetaRows: IDocumentMetaRow[];
+  lineItems: IDocumentLineItem[];
+}
+
+const eur = new Intl.NumberFormat('nl-NL', {
+  style: 'currency',
+  currency: 'EUR',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+/** Format a euro amount in nl-NL style with the locale's no-break space
+ *  between symbol and amount removed (e.g. €1.234,56). */
+export const fmt = (n: number): string => eur.format(n).replace(/\s/g, '');
+
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function metaList(rows: IDocumentMetaRow[]): string {
+  return rows
+    .map((r) => `<div class="row"><span class="lbl">${r.lbl}</span><span class="v">${r.v}</span></div>`)
+    .join('\n          ');
+}
+
+/**
+ * Render the optional labeled section between the meta block and the total
+ * headline (e.g. "Subject" on the invoice, "Description" on the seller
+ * payout). Returns an empty string when the value is empty.
+ */
+export function subjectSection(label: string, value: string): string {
+  const v = (value ?? '').trim();
+  if (v.length === 0) return '';
+  return `
+    <section style="margin-bottom:40px">
+      <div style="font-size:9.5pt; color:${MUTED}; text-transform:uppercase; letter-spacing:1.2px; font-weight:600; margin-bottom:6px">${escapeHtml(label)}</div>
+      <div style="font-size:13pt; font-weight:600">${escapeHtml(v)}</div>
+    </section>`;
+}
+
+/**
+ * Render the two-section financial document HTML.
+ *
+ * Output is a complete `<html>` document, ready to POST to pdf-compiler's
+ * `/compile-html` endpoint.
+ */
+export function createDocumentPdf(options: IDocumentPdf): string {
+  const vatRows = options.vatBreakdown.map((b) => `
+    <tr>
+      <td class="desc">${escapeHtml(options.specDescription)}</td>
+      <td class="rate">${b.rate === 0 ? 'None' : `${b.rate}%`}</td>
+      <td class="num">${fmt(b.excl)}</td>
+      <td class="num">${fmt(b.vat)}</td>
+      <td class="num">${fmt(b.incl)}</td>
+    </tr>`).join('');
+
+  const lineItemRows = options.lineItems.map((it) => `
+    <tr>
+      <td class="desc">${escapeHtml(it.description)}</td>
+      <td class="qty">${it.qty}</td>
+      <td class="rate">${it.rate === 0 ? 'None' : `${it.rate}%`}</td>
+      <td class="num">${fmt(it.excl)}</td>
+      <td class="num">${fmt(it.vat)}</td>
+      <td class="num">${fmt(it.incl)}</td>
+    </tr>`).join('');
+
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><style>
+  @page { size: A4; margin: 0; }
+  html, body { margin:0; -webkit-print-color-adjust:exact; print-color-adjust:exact; }
+  body { font: 10.5pt/1.55 "Helvetica Neue", Arial, sans-serif; color:#222 }
+
+  /* Each page is its own flex column so its footer can be pushed to the
+     bottom of that page regardless of body content height. */
+  .page { display:flex; flex-direction:column; min-height:100vh }
+  .page + .page, .page + .items-flow { page-break-before:always; break-before:page }
+  /* Items section uses a plain block so the table can overflow across pages
+     without breaking @page rules; flex + min-height:100vh suppresses them. */
+  .items-flow { break-before:page }
+
+  .band { background:linear-gradient(135deg, ${PRIMARY}, ${PRIMARY_DARK}); color:white; padding:22px 56px; display:flex; align-items:center; gap:36px; flex:0 0 auto }
+  .band .logo { width:72px; height:72px; flex:0 0 72px }
+  .band .lockup .lbl { font-size:10pt; text-transform:uppercase; letter-spacing:1.6px; opacity:0.85 }
+  .band .lockup .ref { font-size:18pt; font-weight:700; margin-top:2px; letter-spacing:-0.3px }
+
+  .body { padding:48px 56px 0; flex:1 }
+
+  .top { display:flex; justify-content:space-between; gap:48px; margin-bottom:72px }
+  .recipient p { margin:0; line-height:1.4; font-size:10pt }
+  .meta-list { font-size:10pt; line-height:1.5 }
+  .meta-list .row { display:flex; gap:6px; justify-content:flex-end }
+  .meta-list .lbl { color:${MUTED}; text-align:right; min-width:90px }
+  .meta-list .v { min-width:140px; text-align:left }
+
+  .total-headline { margin-bottom:96px }
+  .total-headline .h { font-size:34pt; font-weight:700; line-height:1.08; letter-spacing:-0.6px }
+  .total-headline .note { font-size:9pt; color:${MUTED}; margin-top:14px; max-width:560px; line-height:1.55 }
+
+  .spec { width:100%; border-collapse:collapse; font-size:10pt; margin-bottom:14px }
+  .spec thead th { font-weight:normal; color:${MUTED}; font-size:9.5pt; padding:4px 14px 10px 0; border-bottom:1px solid #BBB; text-align:left }
+  .spec thead th.num { text-align:right; padding-right:0 }
+  .spec tbody td { padding:7px 14px 7px 0; vertical-align:top }
+  .spec td.num { text-align:right; padding-right:0; font-variant-numeric:tabular-nums }
+  .spec td.rate { color:${MUTED} }
+  .spec tr.total td { padding-top:14px; padding-bottom:6px; border-top:1px solid #333 }
+  .spec tr.total td.muted { color:${MUTED}; font-weight:normal !important }
+  .spec tr.total td.bold { font-weight:700 }
+
+  .questions { font-size:9pt; color:${MUTED}; margin-top:24px; text-align:right }
+
+  /* Footer column proportions: BAC name+address | VAT+KvK | IBAN | contact.
+     All four columns lead with a header line; the BTW/IBAN columns use an
+     invisible <strong> spacer so their data rows align with the address /
+     email rows in the bold-labelled columns. */
+  .page-foot { padding:24px 56px 30px; margin-top:60px; font-size:8.5pt; color:${MUTED}; line-height:1.5; display:grid; grid-template-columns:1.3fr 1.2fr 1.6fr 1.1fr; gap:24px; flex:0 0 auto }
+  .page-foot .col { white-space:nowrap }
+  .page-foot .col strong { display:block; color:#111; font-size:9pt; margin-bottom:4px; font-weight:700; white-space:normal }
+
+  /* Line-items page: per-row items table. Compact rows so a typical document
+     fits on one page; tr.total is glued to the previous row so it never
+     orphans onto a new page without context. */
+  .items { width:100%; border-collapse:collapse; font-size:9.5pt; margin-top:8px }
+  .items thead th { font-weight:normal; color:${MUTED}; font-size:9pt; padding:6px 10px 10px 0; border-bottom:1px solid #BBB; text-align:left }
+  .items thead th.num, .items thead th.qty, .items thead th.rate { text-align:right }
+  .items thead th.num { padding-right:0 }
+  /* The spacer row sits in <thead> so Chromium auto-repeats it on every page
+     where the table breaks. That gives spillover pages a top whitespace band
+     instead of starting flush against the page edge. The first items page
+     also picks up the spacer below its meta-list -- consistent across pages. */
+  .items thead tr.spacer th { padding:0; height:80px; border-bottom:0 }
+  /* <tfoot> auto-repeats on every page like <thead>; using it as a bottom
+     spacer reserves whitespace below the rows on every spillover page so the
+     last row never butts up against the page edge. */
+  .items tfoot tr.spacer td { padding:0; height:60px; border:0 }
+  .items tbody tr { break-inside:avoid; page-break-inside:avoid }
+  .items tbody td { padding:5px 10px 5px 0; vertical-align:top; border-bottom:1px solid #F2F2F2 }
+  .items tbody tr:last-child td { border-bottom:0 }
+  .items td.desc { width:auto }
+  .items td.qty { width:50px; text-align:right; padding-right:14px }
+  .items td.rate { width:50px; text-align:right; padding-right:14px; color:${MUTED} }
+  .items td.num { width:80px; text-align:right; padding-right:0; font-variant-numeric:tabular-nums }
+  .items tr.total td { padding-top:12px; padding-bottom:6px; border-top:1px solid #333; font-weight:700 }
+  .items tr.total { break-before:avoid; page-break-before:avoid }
+</style></head><body>
+  <section class="page">
+    <div class="band">
+      <div class="logo">${BAC_LOGO}</div>
+      <div class="lockup">
+        <div class="lbl">${escapeHtml(options.bandLabel)}</div>
+        <div class="ref">${escapeHtml(options.reference)}</div>
+      </div>
+    </div>
+
+    <div class="body">
+      <div class="top">
+        <div class="recipient">${options.recipientHtml}</div>
+        <div class="meta-list">
+          ${metaList(options.metaRows)}
+        </div>
+      </div>
+
+      ${options.subjectSection ?? ''}
+
+      <div class="total-headline">
+        <div class="h">${escapeHtml(options.totalLabel)} ${fmt(options.totalIncl)}</div>
+        <div class="note">${options.noteHtml}</div>
+      </div>
+
+      <table class="spec">
+        <thead>
+          <tr>
+            <th>Description</th>
+            <th>VAT</th>
+            <th class="num">Excl. VAT</th>
+            <th class="num">VAT amount</th>
+            <th class="num">Incl. VAT</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${vatRows}
+          <tr class="total">
+            <td class="muted">All amounts in euros</td>
+            <td class="bold">Total</td>
+            <td class="num bold">${fmt(options.subtotalExcl)}</td>
+            <td class="num bold">${fmt(options.totalVat)}</td>
+            <td class="num bold">${fmt(options.totalIncl)}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="questions">${options.questionsLine}</div>
+    </div>
+
+    <div class="page-foot">
+      <div class="col">
+        <strong>${escapeHtml(BAC.name)}</strong>
+        ${escapeHtml(BAC.street)}<br>
+        ${escapeHtml(BAC.postalCity)}
+      </div>
+      <div class="col">
+        <strong style="visibility:hidden">&nbsp;</strong>
+        VAT ${escapeHtml(BAC.vat)}<br>
+        KvK ${escapeHtml(BAC.kvk)}
+      </div>
+      <div class="col">
+        <strong style="visibility:hidden">&nbsp;</strong>
+        IBAN ${escapeHtml(BAC.iban)}
+      </div>
+      <div class="col">
+        <strong>contact</strong>
+        ${escapeHtml(BAC.email)}<br>
+        ${escapeHtml(BAC.phone)}
+      </div>
+    </div>
+  </section>
+
+  <section class="items-flow">
+    <div class="band">
+      <div class="logo">${BAC_LOGO}</div>
+      <div class="lockup">
+        <div class="lbl">${escapeHtml(options.lineItemsLabel)}</div>
+        <div class="ref">${escapeHtml(options.reference)}</div>
+      </div>
+    </div>
+
+    <div class="body">
+      <div class="top" style="margin-bottom:24px">
+        <div></div>
+        <div class="meta-list">
+          ${metaList(options.lineItemsMetaRows)}
+        </div>
+      </div>
+
+      <table class="items">
+        <thead>
+          <tr class="spacer"><th colspan="6"></th></tr>
+          <tr>
+            <th class="desc">Description</th>
+            <th class="qty">Qty</th>
+            <th class="rate">VAT</th>
+            <th class="num">Excl. VAT</th>
+            <th class="num">VAT amount</th>
+            <th class="num">Incl. VAT</th>
+          </tr>
+        </thead>
+        <tfoot>
+          <tr class="spacer"><td colspan="6"></td></tr>
+        </tfoot>
+        <tbody>
+          ${lineItemRows}
+          <tr class="total">
+            <td></td>
+            <td></td>
+            <td>Total</td>
+            <td class="num">${fmt(options.subtotalExcl)}</td>
+            <td class="num">${fmt(options.totalVat)}</td>
+            <td class="num">${fmt(options.totalIncl)}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</body></html>`;
+}

--- a/src/html/invoice.html.ts
+++ b/src/html/invoice.html.ts
@@ -19,32 +19,21 @@
  */
 
 /**
- * HTML template for the Invoice PDF (the "F6c" design selected during the
- * cli/dev-invoice-variants exploration). Two pages: an AH-style cover with
- * the recipient, invoice metadata, total headline, BTW specification and
- * payment instructions; then a line-items page (one row per
- * sub_transaction_row, with a total).
- *
- * Compiled to a PDF by `pdf-compiler` via `BaseHtmlPdfService`.
+ * Invoice PDF (the "F6c" design). A thin wrapper over the shared
+ * `createDocumentPdf` skeleton: an invoice is that document with an "Invoice"
+ * band label, the recipient address block, invoice meta rows and the payment
+ * instructions note. Compiled to a PDF by `pdf-compiler`.
  */
 
-import fs from 'fs';
-import path from 'path';
 import { BAC } from '../files/templates/bac-letterhead';
-
-const PRIMARY = '#004b31';
-const PRIMARY_DARK = '#074a33';
-const MUTED = '#6B6B6B';
-
-// BAC logo, inlined as SVG so the rendered HTML doesn't need to fetch the
-// asset at compile time. The SVG fills its parent container, so sizing is
-// controlled by the wrapping `.logo` div.
-const BAC_LOGO = fs.readFileSync(
-  path.resolve(__dirname, '../../static/pdf/bac_logo.svg'),
-  'utf-8',
-)
-  .replace(/<\?xml[^>]*\?>/g, '')
-  .replace('<svg ', '<svg style="width:100%;height:100%;display:block" ');
+import {
+  createDocumentPdf,
+  escapeHtml,
+  fmt,
+  IDocumentLineItem,
+  IDocumentVatBand,
+  subjectSection,
+} from './document.html';
 
 export interface IInvoiceAddress {
   street: string;
@@ -54,16 +43,7 @@ export interface IInvoiceAddress {
 }
 
 /** One row in the cover-page BTW specification matrix (per-VAT-band totals). */
-export interface IInvoiceVatBand {
-  /** VAT percentage; 0 renders as "None" on the cover. */
-  rate: number;
-  /** Sum of the excl-VAT amount across rows in this band, in euros. */
-  excl: number;
-  /** Sum of the VAT amount across rows in this band, in euros. */
-  vat: number;
-  /** Sum of the incl-VAT amount across rows in this band, in euros. */
-  incl: number;
-}
+export interface IInvoiceVatBand extends IDocumentVatBand {}
 
 /** One row in the line-items page (a single sub_transaction_row). */
 export interface IInvoiceLineItem {
@@ -109,273 +89,64 @@ export interface IInvoicePdf {
   totalVat: number;
 }
 
-const eur = new Intl.NumberFormat('nl-NL', {
-  style: 'currency',
-  currency: 'EUR',
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
-const fmt = (n: number) => eur.format(n).replace(/ /g, '');
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
 /**
- * Render the Invoice PDF HTML.
- *
- * Output is a complete `<html>` document, ready to POST to pdf-compiler's
- * `/compile-html` endpoint.
+ * Render the Invoice PDF HTML via the shared document skeleton.
  */
 export function createInvoicePdf(options: IInvoicePdf): string {
-  const subject = (options.subject ?? '').trim();
-  const subjectSection = subject.length === 0 ? '' : `
-    <section style="margin-bottom:40px">
-      <div style="font-size:9.5pt; color:${MUTED}; text-transform:uppercase; letter-spacing:1.2px; font-weight:600; margin-bottom:6px">Subject</div>
-      <div style="font-size:13pt; font-weight:600">${escapeHtml(subject)}</div>
-    </section>`;
-
   const attention = (options.attention ?? '').trim();
   const attentionLine = attention.length === 0
     ? ''
     : `Attn. ${escapeHtml(attention)}<br>`;
 
-  const vatRows = options.vatBreakdown.map((b) => `
-    <tr>
-      <td class="desc">Orders</td>
-      <td class="rate">${b.rate === 0 ? 'None' : `${b.rate}%`}</td>
-      <td class="num">${fmt(b.excl)}</td>
-      <td class="num">${fmt(b.vat)}</td>
-      <td class="num">${fmt(b.incl)}</td>
-    </tr>`).join('');
-
-  const lineItemRows = options.lineItems.map((it) => `
-    <tr>
-      <td class="desc">${escapeHtml(it.description)}</td>
-      <td class="qty">${it.qty}</td>
-      <td class="rate">${it.rate === 0 ? 'None' : `${it.rate}%`}</td>
-      <td class="num">${fmt(it.excl)}</td>
-      <td class="num">${fmt(it.vat)}</td>
-      <td class="num">${fmt(it.incl)}</td>
-    </tr>`).join('');
-
-  return `<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><style>
-  @page { size: A4; margin: 0; }
-  html, body { margin:0; -webkit-print-color-adjust:exact; print-color-adjust:exact; }
-  body { font: 10.5pt/1.55 "Helvetica Neue", Arial, sans-serif; color:#222 }
-
-  /* Each page is its own flex column so its footer can be pushed to the
-     bottom of that page regardless of body content height. */
-  .page { display:flex; flex-direction:column; min-height:100vh }
-  .page + .page, .page + .items-flow { page-break-before:always; break-before:page }
-  /* Items section uses a plain block so the table can overflow across pages
-     without breaking @page rules; flex + min-height:100vh suppresses them. */
-  .items-flow { break-before:page }
-
-  .band { background:linear-gradient(135deg, ${PRIMARY}, ${PRIMARY_DARK}); color:white; padding:22px 56px; display:flex; align-items:center; gap:36px; flex:0 0 auto }
-  .band .logo { width:72px; height:72px; flex:0 0 72px }
-  .band .lockup .lbl { font-size:10pt; text-transform:uppercase; letter-spacing:1.6px; opacity:0.85 }
-  .band .lockup .ref { font-size:18pt; font-weight:700; margin-top:2px; letter-spacing:-0.3px }
-
-  .body { padding:48px 56px 0; flex:1 }
-
-  .top { display:flex; justify-content:space-between; gap:48px; margin-bottom:72px }
-  .recipient p { margin:0; line-height:1.4; font-size:10pt }
-  .meta-list { font-size:10pt; line-height:1.5 }
-  .meta-list .row { display:flex; gap:6px; justify-content:flex-end }
-  .meta-list .lbl { color:${MUTED}; text-align:right; min-width:90px }
-  .meta-list .v { min-width:140px; text-align:left }
-
-  .total-headline { margin-bottom:96px }
-  .total-headline .h { font-size:34pt; font-weight:700; line-height:1.08; letter-spacing:-0.6px }
-  .total-headline .note { font-size:9pt; color:${MUTED}; margin-top:14px; max-width:560px; line-height:1.55 }
-
-  .spec { width:100%; border-collapse:collapse; font-size:10pt; margin-bottom:14px }
-  .spec thead th { font-weight:normal; color:${MUTED}; font-size:9.5pt; padding:4px 14px 10px 0; border-bottom:1px solid #BBB; text-align:left }
-  .spec thead th.num { text-align:right; padding-right:0 }
-  .spec tbody td { padding:7px 14px 7px 0; vertical-align:top }
-  .spec td.num { text-align:right; padding-right:0; font-variant-numeric:tabular-nums }
-  .spec td.rate { color:${MUTED} }
-  .spec tr.total td { padding-top:14px; padding-bottom:6px; border-top:1px solid #333 }
-  .spec tr.total td.muted { color:${MUTED}; font-weight:normal !important }
-  .spec tr.total td.bold { font-weight:700 }
-
-  .questions { font-size:9pt; color:${MUTED}; margin-top:24px; text-align:right }
-
-  /* Footer column proportions: BAC name+address | VAT+KvK | IBAN | contact.
-     All four columns lead with a header line; the BTW/IBAN columns use an
-     invisible <strong> spacer so their data rows align with the address /
-     email rows in the bold-labelled columns. */
-  .page-foot { padding:24px 56px 30px; margin-top:60px; font-size:8.5pt; color:${MUTED}; line-height:1.5; display:grid; grid-template-columns:1.3fr 1.2fr 1.6fr 1.1fr; gap:24px; flex:0 0 auto }
-  .page-foot .col { white-space:nowrap }
-  .page-foot .col strong { display:block; color:#111; font-size:9pt; margin-bottom:4px; font-weight:700; white-space:normal }
-
-  /* Line-items page (page 2): per-row items table. Compact rows so a typical
-     ~30-row invoice fits on one page; tr.total is glued to the previous row
-     so it never orphans onto a new page without context. */
-  .items { width:100%; border-collapse:collapse; font-size:9.5pt; margin-top:8px }
-  .items thead th { font-weight:normal; color:${MUTED}; font-size:9pt; padding:6px 10px 10px 0; border-bottom:1px solid #BBB; text-align:left }
-  .items thead th.num, .items thead th.qty, .items thead th.rate { text-align:right }
-  .items thead th.num { padding-right:0 }
-  /* The spacer row sits in <thead> so Chromium auto-repeats it on every page
-     where the table breaks. That gives spillover pages a top whitespace band
-     instead of starting flush against the page edge. The first items page
-     also picks up the spacer below its meta-list -- consistent across pages. */
-  .items thead tr.spacer th { padding:0; height:80px; border-bottom:0 }
-  /* <tfoot> auto-repeats on every page like <thead>; using it as a bottom
-     spacer reserves whitespace below the rows on every spillover page so the
-     last row never butts up against the page edge. */
-  .items tfoot tr.spacer td { padding:0; height:60px; border:0 }
-  .items tbody tr { break-inside:avoid; page-break-inside:avoid }
-  .items tbody td { padding:5px 10px 5px 0; vertical-align:top; border-bottom:1px solid #F2F2F2 }
-  .items tbody tr:last-child td { border-bottom:0 }
-  .items td.desc { width:auto }
-  .items td.qty { width:50px; text-align:right; padding-right:14px }
-  .items td.rate { width:50px; text-align:right; padding-right:14px; color:${MUTED} }
-  .items td.num { width:80px; text-align:right; padding-right:0; font-variant-numeric:tabular-nums }
-  .items tr.total td { padding-top:12px; padding-bottom:6px; border-top:1px solid #333; font-weight:700 }
-  .items tr.total { break-before:avoid; page-break-before:avoid }
-</style></head><body>
-  <section class="page">
-    <div class="band">
-      <div class="logo">${BAC_LOGO}</div>
-      <div class="lockup">
-        <div class="lbl">Invoice</div>
-        <div class="ref">${escapeHtml(options.reference)}</div>
-      </div>
-    </div>
-
-    <div class="body">
-      <div class="top">
-        <div class="recipient">
-          <p>${escapeHtml(options.addressee)}<br>
+  const recipientHtml = `<p>${escapeHtml(options.addressee)}<br>
           ${attentionLine}${escapeHtml(options.address.street)}<br>
           ${escapeHtml(options.address.postalCode)} ${escapeHtml(options.address.city)}<br>
-          ${escapeHtml(options.address.country)}</p>
-        </div>
-        <div class="meta-list">
-          <div class="row"><span class="lbl">Date</span><span class="v">${escapeHtml(options.date)}</span></div>
-          <div class="row"><span class="lbl">Invoice number</span><span class="v">${escapeHtml(options.reference)}</span></div>
-          <div class="row"><span class="lbl">Customer number</span><span class="v">${escapeHtml(options.customerNumber)}</span></div>
-          <div class="row"><span class="lbl">Sequence number</span><span class="v">${escapeHtml(options.identifier)}</span></div>
-          <div class="row"><span class="lbl">Due date</span><span class="v">${escapeHtml(options.dueDate)}</span></div>
-        </div>
-      </div>
+          ${escapeHtml(options.address.country)}</p>`;
 
-      ${subjectSection}
-
-      <div class="total-headline">
-        <div class="h">Total including VAT ${fmt(options.totalIncl)}</div>
-        <div class="note">
+  const noteHtml = `
           The amount of <strong>${fmt(options.totalIncl)}</strong> must be paid within
           <strong>${BAC.paymentTermDays} days</strong> (before <strong>${escapeHtml(options.dueDate)}</strong>)
           to
           <span style="white-space:nowrap"><strong>${escapeHtml(BAC.iban)}</strong></span>
           in the name of ${escapeHtml(BAC.name)}, with reference
-          <strong>${escapeHtml(options.reference)}</strong>.
-        </div>
-      </div>
+          <strong>${escapeHtml(options.reference)}</strong>.`;
 
-      <table class="spec">
-        <thead>
-          <tr>
-            <th>Description</th>
-            <th>VAT</th>
-            <th class="num">Excl. VAT</th>
-            <th class="num">VAT amount</th>
-            <th class="num">Incl. VAT</th>
-          </tr>
-        </thead>
-        <tbody>
-          ${vatRows}
-          <tr class="total">
-            <td class="muted">All amounts in euros</td>
-            <td class="bold">Total</td>
-            <td class="num bold">${fmt(options.subtotalExcl)}</td>
-            <td class="num bold">${fmt(options.totalVat)}</td>
-            <td class="num bold">${fmt(options.totalIncl)}</td>
-          </tr>
-        </tbody>
-      </table>
+  const lineItems: IDocumentLineItem[] = [...options.lineItems]
+    .sort((a, b) => a.id - b.id)
+    .map((it) => ({
+      description: it.description,
+      qty: it.qty,
+      rate: it.rate,
+      excl: it.excl,
+      vat: it.vat,
+      incl: it.incl,
+    }));
 
-      <div class="questions">Questions about this invoice? Email ${escapeHtml(BAC.email)}</div>
-    </div>
-
-    <div class="page-foot">
-      <div class="col">
-        <strong>${escapeHtml(BAC.name)}</strong>
-        ${escapeHtml(BAC.street)}<br>
-        ${escapeHtml(BAC.postalCity)}
-      </div>
-      <div class="col">
-        <strong style="visibility:hidden">&nbsp;</strong>
-        VAT ${escapeHtml(BAC.vat)}<br>
-        KvK ${escapeHtml(BAC.kvk)}
-      </div>
-      <div class="col">
-        <strong style="visibility:hidden">&nbsp;</strong>
-        IBAN ${escapeHtml(BAC.iban)}
-      </div>
-      <div class="col">
-        <strong>contact</strong>
-        ${escapeHtml(BAC.email)}<br>
-        ${escapeHtml(BAC.phone)}
-      </div>
-    </div>
-  </section>
-
-  <section class="items-flow">
-    <div class="band">
-      <div class="logo">${BAC_LOGO}</div>
-      <div class="lockup">
-        <div class="lbl">Line items</div>
-        <div class="ref">${escapeHtml(options.reference)}</div>
-      </div>
-    </div>
-
-    <div class="body">
-      <div class="top" style="margin-bottom:24px">
-        <div></div>
-        <div class="meta-list">
-          <div class="row"><span class="lbl">Date</span><span class="v">${escapeHtml(options.date)}</span></div>
-          <div class="row"><span class="lbl">Invoice number</span><span class="v">${escapeHtml(options.reference)}</span></div>
-        </div>
-      </div>
-
-      <table class="items">
-        <thead>
-          <tr class="spacer"><th colspan="6"></th></tr>
-          <tr>
-            <th class="desc">Description</th>
-            <th class="qty">Qty</th>
-            <th class="rate">VAT</th>
-            <th class="num">Excl. VAT</th>
-            <th class="num">VAT amount</th>
-            <th class="num">Incl. VAT</th>
-          </tr>
-        </thead>
-        <tfoot>
-          <tr class="spacer"><td colspan="6"></td></tr>
-        </tfoot>
-        <tbody>
-          ${lineItemRows}
-          <tr class="total">
-            <td></td>
-            <td></td>
-            <td>Total</td>
-            <td class="num">${fmt(options.subtotalExcl)}</td>
-            <td class="num">${fmt(options.totalVat)}</td>
-            <td class="num">${fmt(options.totalIncl)}</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </section>
-</body></html>`;
+  return createDocumentPdf({
+    bandLabel: 'Invoice',
+    reference: options.reference,
+    recipientHtml,
+    metaRows: [
+      { lbl: 'Date', v: escapeHtml(options.date) },
+      { lbl: 'Invoice number', v: escapeHtml(options.reference) },
+      { lbl: 'Customer number', v: escapeHtml(options.customerNumber) },
+      { lbl: 'Sequence number', v: escapeHtml(options.identifier) },
+      { lbl: 'Due date', v: escapeHtml(options.dueDate) },
+    ],
+    subjectSection: subjectSection('Subject', options.subject),
+    totalIncl: options.totalIncl,
+    totalLabel: 'Total including VAT',
+    noteHtml,
+    specDescription: 'Orders',
+    vatBreakdown: options.vatBreakdown,
+    subtotalExcl: options.subtotalExcl,
+    totalVat: options.totalVat,
+    questionsLine: `Questions about this invoice? Email ${escapeHtml(BAC.email)}`,
+    lineItemsLabel: 'Line items',
+    lineItemsMetaRows: [
+      { lbl: 'Date', v: escapeHtml(options.date) },
+      { lbl: 'Invoice number', v: escapeHtml(options.reference) },
+    ],
+    lineItems,
+  });
 }

--- a/src/html/seller-payout.html.ts
+++ b/src/html/seller-payout.html.ts
@@ -1,0 +1,101 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+/**
+ * Seller Payout / disbursement PDF. The same "F6c" document as the Invoice,
+ * with a "Seller Disbursement" band label, the payout meta rows and the
+ * disbursement explanation note. Compiled to a PDF by `pdf-compiler`.
+ */
+
+import {
+  createDocumentPdf,
+  escapeHtml,
+  fmt,
+  IDocumentLineItem,
+  IDocumentVatBand,
+  subjectSection,
+} from './document.html';
+import { BAC } from '../files/templates/bac-letterhead';
+
+/** One row in the cover-page VAT specification matrix (per-VAT-band totals). */
+export interface ISellerPayoutVatBand extends IDocumentVatBand {}
+
+/** One line item: a product sold in the payout period. */
+export interface ISellerPayoutLineItem extends IDocumentLineItem {}
+
+export interface ISellerPayoutPdf {
+  /** Payout number, e.g. SDS-SP-0001. */
+  reference: string;
+  /** SellerPayout.id, shown as "Sequence number". */
+  identifier: string;
+  /** Free-text payout description; rendered as a "Description" section. */
+  description: string;
+  /** Seller account name (the payee). */
+  account: string;
+  /** The seller's User.id, shown as "Customer number". */
+  customerNumber: string;
+  startDate: string;
+  endDate: string;
+  vatBreakdown: ISellerPayoutVatBand[];
+  lineItems: ISellerPayoutLineItem[];
+  totalIncl: number;
+  subtotalExcl: number;
+  totalVat: number;
+}
+
+/**
+ * Render the Seller Payout PDF HTML via the shared document skeleton.
+ */
+export function createSellerPayoutPdf(options: ISellerPayoutPdf): string {
+  const noteHtml = `
+          This is a payout of your balance in the SudoSOS system based on your sales in the period
+          <strong>${escapeHtml(options.startDate)}</strong> to <strong>${escapeHtml(options.endDate)}</strong>.
+          As a seller, you will receive the total amount of sales <strong>${fmt(options.totalIncl)}</strong>
+          including VAT and are responsible for payment of VAT in the amount of <strong>${fmt(options.totalVat)}</strong>.`;
+
+  return createDocumentPdf({
+    bandLabel: 'Seller Disbursement',
+    reference: options.reference,
+    // The account is shown in the meta-list (top right), so the recipient block stays empty.
+    recipientHtml: '',
+    metaRows: [
+      { lbl: 'Payout number', v: escapeHtml(options.reference) },
+      { lbl: 'Account', v: escapeHtml(options.account) },
+      { lbl: 'Start date', v: escapeHtml(options.startDate) },
+      { lbl: 'End date', v: escapeHtml(options.endDate) },
+      { lbl: 'Customer number', v: escapeHtml(options.customerNumber) },
+    ],
+    subjectSection: subjectSection('Description', options.description),
+    totalIncl: options.totalIncl,
+    totalLabel: 'Payout including VAT',
+    noteHtml,
+    specDescription: 'Sales',
+    vatBreakdown: options.vatBreakdown,
+    subtotalExcl: options.subtotalExcl,
+    totalVat: options.totalVat,
+    questionsLine: `Questions about this payout? Email ${escapeHtml(BAC.email)}`,
+    lineItemsLabel: 'Line items',
+    lineItemsMetaRows: [
+      { lbl: 'Payout number', v: escapeHtml(options.reference) },
+      { lbl: 'Account', v: escapeHtml(options.account) },
+    ],
+    lineItems: options.lineItems,
+  });
+}

--- a/src/service/pdf/seller-payout-pdf-service.ts
+++ b/src/service/pdf/seller-payout-pdf-service.ts
@@ -24,51 +24,69 @@
  * @module internal/pdf/seller-payout-pdf-service
  */
 
-import {
-  FileResponse,
-  SellerPayoutParameters,
-  SellerPayoutRouteParams,
-} from 'pdf-generator-client';
-import {
-  entryToProduct,
-  getPDFTotalsFromReport,
-  userToIdentity,
-} from '../../helpers/pdf';
 import SellerPayout from '../../entity/transactions/payout/seller-payout';
 import SellerPayoutPdf from '../../entity/file/seller-payout-pdf';
+import { createSellerPayoutPdf, ISellerPayoutPdf } from '../../html/seller-payout.html';
 import { SalesReportService } from '../report-service';
-import { ReportProductEntry } from '../../entity/report/report';
-import { PdfService } from './pdf-service';
+import { HtmlPdfService } from './pdf-service';
 
-export default class SellerPayoutPdfService extends PdfService<SellerPayoutPdf, SellerPayout, SellerPayoutRouteParams> {
-  generator(routeParams: SellerPayoutRouteParams): Promise<FileResponse> {
-    return this.client.generateDisbursement(routeParams);
-  }
+export default class SellerPayoutPdfService extends HtmlPdfService<SellerPayoutPdf, SellerPayout, ISellerPayoutPdf> {
+  pdfConstructor = SellerPayoutPdf;
 
-  async getParameters(entity: SellerPayout): Promise<SellerPayoutParameters> {
-    const { startDate, endDate, reference } = entity;
+  htmlGenerator = createSellerPayoutPdf;
+
+  async getParameters(entity: SellerPayout): Promise<ISellerPayoutPdf> {
+    const { startDate, endDate, reference, requestedBy } = entity;
     const report = await new SalesReportService().getReport({
       fromDate: startDate,
       tillDate: endDate,
-      forId: entity.requestedBy.id,
+      forId: requestedBy.id,
     });
 
-    const entries = report.data.products.map((s: ReportProductEntry) => entryToProduct(s));
-    entries.sort((a, b) => a.name.localeCompare(b.name));
+    const lineItems = (report.data.products ?? [])
+      .map((p) => {
+        const excl = p.totalExclVat.getAmount();
+        const incl = p.totalInclVat.getAmount();
+        return {
+          description: p.product.name,
+          qty: p.count,
+          rate: p.product.vat.percentage,
+          excl: excl / 100,
+          vat: (incl - excl) / 100,
+          incl: incl / 100,
+        };
+      })
+      .sort((a, b) => a.description.localeCompare(b.description));
 
-    return new SellerPayoutParameters({
+    const vatBreakdown = (report.data.vat ?? [])
+      .map((v) => {
+        const excl = v.totalExclVat.getAmount();
+        const incl = v.totalInclVat.getAmount();
+        return {
+          rate: v.vat.percentage,
+          excl: excl / 100,
+          vat: (incl - excl) / 100,
+          incl: incl / 100,
+        };
+      })
+      .sort((a, b) => a.rate - b.rate);
+
+    const exclCents = report.totalExclVat.getAmount();
+    const inclCents = report.totalInclVat.getAmount();
+
+    return {
       reference: `SDS-SP-${String(entity.id).padStart(4, '0')}`,
-      startDate,
-      endDate,
-      entries,
-      total: getPDFTotalsFromReport(report),
+      identifier: String(entity.id),
       description: reference,
-      debtorId: entity.requestedBy.id,
-      account: userToIdentity(entity.requestedBy),
-    });
+      account: [requestedBy.firstName, requestedBy.lastName].filter(Boolean).join(' '),
+      customerNumber: String(requestedBy.id),
+      startDate: startDate.toLocaleDateString('nl-NL'),
+      endDate: endDate.toLocaleDateString('nl-NL'),
+      vatBreakdown,
+      lineItems,
+      totalIncl: inclCents / 100,
+      subtotalExcl: exclCents / 100,
+      totalVat: (inclCents - exclCents) / 100,
+    };
   }
-
-  pdfConstructor = SellerPayoutPdf;
-
-  routeConstructor = SellerPayoutRouteParams;
 }

--- a/test/unit/controller/seller-payout-controller.ts
+++ b/test/unit/controller/seller-payout-controller.ts
@@ -41,8 +41,8 @@ import {
 import { ReportResponse } from '../../../src/controller/response/report-response';
 import dinero from 'dinero.js';
 import sinon from 'sinon';
-import { Client } from 'pdf-generator-client';
-import { BasePdfService } from '../../../src/service/pdf/pdf-service';
+import SellerPayoutPdfService from '../../../src/service/pdf/seller-payout-pdf-service';
+import { PdfError } from '../../../src/errors';
 import {
   SellerPayoutSeeder, TransactionSeeder, TransferSeeder,
   UserSeeder,
@@ -277,27 +277,16 @@ describe('SellerPayoutController', () => {
   });
 
   describe('GET /seller-payouts/{id}/report/pdf', () => {
-    let clientStub: sinon.SinonStubbedInstance<Client>;
-
-    function resolveSuccessful() {
-      clientStub.generateDisbursement.resolves({
-        data: new Blob(),
-        status: 200,
-      });
-    }
-
-    beforeEach(() => {
-      clientStub = sinon.createStubInstance(Client);
-      sinon.stub(BasePdfService, 'getClient').returns(clientStub);
-    });
+    let compileHtmlStub: sinon.SinonStub;
 
     afterEach(() => {
+      if (compileHtmlStub) compileHtmlStub.restore();
       sinon.restore();
     });
 
     it('should return HTTP 200 with the sales report PDF belonging to the seller payout', async () => {
       fs.mkdirSync(SELLER_PAYOUT_PDF_LOCATION, { recursive: true });
-      resolveSuccessful();
+      compileHtmlStub = sinon.stub(SellerPayoutPdfService.prototype, 'compileHtml' as any).resolves(Buffer.from('PDF content'));
       const sellerPayout = ctx.sellerPayouts[0];
       const res = await request(ctx.app)
         .get(`/seller-payouts/${sellerPayout.id}/report/pdf`)
@@ -321,7 +310,7 @@ describe('SellerPayoutController', () => {
       expect(res.status).to.equal(403);
     });
     it('should return HTTP 502 if pdf generation fails', async () => {
-      clientStub.generateDisbursement.rejects(new Error('Failed to generate PDF'));
+      compileHtmlStub = sinon.stub(SellerPayoutPdfService.prototype, 'compileHtml' as any).rejects(new PdfError('Failed to generate PDF'));
       const sellerPayout = await SellerPayout.findOne({ where: { id: 1 }, relations: {
         requestedBy: true,
       } });

--- a/test/unit/html/seller-payout.ts
+++ b/test/unit/html/seller-payout.ts
@@ -1,0 +1,92 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+import { expect } from 'chai';
+import {
+  createSellerPayoutPdf,
+  ISellerPayoutPdf,
+} from '../../../src/html/seller-payout.html';
+
+describe('createSellerPayoutPdf', () => {
+  const params: ISellerPayoutPdf = {
+    reference: 'SDS-SP-0001',
+    identifier: '1',
+    description: 'October bar sales',
+    account: 'Bar Committee',
+    customerNumber: '7',
+    startDate: '1-1-2026',
+    endDate: '31-1-2026',
+    vatBreakdown: [
+      { rate: 9, excl: 8.26, vat: 0.74, incl: 9.00 },
+      { rate: 21, excl: 33.06, vat: 6.94, incl: 40.00 },
+    ],
+    lineItems: [
+      { description: 'Beer', qty: 40, rate: 21, excl: 33.06, vat: 6.94, incl: 40.00 },
+      { description: 'Cola', qty: 10, rate: 9, excl: 8.26, vat: 0.74, incl: 9.00 },
+    ],
+    totalIncl: 49.00,
+    subtotalExcl: 41.32,
+    totalVat: 7.68,
+  };
+
+  it('renders the disbursement header, reference, account and period', () => {
+    const html = createSellerPayoutPdf(params);
+    expect(html).to.be.a('string');
+    expect(html).to.include('Seller Disbursement');
+    expect(html).to.include(params.reference);
+    expect(html).to.include(params.account);
+    expect(html).to.include(params.startDate);
+    expect(html).to.include(params.endDate);
+  });
+
+  it('renders the disbursement note with the totals (nl-NL formatted)', () => {
+    const html = createSellerPayoutPdf(params);
+    expect(html).to.include('This is a payout of your balance');
+    expect(html).to.include('Payout including VAT');
+    expect(html).to.include('49,00');
+    expect(html).to.include('41,32');
+  });
+
+  it('renders each line item description and quantity', () => {
+    const html = createSellerPayoutPdf(params);
+    expect(html).to.include('Beer');
+    expect(html).to.include('>40<');
+    expect(html).to.include('Cola');
+    expect(html).to.include('>10<');
+  });
+
+  it('renders each VAT band rate', () => {
+    const html = createSellerPayoutPdf(params);
+    expect(html).to.include('9%');
+    expect(html).to.include('21%');
+  });
+
+  it('renders the description as a section', () => {
+    const html = createSellerPayoutPdf(params);
+    expect(html).to.include(params.description);
+  });
+
+  it('handles an empty line-items list without throwing', () => {
+    const empty: ISellerPayoutPdf = { ...params, lineItems: [], vatBreakdown: [] };
+    const html = createSellerPayoutPdf(empty);
+    expect(html).to.be.a('string');
+    expect(html).to.include('Total');
+  });
+});

--- a/test/unit/service/pdf/seller-payout-pdf-service.ts
+++ b/test/unit/service/pdf/seller-payout-pdf-service.ts
@@ -1,0 +1,142 @@
+/**
+ *  SudoSOS back-end API service.
+ *  Copyright (C) 2026 Study association GEWIS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  @license
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import dinero from 'dinero.js';
+import SellerPayoutPdfService from '../../../../src/service/pdf/seller-payout-pdf-service';
+import { SalesReportService } from '../../../../src/service/report-service';
+import SellerPayout from '../../../../src/entity/transactions/payout/seller-payout';
+import { SELLER_PAYOUT_PDF_LOCATION } from '../../../../src/files/storage/locations';
+
+describe('SellerPayoutPdfService', () => {
+  const startDate = new Date('2022-01-01');
+  const endDate = new Date('2022-12-31');
+
+  const payout = {
+    id: 1,
+    startDate,
+    endDate,
+    reference: 'Some description',
+    requestedBy: { id: 7, firstName: 'Bar', lastName: 'Committee' },
+  } as unknown as SellerPayout;
+
+  // Two products supplied out of order to exercise the name sort.
+  const cola = {
+    count: 3,
+    product: { name: 'Cola', vat: { percentage: 9 } },
+    totalExclVat: dinero({ amount: 300 }),
+    totalInclVat: dinero({ amount: 327 }),
+  };
+  const beer = {
+    count: 2,
+    product: { name: 'Beer', vat: { percentage: 21 } },
+    totalExclVat: dinero({ amount: 200 }),
+    totalInclVat: dinero({ amount: 242 }),
+  };
+
+  // Two VAT bands supplied out of order to exercise the rate sort.
+  const vatHigh = {
+    vat: { percentage: 21 },
+    totalExclVat: dinero({ amount: 500 }),
+    totalInclVat: dinero({ amount: 605 }),
+  };
+  const vatLow = {
+    vat: { percentage: 9 },
+    totalExclVat: dinero({ amount: 100 }),
+    totalInclVat: dinero({ amount: 109 }),
+  };
+
+  const makeReport = () => ({
+    data: { products: [cola, beer], vat: [vatHigh, vatLow] },
+    totalExclVat: dinero({ amount: 600 }),
+    totalInclVat: dinero({ amount: 714 }),
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('maps the sales report into seller payout pdf parameters', async () => {
+    const report = makeReport();
+    sinon.stub(SalesReportService.prototype, 'getReport').resolves(report as any);
+
+    const service = new SellerPayoutPdfService(SELLER_PAYOUT_PDF_LOCATION);
+    const params = await service.getParameters(payout);
+
+    expect(params.reference).to.equal('SDS-SP-0001');
+    expect(params.identifier).to.equal('1');
+    expect(params.account).to.equal('Bar Committee');
+    expect(params.customerNumber).to.equal('7');
+    expect(params.description).to.equal('Some description');
+    expect(params.startDate).to.equal(startDate.toLocaleDateString('nl-NL'));
+    expect(params.endDate).to.equal(endDate.toLocaleDateString('nl-NL'));
+
+    // Line items sorted by description (Beer before Cola), amounts in euros.
+    expect(params.lineItems.map((it) => it.description)).to.deep.equal(['Beer', 'Cola']);
+    expect(params.lineItems[0].qty).to.equal(2);
+    expect(params.lineItems[0].rate).to.equal(21);
+    expect(params.lineItems[0].excl).to.be.closeTo(beer.totalExclVat.getAmount() / 100, 0.001);
+    expect(params.lineItems[0].incl).to.be.closeTo(beer.totalInclVat.getAmount() / 100, 0.001);
+    expect(params.lineItems[0].vat).to.be.closeTo(
+      (beer.totalInclVat.getAmount() - beer.totalExclVat.getAmount()) / 100, 0.001,
+    );
+
+    // VAT bands sorted ascending by rate (9% before 21%).
+    expect(params.vatBreakdown.map((b) => b.rate)).to.deep.equal([9, 21]);
+    expect(params.vatBreakdown[0].excl).to.be.closeTo(vatLow.totalExclVat.getAmount() / 100, 0.001);
+    expect(params.vatBreakdown[0].vat).to.be.closeTo(
+      (vatLow.totalInclVat.getAmount() - vatLow.totalExclVat.getAmount()) / 100, 0.001,
+    );
+
+    expect(params.subtotalExcl).to.be.closeTo(report.totalExclVat.getAmount() / 100, 0.001);
+    expect(params.totalIncl).to.be.closeTo(report.totalInclVat.getAmount() / 100, 0.001);
+    expect(params.totalVat).to.be.closeTo(
+      (report.totalInclVat.getAmount() - report.totalExclVat.getAmount()) / 100, 0.001,
+    );
+  });
+
+  it('renders the parameters to an HTML buffer via createRaw', async () => {
+    sinon.stub(SalesReportService.prototype, 'getReport').resolves(makeReport() as any);
+
+    const service = new SellerPayoutPdfService(SELLER_PAYOUT_PDF_LOCATION);
+    const buffer = await service.createRaw(payout);
+
+    expect(buffer).to.be.instanceOf(Buffer);
+    const text = buffer.toString('utf-8');
+    expect(text).to.include('Cola');
+    expect(text).to.include('Seller Disbursement');
+  });
+
+  it('handles an empty report (no products / no vat) without throwing', async () => {
+    const report = {
+      data: {},
+      totalExclVat: dinero({ amount: 0 }),
+      totalInclVat: dinero({ amount: 0 }),
+    };
+    sinon.stub(SalesReportService.prototype, 'getReport').resolves(report as any);
+
+    const service = new SellerPayoutPdfService(SELLER_PAYOUT_PDF_LOCATION);
+    const params = await service.getParameters(payout);
+
+    expect(params.lineItems).to.deep.equal([]);
+    expect(params.vatBreakdown).to.deep.equal([]);
+    expect(params.subtotalExcl).to.equal(0);
+    expect(params.totalIncl).to.equal(0);
+  });
+});


### PR DESCRIPTION
# Description

Migrates the seller payout / disbursement report PDF off the LaTeX pdf-generator-client path onto pdf-compiler. Third of the PDF migrations tracked in #926, after the invoice (#931) and the fine report (#952).

A disbursement is the same document as the invoice, just with different header and info-box text, so this also extracts the shared layout. The invoice's cover + line-items skeleton (band, recipient block, meta-list, total headline, VAT specification, footer, and the line-items page) moves into a new document.html.ts. invoice.html.ts and seller-payout.html.ts are now thin wrappers that pass their own band label, meta rows, note text and line items. The invoice output is unchanged and its tests still pass.

The seller payout renders as a cover page with the "Seller Disbursement" header, the account, the payout meta (Payout number, Account, Start date, End date, Customer number), a Description section, a "Payout including VAT" headline and the disbursement note ("This is a payout of your balance ... responsible for payment of VAT in the amount of ..."), then a line-items page listing the products sold. Amounts use nl-NL formatting (EUR 8,70).

SellerPayoutPdfService now extends HtmlPdfService and builds numeric line items and VAT bands straight from the sales report. It is still a stored PDF, so the SellerPayout entity keeps its pdf relation and pdfConstructor and the getOrCreatePdf caching is unchanged. The GET /seller-payouts/{id}/report/pdf route, its RBAC and the controller handler are untouched.

Verified end to end against a live pdf-compiler container: GET /seller-payouts/1/report/pdf on the dev seed stored a valid two-page PDF. tsc, eslint, the new html/service unit tests, the invoice unit tests and the seller-payout-controller suite all pass.

## Related issues/external references
Part of #926.

## Types of changes
- New feature _(non-breaking change which adds functionality)_
- Style _(Change that do not affect the functionality of the code)_

---

## ✅ PR Checklist

- [x] **Test Coverage**: New functionality has appropriate test coverage and all tests pass (`npm run test`)
- [x] **Documentation**: New functionality is documented with TypeDoc comments and API documentation is updated
- [x] **Database Changes**: Database migrations created (if applicable) and tested with both SQLite and MariaDB

## 🔗 Additional Notes
No new dependencies and no DB migration. The shared document.html.ts is now used by both the invoice and the seller payout; future PDFs in #926 with a recipient + line items (e.g. payout request) can reuse it too. pdf-generator-client and the PDF_VAT_* constants stay for the PDFs not yet migrated.
